### PR TITLE
fix(hygon): corrected a number of documentation errors

### DIFF
--- a/docs/userguide/Hygon-device/examples/allocate-core-and-memory.md
+++ b/docs/userguide/Hygon-device/examples/allocate-core-and-memory.md
@@ -4,9 +4,9 @@ title: Allocate device core and memory resource
 
 ## Allocate device core and memory to container
 
-To allocate a certain part of device core resource, you need only to assign the `hygon.com/dcucores` and `hygon.com/dcumem` along with the number of cambricon DCUs you requested in the container using `hygon.com/dcunum`
+To allocate a certain part of device core resource, you need only to assign the `hygon.com/dcucores` and `hygon.com/dcumem` along with the number of hygon DCUs you requested in the container using `hygon.com/dcunum`
 
-```
+```yaml
 apiVersion: v1
 kind: Pod
 metadata:
@@ -23,5 +23,5 @@ spec:
         limits:
           hygon.com/dcunum: 1 # requesting a GPU
           hygon.com/dcumem: 2000 # each dcu require 2000 MiB device memory
-          hygon.com/dcucores: 15 # each dcu use 15 device cores
+          hygon.com/dcucores: 15 # each dcu use 15% device cores
 ```

--- a/docs/userguide/Hygon-device/examples/allocate-exclusive.md
+++ b/docs/userguide/Hygon-device/examples/allocate-exclusive.md
@@ -4,7 +4,7 @@ title: Allocate exclusive device
 
 ## Allocate exclusive device
 
-To allocate a whole cambricon device, you need to only assign `hygon.com/dcunum` without other fields.
+To allocate a whole hygon DCU device, you need to only assign `hygon.com/dcunum` without other fields.
 
 ```
 apiVersion: v1

--- a/docs/userguide/Hygon-device/specify-device-core-usage.md
+++ b/docs/userguide/Hygon-device/specify-device-core-usage.md
@@ -4,14 +4,12 @@ title: Allocate device core usage
 
 ## Allocate device core to container
 
-Allocate a percentage of device core resources by specify resource `cambricon.com/mlu.smlu.vcore`.
-Optional, each unit of `cambricon.com/mlu.smlu.vcore` equals to 1% device cores.
+Allocate a percentage of device core resources by specify resource `hygon.com/dcucores`.
+Optional, each unit of `hygon.com/dcucores` equals to 1% device cores.
 
-```
+```yaml
       resources:
         limits:
-          cambricon.com/vmlu: 1 # requesting 1 MLU
-          cambricon.com/mlu.smlu.vcore: "10" # Each MLU contains 10% device cores
+          hygon.com/dcunum: 1 # requesting 1 DCU
+          hygon.com/dcucores: 15 # Each DCU allocates 15% device cores.
 ```
-
-> **NOTICE:** *Depending on the parameters of cambricon-device-plugin, resource name can be `cambricon.com/mlu370.smlu.vcore` or other types*

--- a/docs/userguide/Hygon-device/specify-device-memory-usage.md
+++ b/docs/userguide/Hygon-device/specify-device-memory-usage.md
@@ -7,7 +7,7 @@ title: Allocate device memory
 Allocate a percentage size of device memory by specify resources such as `hygon.com/dcumem`.
 Optional, Each unit of `hygon.com/dcumem` equals to 1M device memory.
 
-```
+```yaml
       resources:
         limits:
           hygon.com/dcunum: 1 # requesting 1 DCU

--- a/i18n/zh/docusaurus-plugin-content-docs/current/userguide/Hygon-device/enable-hygon-dcu-sharing.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/current/userguide/Hygon-device/enable-hygon-dcu-sharing.md
@@ -41,9 +41,9 @@ spec:
       command: ["sleep","infinity"]
       resources:
         limits:
-          hygon.com/dcunum: 1 # requesting a GPU
-          hygon.com/dcumem: 2000 # each dcu require 2000 MiB device memory
-          hygon.com/dcucores: 60 # each dcu use 60% of total compute cores
+          hygon.com/dcunum: 1 # 请求一个 DCU
+          hygon.com/dcumem: 2000 # 每个 DCU 包含 2000M 设备内存
+          hygon.com/dcucores: 60 # 每个 DCU 分配 15% 的设备核心
 
 ```
 

