### PR TITLE
chore: update GA4 tracking ID and add site verification

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -235,7 +235,7 @@ module.exports = {
           includeCurrentVersion: true,
         },
         gtag: {
-          trackingID: "UA-195246198-1",
+          trackingID: "G-MK932R9NMD",
           anonymizeIP: false,
         },
         blog: {

--- a/static/google69a5cccb61297807.html
+++ b/static/google69a5cccb61297807.html
@@ -1,0 +1,1 @@
+google-site-verification: google69a5cccb61297807.html


### PR DESCRIPTION
Switch to the new GA4 tracking ID and add the Google site verification file for ownership validation.chore: update GA4 tracking ID and add site verification

Switch to the new GA4 tracking ID and add the Google site verification file for ownership validation.