### PR TITLE
fix: sync v2.8.0 with latest documentation

### DIFF
--- a/i18n/zh/docusaurus-plugin-content-docs/current.json
+++ b/i18n/zh/docusaurus-plugin-content-docs/current.json
@@ -82,5 +82,9 @@
   "sidebar.docs.category.Metax GPU topology-aware scheduling": {
     "message": "Metax GPU 拓扑感知调度",
     "description": "The label for category Metax GPU topology-aware scheduling in sidebar docs"
+  },
+  "sidebar.docs.category.Using HAMi with Kueue": {
+    "message": "在 Kueue 中使用 HAMi",
+    "description": "The label for category Using HAMi with Kueue in sidebar docs"
   }
 }

--- a/i18n/zh/docusaurus-plugin-content-docs/version-v2.8.0.json
+++ b/i18n/zh/docusaurus-plugin-content-docs/version-v2.8.0.json
@@ -82,5 +82,9 @@
   "sidebar.docs.category.Metax GPU topology-aware scheduling": {
     "message": "Metax GPU 拓扑感知调度",
     "description": "The label for category Metax GPU topology-aware scheduling in sidebar docs"
+  },
+  "sidebar.docs.category.Using HAMi with Kueue": {
+    "message": "在 Kueue 中使用 HAMi",
+    "description": "The label for category Using HAMi with Kueue in sidebar docs"
   }
 }

--- a/i18n/zh/docusaurus-plugin-content-docs/version-v2.8.0/userguide/Kueue/examples/defalt_use.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/version-v2.8.0/userguide/Kueue/examples/defalt_use.md
@@ -1,0 +1,85 @@
+---
+title: 默认 Kueue 使用示例
+---
+
+本示例演示了如何将 Kueue 与 HAMi vGPU 资源配合使用。示例包含一套完整的配置，用于创建
+ResourceFlavor、ClusterQueue、LocalQueue，以及一个请求 vGPU 资源的示例 Deployment。
+
+在应用此示例之前，请确保已安装 HAMi 和 Kueue，并且已在 Kueue 中启用 ResourceTransformation
+配置（参见 [如何在 HAMi 上使用 Kueue](../how-to-use-kueue.md)）。
+
+```yaml
+apiVersion: kueue.x-k8s.io/v1beta1
+kind: ResourceFlavor
+metadata:
+  name: hami-flavor
+spec:
+  nodeLabels:
+    gpu: "on"
+---
+apiVersion: kueue.x-k8s.io/v1beta1
+kind: ClusterQueue
+metadata:
+  name: hami-queue
+spec:
+  namespaceSelector: {}
+  resourceGroups:
+  - coveredResources:
+    - nvidia.com/gpu
+    - nvidia.com/total-gpucores
+    - nvidia.com/total-gpumem
+    flavors:
+    - name: hami-flavor
+      resources:
+      - name: nvidia.com/gpu
+        nominalQuota: 20
+      - name: nvidia.com/total-gpucores
+        nominalQuota: 600
+      - name: nvidia.com/total-gpumem
+        nominalQuota: 20480
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: kueue-test
+---
+apiVersion: kueue.x-k8s.io/v1beta1
+kind: LocalQueue
+metadata:
+  name: user-queue
+  namespace: kueue-test
+spec:
+  clusterQueue: "hami-queue"
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: gpu-burn
+  namespace: kueue-test
+  labels:
+    kueue.x-k8s.io/queue-name: user-queue
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app-name: gpu-burn
+  template:
+    metadata:
+      labels:
+        app-name: gpu-burn
+    spec:
+      containers:
+      - args:
+        - while :; do /app/gpu_burn 300 || true; sleep 300; done
+        command:
+        - /bin/sh
+        - -lc
+        image: oguzpastirmaci/gpu-burn:latest
+        imagePullPolicy: IfNotPresent
+        name: main
+        resources:
+          limits:
+            nvidia.com/gpu: "2"        # 请求 2 个 vGPU 实例
+            nvidia.com/gpucores: "30"  # 每个 vGPU 为 30 核
+            nvidia.com/gpumem: "1024"  # 每个 vGPU 为 1024 MiB
+```