--- a/i18n/zh/docusaurus-plugin-content-docs/current/userguide/Hygon-device/examples/allocate-core-and-memory.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/current/userguide/Hygon-device/examples/allocate-core-and-memory.md
@@ -5,9 +5,9 @@ translated: true
 
 ## 为容器分配设备核心和内存
 
-要分配设备核心资源的某一部分，您只需在容器中使用 `hygon.com/dcunum` 请求的 cambricon DCU 数量，并分配 `hygon.com/dcucores` 和 `hygon.com/dcumem`。
+要分配设备核心资源的某一部分，您只需在容器中使用 `hygon.com/dcunum` 请求的海光 DCU 数量，并分配 `hygon.com/dcucores` 和 `hygon.com/dcumem`。
 
-```
+```yaml
 apiVersion: v1
 kind: Pod
 metadata:
@@ -22,7 +22,7 @@ spec:
       command: ["sleep","infinity"]
       resources:
         limits:
-          hygon.com/dcunum: 1 # 请求一个 GPU
-          hygon.com/dcumem: 2000 # 每个 dcu 需要 2000 MiB 设备内存
-          hygon.com/dcucores: 15 # 每个 dcu 使用 15 个设备核心
+          hygon.com/dcunum: 1 # 请求一个 DCU
+          hygon.com/dcumem: 2000 # 每个 DCU 需要 2000 MiB 设备内存
+          hygon.com/dcucores: 15 # 每个 DCU 使用 15% 个设备核心
 ```

--- a/i18n/zh/docusaurus-plugin-content-docs/current/userguide/Hygon-device/examples/allocate-exclusive.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/current/userguide/Hygon-device/examples/allocate-exclusive.md
@@ -5,9 +5,9 @@ translated: true
 
 ## 分配独占设备
 
-要分配整个寒武纪设备，您只需分配 `hygon.com/dcunum`，无需其他字段。
+要分配整个海光 DCU 设备，您只需分配 `hygon.com/dcunum`，无需其他字段。
 
-```
+```yaml
 apiVersion: v1
 kind: Pod
 metadata:
@@ -22,5 +22,5 @@ spec:
       command: ["sleep","infinity"]
       resources:
         limits:
-          hygon.com/dcunum: 1 # 请求一个 GPU
+          hygon.com/dcunum: 1 # 请求一个 DCU
 ```

--- a/i18n/zh/docusaurus-plugin-content-docs/current/userguide/Hygon-device/specify-device-core-usage.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/current/userguide/Hygon-device/specify-device-core-usage.md
@@ -5,14 +5,12 @@ translated: true
 
 ## 分配设备核心给容器
 
-通过指定资源 `cambricon.com/mlu.smlu.vcore` 来分配设备核心资源的百分比。
-可选项，每个 `cambricon.com/mlu.smlu.vcore` 单位等于设备核心的 1%。
+通过指定资源 `hygon.com/dcucores` 来分配设备核心资源的百分比。
+可选项，每个 `hygon.com/dcucores` 单位等于设备核心的 1%。
 
-```
+```yaml
       resources:
         limits:
