### PR TITLE
updated usage example of hygon assigning tasks to specific DCUs

### DIFF
--- a/docs/userguide/Hygon-device/examples/specify-certain-cards.md
+++ b/docs/userguide/Hygon-device/examples/specify-certain-cards.md
@@ -1,0 +1,24 @@
+---
+title: Assign task to certain DCU cards
+---
+
+## Assign task to certain DCU cards
+
+To assign a task to certain DCUs, you need only to assign the `hygon.com/use-gpuuuid` in annotations field.
+
+```yaml
+apiVersion: v1
+kind: Pod
+metadata:
+  name: gpu-pod
+  annotations:
+    hygon.com/use-gpuuuid: "DCU-123,DCU-456" # specify the DCU UUIDs, comma-separated
+spec:
+  containers:
+    - name: ubuntu-container
+      image: ubuntu:18.04
+      command: ["bash", "-c", "sleep 86400"]
+      resources:
+        limits:
+          hygon.com/dcunum: 1 # requesting DCU
+```

--- a/docs/userguide/Hygon-device/specify-device-uuid-to-use.md
+++ b/docs/userguide/Hygon-device/specify-device-uuid-to-use.md
@@ -1,0 +1,17 @@
+---
+title: Assign to certain device
+---
+
+## Assign to certain device type
+
+Sometimes a task may wish to run on a certain DCU, it can fill the `hygon.com/use-gpuuuid` field in pod annotation. HAMi scheduler will try to fit in device with that uuid.
+
+For example, a task with the following annotation will be assigned to the device with uuid `DCU-123456`
+
+```yaml
+metadata:
+  annotations:
+    hygon.com/use-gpuuuid: "DCU-123456"
+```
+
+> **NOTICE:** *Each DCU UUID is unique in a cluster, so assign a certain UUID means assigning this task to certain node with that DCU*

--- a/i18n/zh/docusaurus-plugin-content-docs/current/userguide/Hygon-device/examples/specify-certain-cards.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/current/userguide/Hygon-device/examples/specify-certain-cards.md
@@ -1,0 +1,25 @@
+---
+title: 将任务分配给特定的 DCU
+translated: true
+---
+
+## 将任务分配给特定的 DCU
+
+要将任务分配给特定的 DCU，只需在注释字段中分配  `hygon.com/use-gpuuuid`
+
+```yaml
+apiVersion: v1
+kind: Pod
+metadata:
+  name: gpu-pod
+  annotations:
+    hygon.com/use-gpuuuid: "DCU-123,DCU-456" # 指定以逗号分隔的 DCU UUID
+spec:
+  containers:
+    - name: ubuntu-container
+      image: ubuntu:18.04
+      command: ["bash", "-c", "sleep 86400"]
+      resources:
+        limits:
+          hygon.com/dcunum: 1 # 请求两个 DCU 卡
+```

--- a/i18n/zh/docusaurus-plugin-content-docs/current/userguide/Hygon-device/specify-device-uuid-to-use.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/current/userguide/Hygon-device/specify-device-uuid-to-use.md
@@ -1,0 +1,18 @@
+---
+title: 分配到特定设备
+translated: true
+---
+
+## 分配到特定设备类型
+
+有时任务可能希望在某个特定的DCU上运行，可以在pod注释中填写`hygon.com/use-gpuuuid`字段。HAMi调度器将尝试匹配具有该UUID的设备。
+
+例如，具有以下注释的任务将被分配到UUID为`DCU-123456`的设备上
+
+```yaml
+metadata:
+  annotations:
+    hygon.com/use-gpuuuid: "DCU-123456"
+```
+
+> **注意：** *每个DCU UUID在集群中是唯一的，因此分配某个UUID意味着将此任务分配到具有该DCU的特定节点上*

--- a/sidebars.js
+++ b/sidebars.js
@@ -100,12 +100,14 @@ module.exports = {
             "userguide/Hygon-device/enable-hygon-dcu-sharing",
             "userguide/Hygon-device/specify-device-memory-usage",
             "userguide/Hygon-device/specify-device-core-usage",
+            "userguide/Hygon-device/specify-device-uuid-to-use",
             {
               "type": "category",
               "label": "Examples",
               "items": [
                 "userguide/Hygon-device/examples/allocate-core-and-memory",
-                "userguide/Hygon-device/examples/allocate-exclusive"
+                "userguide/Hygon-device/examples/allocate-exclusive",
+                "userguide/Hygon-device/examples/specify-certain-cards",
               ]
             }
           ]


### PR DESCRIPTION
With this [PullRequest](https://github.com/Project-HAMi/dcu-vgpu-device-plugin/pull/17) fixed, the id of the hygon DCU should now be unique in the cluster, so you can use `hygon.com/use-uuid` annotation to specify the Pod scheduling range.

Sample documentation for assigning tasks to specific hygon DCUs has been added, taking into account existing documentation