--- a/i18n/zh/docusaurus-plugin-content-docs/version-v2.8.0/userguide/Kueue/how-to-use-kueue.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/version-v2.8.0/userguide/Kueue/how-to-use-kueue.md
@@ -1,0 +1,273 @@
+---
+title: 如何在 HAMi 上使用 Kueue
+---
+
+# 在 HAMi 中使用 Kueue
+
+本指南将帮助你使用 Kueue 来管理 HAMi vGPU 资源，包括启用 Deployment 支持、配置
+ResourceTransformation，以及创建请求 vGPU 资源的工作负载。
+
+## 前置条件
+
+在开始之前，请确保：
+
+- 集群中已安装 HAMi
+- 集群中已安装 Kueue
+
+## 快速开始
+
+### 安装 Kueue
+
+如果尚未安装 Kueue，可以使用以下命令进行安装：
+
+```bash
+kubectl apply --server-side -f https://github.com/kubernetes-sigs/kueue/releases/download/v0.15.0/manifests.yaml
+```
+
+安装完成后，Kueue 控制器将运行在 `kueue-system` 命名空间中。
+
+## 在 Kueue 中启用 Deployment 支持
+
+Kueue 支持管理 Deployment，但你需要在 Kueue 配置中启用 `deployment` 集成。
+
+### 配置 Kueue
+
+编辑 Kueue manager 的配置以启用 Deployment 支持：
+
+```bash
+kubectl edit configmap kueue-manager-config -n kueue-system
+```
+
+添加如下配置：
+
+```yaml
+apiVersion: config.kueue.x-k8s.io/v1beta2
+kind: Configuration
+integrations:
+  frameworks:
+    - "deployment"
+    - "pod"
+```
+
+更新配置后，重启 kueue-manager：
+
+```bash
+kubectl rollout restart deployment kueue-manager -n kueue-system
+```
+
+## 配置 ResourceTransformation
+
+ResourceTransformation 允许 Kueue 将一种形式的资源请求转换为另一种形式。
+对于 HAMi vGPU 资源，这使得 Kueue 可以使用聚合指标
+（如 `nvidia.com/total-gpucores` 和 `nvidia.com/total-gpumem`）来跟踪 GPU 资源，
+而不是单独的 `nvidia.com/gpu` 请求。
+
+编辑 kueue-manager 配置以添加 ResourceTransformation：
+
+```bash
+kubectl edit configmap kueue-manager-config -n kueue-system
+```
+
+将 ResourceTransformation 配置添加到同一个 Configuration 对象中：
+
+```yaml
+apiVersion: config.kueue.x-k8s.io/v1beta2
+kind: Configuration
+integrations:
+  frameworks:
+    - "deployment"
+    - "pod"
+resources:
+  transformations:
+  - input: nvidia.com/gpucores
+    strategy: Replace
+    multiplyBy: nvidia.com/gpu
+    outputs:
+      nvidia.com/total-gpucores: "1"
+  - input: nvidia.com/gpumem
+    strategy: Replace
+    multiplyBy: nvidia.com/gpu
+    outputs:
+      nvidia.com/total-gpumem: "1"
+```
+
+更新配置后，重启 kueue-manager：
+
+```bash
+kubectl rollout restart deployment kueue-manager -n kueue-system
+```
+
+### 创建 ResourceFlavor
+
+首先，创建一个 ResourceFlavor：
+
+```yaml
+apiVersion: kueue.x-k8s.io/v1beta2
+kind: ResourceFlavor
+metadata:
+  name: hami-flavor
+spec:
+  nodeLabels:
+    gpu: "on"
+```
+
+该 ResourceFlavor 仅适用于启用了 vGPU 功能的节点。
+
+### 创建 ClusterQueue
+
+创建一个用于跟踪 HAMi 资源的 ClusterQueue：
+
+```yaml
+apiVersion: kueue.x-k8s.io/v1beta2
+kind: ClusterQueue
+metadata:
+  name: hami-queue
+spec:
+  resourceGroups:
+    - coveredResources: ["nvidia.com/gpu", "nvidia.com/total-gpucores", "nvidia.com/total-gpumem"]
+      flavors:
+        - name: hami-flavor
+          resources:
+            - name: "nvidia.com/gpu"
+              nominalQuota: 80
+            - name: "nvidia.com/total-gpucores"
+              nominalQuota: 200
+            - name: "nvidia.com/total-gpumem"
+              nominalQuota: 10240
+```
+
+该 ClusterQueue 跟踪以下资源：
+
+* `nvidia.com/total-gpucores`：所有 vGPU 的 GPU 核心总量（每个单位表示 1% 的 GPU 核心）
+* `nvidia.com/total-gpumem`：所有 vGPU 的 GPU 显存总量（单位为 MiB）
+
+### 创建 LocalQueue
+
+创建一个引用该 ClusterQueue 的 LocalQueue：
+
+```yaml
+apiVersion: kueue.x-k8s.io/v1beta2
+kind: LocalQueue
+metadata:
+  name: hami-local-queue
+  namespace: default
+spec:
+  clusterQueue: hami-queue
+```
+
+## 创建请求 vGPU 资源的工作负载
+
+现在，你可以创建请求 vGPU 资源的 Deployment。
+Kueue 将通过 ResourceTransformation 自动转换资源请求。
+
+### 基础 vGPU Deployment
+
+下面是一个请求 vGPU 资源的 Deployment 示例：
+
+```yaml
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: vgpu-deployment
+  labels:
+    app: vgpu-app
+    kueue.x-k8s.io/queue-name: hami-local-queue
+spec:
+  replicas: 2
+  selector:
+    matchLabels:
+      app: vgpu-app
+  template:
+    metadata:
+      labels:
+        app: vgpu-app
+    spec:
+      containers:
+        - name: vgpu-container
+          image: nvidia/cuda:11.8.0-base-ubuntu22.04
+          command: ["sleep", "infinity"]
+          resources:
+            limits:
+              nvidia.com/gpu: 1
+              nvidia.com/gpucores: 50
+              nvidia.com/gpumem: 1024
+```
+
+在该示例中：
+
+* `kueue.x-k8s.io/queue-name` 标签将 Deployment 关联到 `hami-local-queue`
+* `nvidia.com/gpu: 1` 请求 1 个 vGPU
+* `nvidia.com/gpucores: 50` 为每个 vGPU 请求 50% 的 GPU 核心
+* `nvidia.com/gpumem: 1024` 为每个 vGPU 请求 1024 MiB 的 GPU 显存
+
+### 请求多个 vGPU 的 Deployment
+
+你也可以创建一个请求多个 vGPU 的 Deployment：
+
+```yaml
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: multi-vgpu-deployment
+  labels:
+    app: multi-vgpu-app
+    kueue.x-k8s.io/queue-name: hami-local-queue
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: multi-vgpu-app
+  template:
+    metadata:
+      labels:
+        app: multi-vgpu-app
+    spec:
+      containers:
+        - name: vgpu-container
+          image: nvidia/cuda:11.8.0-base-ubuntu22.04
+          command: ["sleep", "infinity"]
+          resources:
+            limits:
+              nvidia.com/gpu: 2
+              nvidia.com/gpucores: 30
+              nvidia.com/gpumem: 1024
+```
+
+该 Deployment 请求 2 个 vGPU，每个 vGPU 分配 30% 的 GPU 核心和 1024 MiB 的 GPU 显存。
+
+## 验证资源使用情况
+
+要检查 ClusterQueue 中的资源使用情况，可以查看 `status.flavorsReservation` 字段：
+
+```bash
+kubectl get clusterqueue hami-queue -o yaml
+```
+
+`status.flavorsReservation` 显示当前的资源消耗情况：
+
+```yaml
+status:
+  flavorsReservation:
+  - name: hami-flavor
+    resources:
+    - name: nvidia.com/total-gpucores
+      total: "160"  # 当前使用量：(2 个副本 × 1 GPU × 50 核心) + (1 个副本 × 2 GPU × 30 核心) = 160
+    - name: nvidia.com/total-gpumem
+      total: "4096"  # 当前使用量：(2 个副本 × 1 GPU × 1024 MiB) + (1 个副本 × 2 GPU × 1024 MiB) = 4096
+```
+
+## Resource Transformation 细节
+
+Kueue 的 ResourceTransformation 会自动转换 HAMi vGPU 的资源请求：
+
+* `nvidia.com/gpu` × `nvidia.com/gpucores` → `nvidia.com/total-gpucores`
+* `nvidia.com/gpu` × `nvidia.com/gpumem` → `nvidia.com/total-gpumem`
+
+例如：
+
+* 一个 Deployment 有 2 个副本，每个副本请求 `nvidia.com/gpu: 1`、`nvidia.com/gpucores: 50` 和 `nvidia.com/gpumem: 1024`
+* 将消耗：`nvidia.com/total-gpucores: 100`（2 个副本 × 1 GPU × 50 核心）以及 `nvidia.com/total-gpumem: 2048`（2 个副本 × 1 GPU × 1024 MiB）
+
+## 示例
+
+完整可运行示例请参见 [示例文件](./examples/defalt_use.md)。

