### PR TITLE
fix: Optimize the spread scheduling strategy description

### DIFF
--- a/changelog/source/v2.5.0.md
+++ b/changelog/source/v2.5.0.md
@@ -1,7 +1,7 @@
 ---
 mdx:
  format: md
-date: 2025-02-06T7:00
+date: 2025-02-06T20:00
 authors:
   - 'chinaran'
   - 'elrondwong'

--- a/changelog/source/v2.5.1.md
+++ b/changelog/source/v2.5.1.md
@@ -1,7 +1,7 @@
 ---
 mdx:
  format: md
-date: 2025-05-06T7:00
+date: 2025-05-06T20:00
 authors:
   - 'archlitchi'
   - 'dependabot'

--- a/i18n/zh/docusaurus-plugin-content-docs/version-v2.6.0/developers/scheduling.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/version-v2.6.0/developers/scheduling.md
@@ -151,7 +151,7 @@ GPU2 Score: ((20+70)/100 + (1000+6000)/8000)) * 10 = 17.75
 
 #### Spread
 
-Spread 主要关注每张卡的计算能力和显存使用情况。使用越少，得分越高。
+Spread 主要关注每张卡的计算能力和显存使用情况。使用越少，得分越少，但调度优先级越高。
 ```
 score: ((request.core + used.core) / allocatable.core + (request.mem + used.mem) / allocatable.mem)) * 10
 ```

--- a/versioned_docs/version-v2.6.0/developers/scheduling.md
+++ b/versioned_docs/version-v2.6.0/developers/scheduling.md
@@ -108,7 +108,7 @@ So, in `Binpack` policy we can select `Node1`.
 
 #### Spread
 
-Spread mainly considers node resource usage. The less it is used, the higher the score.
+Spread mainly considers node resource usage. The less it is used, the lower the score, but the higher the priority.
 
 ```
 score: ((request + used) / allocatable) * 10 


### PR DESCRIPTION
Under the current description of the spread mode, it is inaccurate to say that using less scores higher
 It should be that scoring less has a higher priority.