-          cambricon.com/vmlu: 1 # 请求 1 个 MLU
-          cambricon.com/mlu.smlu.vcore: "10" # 每个 MLU 包含 10% 的设备核心
+          hygon.com/dcunum: 1 # 请求 1 个 DCU
+          hygon.com/dcucores: 15 # 每个 DCU 分配 15% 的设备核心
 ```
-
-> **注意：** *根据 cambricon-device-plugin 的参数，资源名称可以是 `cambricon.com/mlu370.smlu.vcore` 或其他类型*

--- a/i18n/zh/docusaurus-plugin-content-docs/version-v2.6.0/userguide/Hygon-device/enable-hygon-dcu-sharing.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/version-v2.6.0/userguide/Hygon-device/enable-hygon-dcu-sharing.md
@@ -41,9 +41,9 @@ spec:
       command: ["sleep","infinity"]
       resources:
         limits:
-          hygon.com/dcunum: 1 # requesting a GPU
-          hygon.com/dcumem: 2000 # each dcu require 2000 MiB device memory
-          hygon.com/dcucores: 60 # each dcu use 60% of total compute cores
+          hygon.com/dcunum: 1 # 请求一个 DCU
+          hygon.com/dcumem: 2000 # 每个 DCU 包含 2000M 设备内存
+          hygon.com/dcucores: 60 # 每个 DCU 分配 15% 的设备核心
 
 ```
 

--- a/i18n/zh/docusaurus-plugin-content-docs/version-v2.6.0/userguide/Hygon-device/examples/allocate-core-and-memory.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/version-v2.6.0/userguide/Hygon-device/examples/allocate-core-and-memory.md
@@ -5,7 +5,7 @@ translated: true
 
 ## 为容器分配设备核心和内存
 
-要分配设备核心资源的某一部分，您只需在容器中使用 `hygon.com/dcunum` 请求的 cambricon DCU 数量，并分配 `hygon.com/dcucores` 和 `hygon.com/dcumem`。
+要分配设备核心资源的某一部分，您只需在容器中使用 `hygon.com/dcunum` 请求的海光 DCU 数量，并分配 `hygon.com/dcucores` 和 `hygon.com/dcumem`。
 
 ```
 apiVersion: v1

--- a/i18n/zh/docusaurus-plugin-content-docs/version-v2.6.0/userguide/Hygon-device/examples/allocate-exclusive.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/version-v2.6.0/userguide/Hygon-device/examples/allocate-exclusive.md
@@ -5,7 +5,7 @@ translated: true
 
 ## 分配独占设备
 
-要分配整个寒武纪设备，您只需分配 `hygon.com/dcunum`，无需其他字段。
+要分配整个海光 DCU 设备，您只需分配 `hygon.com/dcunum`，无需其他字段。
 
 ```
 apiVersion: v1

--- a/i18n/zh/docusaurus-plugin-content-docs/version-v2.6.0/userguide/Hygon-device/specify-device-core-usage.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/version-v2.6.0/userguide/Hygon-device/specify-device-core-usage.md
@@ -5,14 +5,12 @@ translated: true
 
 ## 分配设备核心给容器
 
-通过指定资源 `cambricon.com/mlu.smlu.vcore` 来分配设备核心资源的百分比。
-可选项，每个 `cambricon.com/mlu.smlu.vcore` 单位等于设备核心的 1%。
+通过指定资源 `hygon.com/dcucores` 来分配设备核心资源的百分比。
+可选项，每个 `hygon.com/dcucores` 单位等于设备核心的 1%。
 
-```
+```yaml
       resources:
         limits:
-          cambricon.com/vmlu: 1 # 请求 1 个 MLU
-          cambricon.com/mlu.smlu.vcore: "10" # 每个 MLU 包含 10% 的设备核心
+          hygon.com/dcunum: 1 # 请求一个 DCU
+          hygon.com/dcucores: 15 # 每个 DCU 分配 15% 的设备核心
 ```
-
-> **注意：** *根据 cambricon-device-plugin 的参数，资源名称可以是 `cambricon.com/mlu370.smlu.vcore` 或其他类型*


### PR DESCRIPTION
1. Replace the Cambricon document that was incorrectly placed under the hygon category
2. Translate English comments in code blocks in the Chinese documents into Chinese
3. Add missing yaml language specifiers to the code block
4. Add % postfix to the pod contaienr device cores resource request