--- a/sidebars.js
+++ b/sidebars.js
@@ -277,11 +277,11 @@ module.exports = {
               "type": "category",
               "label": "Examples",
               "items": [
-                "userguide/Kueue/examples/defalt_use",
+                "userguide/Kueue/examples/defalt_use"
               ]
             }
           ]
-        },
+        }
       ]
     },
     {

--- a/versioned_docs/version-v2.8.0/userguide/Kueue/examples/defalt_use.md
+++ b/versioned_docs/version-v2.8.0/userguide/Kueue/examples/defalt_use.md
@@ -1,0 +1,83 @@
+---
+title: Default Kueue Usage Example
+---
+
+This example demonstrates how to use Kueue with HAMi vGPU resources. It includes a complete configuration that sets up ResourceFlavor, ClusterQueue, LocalQueue, and a sample Deployment that requests vGPU resources.
+
+Before applying this example, ensure that HAMi and Kueue are installed, and Kueue is configured with ResourceTransformation enabled (see [How to use Kueue on HAMi](../how-to-use-kueue.md)).
+
+```yaml
+apiVersion: kueue.x-k8s.io/v1beta1
+kind: ResourceFlavor
+metadata:
+  name: hami-flavor
+spec:
+  nodeLabels:
+    gpu: "on"
+---
+apiVersion: kueue.x-k8s.io/v1beta1
+kind: ClusterQueue
+metadata:
+  name: hami-queue
+spec:
+  namespaceSelector: {}
+  resourceGroups:
+  - coveredResources:
+    - nvidia.com/gpu
+    - nvidia.com/total-gpucores
+    - nvidia.com/total-gpumem
+    flavors:
+    - name: hami-flavor
+      resources:
+      - name: nvidia.com/gpu
+        nominalQuota: 20
+      - name: nvidia.com/total-gpucores
+        nominalQuota: 600
+      - name: nvidia.com/total-gpumem
+        nominalQuota: 20480
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: kueue-test
+---
+apiVersion: kueue.x-k8s.io/v1beta1
+kind: LocalQueue
+metadata:
+  name: user-queue
+  namespace: kueue-test
+spec:
+  clusterQueue: "hami-queue"
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: gpu-burn
+  namespace: kueue-test
+  labels:
+    kueue.x-k8s.io/queue-name: user-queue
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app-name: gpu-burn
+  template:
+    metadata:
+      labels:
+        app-name: gpu-burn
+    spec:
+      containers:
+      - args:
+        - while :; do /app/gpu_burn 300 || true; sleep 300; done
+        command:
+        - /bin/sh
+        - -lc
+        image: oguzpastirmaci/gpu-burn:latest
+        imagePullPolicy: IfNotPresent
+        name: main
+        resources:
+          limits:
+            nvidia.com/gpu: "2"        # requesting 2 vGPU instances
+            nvidia.com/gpucores: "30"  # 30 cores per vGPU
+            nvidia.com/gpumem: "1024"  # 1024 MiB per vGPU
+```

--- a/versioned_docs/version-v2.8.0/userguide/Kueue/how-to-use-kueue.md
+++ b/versioned_docs/version-v2.8.0/userguide/Kueue/how-to-use-kueue.md
@@ -1,0 +1,271 @@
+---
+title: How to use kueue on HAMi
+---
+
+# Using Kueue with HAMi
+
+This guide will help you use Kueue to manage HAMi vGPU resources, including enabling Deployment support, configuring ResourceTransformation, and creating workloads that request vGPU resources.
+
+## Prerequisites
+
+Before you begin, ensure that:
+
+- HAMi is installed in your cluster
+- Kueue is installed in your cluster
+
+## Quick Start
+
+### Install Kueue
+
+If Kueue is not already installed, you can install it using:
+
+```bash
+kubectl apply --server-side -f https://github.com/kubernetes-sigs/kueue/releases/download/v0.15.0/manifests.yaml
+```
+
+After installation, Kueue controllers will run in the `kueue-system` namespace.
+
+## Enable Deployment Support in Kueue
+
+Kueue supports managing Deployments, but you need to enable the `deployment` integration in the Kueue configuration.
+
+### Configure Kueue
+
+Edit the Kueue manager configuration to enable Deployment support:
+
+```bash
+kubectl edit configmap kueue-manager-config -n kueue-system
+```
+
+Add the following configuration:
+
+```yaml
+apiVersion: config.kueue.x-k8s.io/v1beta2
+kind: Configuration
+integrations:
+  frameworks:
+    - "deployment"
+    - "pod"
+```
+
+:::note
+
+Starting from Kueue v0.15, you don't need to explicitly enable the `"pod"` integration to use `"deployment"` integration. For Kueue v0.14 and earlier versions, you need to explicitly enable the `"pod"` integration.
+
+:::
+
+After updating the configuration, restart the Kueue manager:
+
+```bash
+kubectl rollout restart deployment kueue-manager -n kueue-system
+```
+
+## Configure ResourceTransformation
+
+ResourceTransformation allows Kueue to transform resource requests from one form to another. For HAMi vGPU resources, this enables Kueue to track GPU resources using aggregated metrics like `nvidia.com/total-gpucores` and `nvidia.com/total-gpumem` instead of individual `nvidia.com/gpu` requests.
+
+Edit the Kueue manager configuration to add ResourceTransformation:
+
+```bash
+kubectl edit configmap kueue-manager-config -n kueue-system
+```
+
+Add the ResourceTransformation configuration to the same Configuration object:
+
+```yaml
+apiVersion: config.kueue.x-k8s.io/v1beta2
+kind: Configuration
+integrations:
+  frameworks:
+    - "deployment"
+    - "pod"
+resources:
+  transformations:
+  - input: nvidia.com/gpucores
+    strategy: Replace
+    multiplyBy: nvidia.com/gpu
+    outputs:
+      nvidia.com/total-gpucores: "1"
+  - input: nvidia.com/gpumem
+    strategy: Replace
+    multiplyBy: nvidia.com/gpu
+    outputs:
+      nvidia.com/total-gpumem: "1"
+```
+
+After updating the configuration, restart the Kueue manager:
+
+```bash
+kubectl rollout restart deployment kueue-manager -n kueue-system
+```
+
+### Create ResourceFlavor
+
+First, create a ResourceFlavor:
+
+```yaml
+apiVersion: kueue.x-k8s.io/v1beta2
+kind: ResourceFlavor
+metadata:
+  name: hami-flavor
+spec:
+  nodeLabels:
+    gpu: "on"
+```
+
+This ResourceFlavor will only apply to nodes with vGPU functionality enabled.
+
+### Create ClusterQueue
+
+Create a ClusterQueue to track HAMi resources:
+
+```yaml
+apiVersion: kueue.x-k8s.io/v1beta2
+kind: ClusterQueue
+metadata:
+  name: hami-queue
+spec:
+  resourceGroups:
+    - coveredResources: ["nvidia.com/gpu", "nvidia.com/total-gpucores", "nvidia.com/total-gpumem"]
+      flavors:
+        - name: hami-flavor
+          resources:
+            - name: "nvidia.com/gpu"
+              nominalQuota: 80
+            - name: "nvidia.com/total-gpucores"
+              nominalQuota: 200
+            - name: "nvidia.com/total-gpumem"
+              nominalQuota: 10240
+```
+
+The ClusterQueue tracks:
+- `nvidia.com/total-gpucores`: Total GPU cores across all vGPUs (each unit represents 1% of a GPU core)
+- `nvidia.com/total-gpumem`: Total GPU memory across all vGPUs (in MiB)
+
+### Create LocalQueue
+
+Create a LocalQueue that references the ClusterQueue:
+
+```yaml
+apiVersion: kueue.x-k8s.io/v1beta2
+kind: LocalQueue
+metadata:
+  name: hami-local-queue
+  namespace: default
+spec:
+  clusterQueue: hami-queue
+```
+
+## Create Workloads Requesting vGPU Resources
+
+Now you can create Deployments that request vGPU resources. Kueue will automatically transform the resource requests using ResourceTransformation.
+
+### Basic vGPU Deployment
+
+Here's an example Deployment that requests vGPU resources:
+
+```yaml
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: vgpu-deployment
+  labels:
+    app: vgpu-app
+    kueue.x-k8s.io/queue-name: hami-local-queue
+spec:
+  replicas: 2
+  selector:
+    matchLabels:
+      app: vgpu-app
+  template:
+    metadata:
+      labels:
+        app: vgpu-app
+    spec:
+      containers:
+        - name: vgpu-container
+          image: nvidia/cuda:11.8.0-base-ubuntu22.04
+          command: ["sleep", "infinity"]
+          resources:
+            limits:
+              nvidia.com/gpu: 1
+              nvidia.com/gpucores: 50
+              nvidia.com/gpumem: 1024
+```
+
+In this example:
+- `kueue.x-k8s.io/queue-name` label associates the Deployment with the `hami-local-queue`
+- `nvidia.com/gpu: 1` requests 1 vGPU
+- `nvidia.com/gpucores: 50` requests 50% of GPU cores for each vGPU
+- `nvidia.com/gpumem: 1024` requests 1024 MiB of GPU memory for each vGPU
+
+### Deployment with Multiple vGPUs
+
+You can also create a Deployment that requests multiple vGPUs:
+
+```yaml
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: multi-vgpu-deployment
+  labels:
+    app: multi-vgpu-app
+    kueue.x-k8s.io/queue-name: hami-local-queue
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: multi-vgpu-app
+  template:
+    metadata:
+      labels:
+        app: multi-vgpu-app
+    spec:
+      containers:
+        - name: vgpu-container
+          image: nvidia/cuda:11.8.0-base-ubuntu22.04
+          command: ["sleep", "infinity"]
+          resources:
+            limits:
+              nvidia.com/gpu: 2
+              nvidia.com/gpucores: 30
+              nvidia.com/gpumem: 1024
+```
+
+This Deployment requests 2 vGPUs, each with 30% GPU cores and 1024 MiB GPU memory.
+
+## Verify Resource Usage
+
+To check the resource usage in the ClusterQueue, inspect the `status.flavorsReservation` field:
+
+```bash
+kubectl get clusterqueue hami-queue -o yaml
+```
+
+The `status.flavorsReservation` shows the current resource consumption:
+
+```yaml
+status:
+  flavorsReservation:
+  - name: hami-flavor
+    resources:
+    - name: nvidia.com/total-gpucores
+      total: "160"  # Current usage: (2 replicas × 1 GPU × 50 cores) + (1 replica × 2 GPUs × 30 cores) = 160
+    - name: nvidia.com/total-gpumem
+      total: "4096"  # Current usage: (2 replicas × 1 GPU × 1024 MiB) + (1 replica × 2 GPUs × 1024 MiB) = 4096
+```
+
+## Resource Transformation Details
+
+Kueue's ResourceTransformation automatically converts HAMi vGPU resource requests:
+
+- `nvidia.com/gpu` × `nvidia.com/gpucores` → `nvidia.com/total-gpucores`
+- `nvidia.com/gpu` × `nvidia.com/gpumem` → `nvidia.com/total-gpumem`
+
+For example:
+- A Deployment with 2 replicas, each requesting `nvidia.com/gpu: 1`, `nvidia.com/gpucores: 50`, and `nvidia.com/gpumem: 1024`
+- Will consume: `nvidia.com/total-gpucores: 100` (2 replicas × 1 GPU × 50 cores) and `nvidia.com/total-gpumem: 2048` (2 replicas × 1 GPU × 1024 MiB)
+
+## Example
+
+See the [example file](./examples/defalt_use.md) for a complete working example.

--- a/versioned_sidebars/version-v2.8.0-sidebars.json
+++ b/versioned_sidebars/version-v2.8.0-sidebars.json
@@ -265,6 +265,20 @@
               ]
             }
           ]
+        },
+        {
+          "type": "category",
+          "label": "Using HAMi with Kueue",
+          "items": [
+            "userguide/Kueue/how-to-use-kueue",
+            {
+              "type": "category",
+              "label": "Examples",
+              "items": [
+                "userguide/Kueue/examples/defalt_use"
+              ]
+            }
+          ]
         }
       ]
     },


### PR DESCRIPTION
Add missing documentation to v2.8.0 to keep it in sync with the next version:

- Kueue integration (English and Chinese)
- DRA (Dynamic Resource Allocation) support
- Fixed sidebar configuration

Now v2.8.0 and next versions have the same documentation.