### PR TITLE
docs: simplify GPU runtime configuration using nvidia-ctk & fix k8s pod container crashes 

### DIFF
--- a/docs/installation/prequisities.md
+++ b/docs/installation/prequisities.md
@@ -31,18 +31,10 @@ sudo apt-get update && sudo apt-get install -y nvidia-container-toolkit
 
 #### Configure Docker
 
-When running Kubernetes with Docker, edit the configuration file, typically located at `/etc/docker/daemon.json`, to set up `nvidia-container-runtime` as the default low-level runtime:
+When running Kubernetes with Docker, use the `nvidia-ctk` tool to automatically configure Docker:
 
-```json
-{
-    "default-runtime": "nvidia",
-    "runtimes": {
-        "nvidia": {
-            "path": "/usr/bin/nvidia-container-runtime",
-            "runtimeArgs": []
-        }
-    }
-}
+```bash
+sudo nvidia-ctk runtime configure --runtime=docker
 ```
 
 And then restart Docker:
@@ -53,24 +45,10 @@ sudo systemctl daemon-reload && systemctl restart docker
 
 #### Configure containerd
 
-When running Kubernetes with containerd, modify the configuration file typically located at `/etc/containerd/config.toml`, to set up
-`nvidia-container-runtime` as the default low-level runtime:
+When running Kubernetes with containerd, use the `nvidia-ctk` tool to automatically configure containerd:
 
-```toml
-version = 2
-[plugins]
-  [plugins."io.containerd.grpc.v1.cri"]
-    [plugins."io.containerd.grpc.v1.cri".containerd]
-      default_runtime_name = "nvidia"
-
-      [plugins."io.containerd.grpc.v1.cri".containerd.runtimes]
-        [plugins."io.containerd.grpc.v1.cri".containerd.runtimes.nvidia]
-          privileged_without_host_devices = false
-          runtime_engine = ""
-          runtime_root = ""
-          runtime_type = "io.containerd.runc.v2"
-          [plugins."io.containerd.grpc.v1.cri".containerd.runtimes.nvidia.options]
-            BinaryName = "/usr/bin/nvidia-container-runtime"
+```bash
+sudo nvidia-ctk runtime configure --runtime=containerd
 ```
 
 And then restart containerd:

--- a/i18n/zh/docusaurus-plugin-content-docs/current/installation/prequisities.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/current/installation/prequisities.md
@@ -32,51 +32,29 @@ sudo apt-get update && sudo apt-get install -y nvidia-container-toolkit
 
 #### 配置 `Docker`
 
-在使用 `Docker` 运行 `Kubernetes` 时，编辑配置文件，通常位于 `/etc/docker/daemon.json`，以设置 `nvidia-container-runtime` 作为默认的低级运行时：
+在使用 `Docker` 运行 `Kubernetes` 时，使用 `nvidia-ctk` 工具自动配置 Docker：
 
-```json
-{
-    "default-runtime": "nvidia",
-    "runtimes": {
-        "nvidia": {
-            "path": "/usr/bin/nvidia-container-runtime",
-            "runtimeArgs": []
-        }
-    }
-}
+```bash
+sudo nvidia-ctk runtime configure --runtime=docker
 ```
 
 然后重启 `Docker`：
 
-```
+```bash
 sudo systemctl daemon-reload && systemctl restart docker
 ```
 
 #### 配置 `containerd`
 
-在使用 `containerd` 运行 `Kubernetes` 时，修改配置文件，通常位于 `/etc/containerd/config.toml`，以设置
-`nvidia-container-runtime` 作为默认的低级运行时：
+在使用 `containerd` 运行 `Kubernetes` 时，使用 `nvidia-ctk` 工具自动配置 containerd：
 
-```
-version = 2
-[plugins]
-  [plugins."io.containerd.grpc.v1.cri"]
-    [plugins."io.containerd.grpc.v1.cri".containerd]
-      default_runtime_name = "nvidia"
-
-      [plugins."io.containerd.grpc.v1.cri".containerd.runtimes]
-        [plugins."io.containerd.grpc.v1.cri".containerd.runtimes.nvidia]
-          privileged_without_host_devices = false
-          runtime_engine = ""
-          runtime_root = ""
-          runtime_type = "io.containerd.runc.v2"
-          [plugins."io.containerd.grpc.v1.cri".containerd.runtimes.nvidia.options]
-            BinaryName = "/usr/bin/nvidia-container-runtime"
+```bash
+sudo nvidia-ctk runtime configure --runtime=containerd
 ```
 
 然后重启 `containerd`：
 
-```
+```bash
 sudo systemctl daemon-reload && systemctl restart containerd
 ```
 

--- a/i18n/zh/docusaurus-plugin-content-docs/version-v2.6.0/installation/prequisities.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/version-v2.6.0/installation/prequisities.md
@@ -32,19 +32,10 @@ sudo apt-get update && sudo apt-get install -y nvidia-container-toolkit
 
 #### 配置 Docker
 
