### PR TITLE
fix: update Meeting Recordings link to Bilibili channel

### DIFF
--- a/src/pages/community.js
+++ b/src/pages/community.js
@@ -85,7 +85,7 @@ export default function CommunityPage() {
       title: { en: 'Resources', zh: '社区资料' },
       items: [
         { label: { en: 'Community Repository', zh: '社区仓库' }, href: 'https://github.com/Project-HAMi/community', icon: faBookOpen },
-        { label: { en: 'Meeting Recordings', zh: '会议录屏' }, href: 'https://github.com/Project-HAMi/community', icon: faVideo },
+        { label: { en: 'Meeting Recordings', zh: '会议录屏' }, href: 'https://space.bilibili.com/1105878584', icon: faVideo },
         { label: { en: 'Blog', zh: '博客' }, href: isZh ? '/zh/blog' : '/blog', icon: faFileLines },
       ],
     },


### PR DESCRIPTION
## Summary
- Fix the Meeting Recordings link in the community page, which previously pointed to the community repository instead of the actual Bilibili recording space

## Test plan
- [ ] Verify the Meeting Recordings link on the community page navigates to https://space.bilibili.com/1105878584

Signed-off-by: wawa0210 <xiao.zhang@dynamia.ai>

🤖 Generated with [Claude Code](https://claude.com/claude-code)