### PR TITLE
fix-doc-bug:missed some space before resource type in limits

### DIFF
--- a/docs/userguide/NVIDIA-device/examples/allocate-device-core.md
+++ b/docs/userguide/NVIDIA-device/examples/allocate-device-core.md
@@ -19,7 +19,7 @@ spec:
       resources:
         limits:
           nvidia.com/gpu: 2 # requesting 2 vGPUs
-	  nvidia.com/gpucores: 50 # requesting 50% of each vGPU's core resources
+          nvidia.com/gpucores: 50 # requesting 50% of each vGPU's core resources
 ```
 
 > **NOTICE:** *HAMi implements `nvidia.com/gpucores` using time-slice, Therefore, when the core utilization is queried through the nvidia-smi command, there will be fluctuations*

--- a/docs/userguide/NVIDIA-device/examples/allocate-device-memory.md
+++ b/docs/userguide/NVIDIA-device/examples/allocate-device-memory.md
@@ -19,7 +19,7 @@ spec:
       resources:
         limits:
           nvidia.com/gpu: 2 # requesting 2 vGPUs
-	  nvidia.com/gpumem: 3000 # each vGPU requests 3G device memory
+          nvidia.com/gpumem: 3000 # each vGPU requests 3G device memory
 ```
 
 > **NOTICE:** *`nvidia.com/gpumem` can't be used together with `nvidia.com/gpumem-percentage`*

--- a/docs/userguide/NVIDIA-device/examples/allocate-device-memory2.md
+++ b/docs/userguide/NVIDIA-device/examples/allocate-device-memory2.md
@@ -19,7 +19,7 @@ spec:
       resources:
         limits:
           nvidia.com/gpu: 2 # requesting 2 vGPUs
-	  nvidia.com/gpumem-percentage: 50 # each vGPU requests 50% of device memory
+          nvidia.com/gpumem-percentage: 50 # each vGPU requests 50% of device memory
 ```
 
 > **NOTICE:** *`nvidia.com/gpumem` can't be used together with `nvidia.com/gpumem-percentage`*


### PR DESCRIPTION
Hi，there is some format bug in doc as show bellow
![image](https://github.com/user-attachments/assets/6f78dfbd-b907-40c9-b626-396ad2472985)

origin doc see here: https://project-hami.io/zh/docs/userguide/NVIDIA-device/examples/allocate-device-memory