-在使用 Docker 运行 Kubernetes 时，编辑通常位于 `/etc/docker/daemon.json` 的配置文件，
-以设置 `nvidia-container-runtime` 作为默认的低级运行时：
+在使用 Docker 运行 Kubernetes 时，使用 `nvidia-ctk` 工具自动配置 Docker：
 
-```json
-{
-    "default-runtime": "nvidia",
-    "runtimes": {
-        "nvidia": {
-            "path": "/usr/bin/nvidia-container-runtime",
-            "runtimeArgs": []
-        }
-    }
-}
+```bash
+sudo nvidia-ctk runtime configure --runtime=docker
 ```
 
 然后重启 Docker：
@@ -55,24 +46,10 @@ sudo systemctl daemon-reload && systemctl restart docker
 
 #### 配置 containerd
 
-在使用 containerd 运行 Kubernetes 时，修改配置文件，通常位于 `/etc/containerd/config.toml`，以设置
-`nvidia-container-runtime` 作为默认的低级运行时：
+在使用 containerd 运行 Kubernetes 时，使用 `nvidia-ctk` 工具自动配置 containerd：
 
-```toml
-version = 2
-[plugins]
-  [plugins."io.containerd.grpc.v1.cri"]
-    [plugins."io.containerd.grpc.v1.cri".containerd]
-      default_runtime_name = "nvidia"
-
-      [plugins."io.containerd.grpc.v1.cri".containerd.runtimes]
-        [plugins."io.containerd.grpc.v1.cri".containerd.runtimes.nvidia]
-          privileged_without_host_devices = false
-          runtime_engine = ""
-          runtime_root = ""
-          runtime_type = "io.containerd.runc.v2"
-          [plugins."io.containerd.grpc.v1.cri".containerd.runtimes.nvidia.options]
-            BinaryName = "/usr/bin/nvidia-container-runtime"
+```bash
+sudo nvidia-ctk runtime configure --runtime=containerd
 ```
 
 然后重启 containerd：

--- a/versioned_docs/version-v2.6.0/installation/prequisities.md
+++ b/versioned_docs/version-v2.6.0/installation/prequisities.md
@@ -31,52 +31,30 @@ sudo apt-get update && sudo apt-get install -y nvidia-container-toolkit
 
 #### Configure `Docker`
 
-When running `Kubernetes` with `Docker`, edit the configuration file, typically located at `/etc/docker/daemon.json`, to set up `nvidia-container-runtime` as the default low-level runtime:
+When running `Kubernetes` with `Docker`, use the `nvidia-ctk` tool to automatically configure Docker:
 
-```json
-{
-    "default-runtime": "nvidia",
-    "runtimes": {
-        "nvidia": {
-            "path": "/usr/bin/nvidia-container-runtime",
-            "runtimeArgs": []
-        }
-    }
-}
+```bash
+sudo nvidia-ctk runtime configure --runtime=docker
 ```
 
 And then restart `Docker`:
 
-```
+```bash
 sudo systemctl daemon-reload && systemctl restart docker
 ```
 
 
 #### Configure `containerd`
 
-When running `Kubernetes` with `containerd`, modify the configuration file typically located at `/etc/containerd/config.toml`, to set up
-`nvidia-container-runtime` as the default low-level runtime:
+When running `Kubernetes` with `containerd`, use the `nvidia-ctk` tool to automatically configure containerd:
 
-```
-version = 2
-[plugins]
-  [plugins."io.containerd.grpc.v1.cri"]
-    [plugins."io.containerd.grpc.v1.cri".containerd]
-      default_runtime_name = "nvidia"
-
-      [plugins."io.containerd.grpc.v1.cri".containerd.runtimes]
-        [plugins."io.containerd.grpc.v1.cri".containerd.runtimes.nvidia]
-          privileged_without_host_devices = false
-          runtime_engine = ""
-          runtime_root = ""
-          runtime_type = "io.containerd.runc.v2"
-          [plugins."io.containerd.grpc.v1.cri".containerd.runtimes.nvidia.options]
-            BinaryName = "/usr/bin/nvidia-container-runtime"
+```bash
+sudo nvidia-ctk runtime configure --runtime=containerd
 ```
 
 And then restart `containerd`:
 
-```
+```bash
 sudo systemctl daemon-reload && systemctl restart containerd
 ```
 


### PR DESCRIPTION
Context:
When I use the original document, k8s's pod is only valid for the first time, and after restarting, the pod is very fragile, and there is a small probability that it will be successful.

Changes:
- Replace manual Docker daemon.json configuration with nvidia-ctk runtime configure --runtime=docker
- Replace manual containerd config.toml configuration with nvidia-ctk runtime configure --runtime=containerd
- Update both English and Chinese documentation for easier setup process

Reference:
- https://docs.nvidia.com/datacenter/cloud-native/container-toolkit/latest/install-guide.html
- https://www.reddit.com/r/kubernetes/comments/yvj4s4/setting_containerd_default_runtime_to_nvidia/
- https://www.cnblogs.com/handsomer/p/19068098