### PR TITLE
fix(theme): safely disable announcement bar and refine chat links

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -231,10 +231,10 @@ module.exports = {
       defaultMode: "dark",
       respectPrefersColorScheme: false,
     },
-    announcementBar: {
-      id: "kubecon-2026-europe", // Increment on change
-      content: 'theme.announcementBar.message',
-    },
+    // announcementBar: {
+    //   id: "kubecon-2026-europe", // Increment on change
+    //   content: 'theme.announcementBar.message',
+    // },
     navbar: {
       title: "HAMi",
       logo: {
@@ -307,12 +307,12 @@ module.exports = {
           title: "Community",
           items: [
             {
-              label: "Slack ",
-              href: "https://slack.cncf.io/",
-            },
-            {
               label: "Discord",
               href: "https://discord.gg/Amhy7XmbNq",
+            },
+            {
+              label: "Slack (#hami-dev)",
+              href: "https://slack.cncf.io/",
             },
             {
               label: "WeChat Group",

--- a/src/pages/community.js
+++ b/src/pages/community.js
@@ -64,8 +64,8 @@ export default function CommunityPage() {
       key: 'join',
       title: { en: 'Join Chat', zh: '加入交流' },
       items: [
-        { label: { en: 'Slack', zh: 'Slack' }, href: 'https://slack.cncf.io/', icon: faSlack },
         { label: { en: 'Discord', zh: 'Discord' }, href: 'https://discord.gg/Amhy7XmbNq', icon: faDiscord },
+        { label: { en: 'Slack (join #hami-dev)', zh: 'Slack（搜索 #hami-dev）' }, href: 'https://slack.cncf.io/', icon: faSlack },
         { label: { en: 'GitHub', zh: 'GitHub' }, href: 'https://github.com/Project-HAMi', icon: faGithub },
         { label: { en: 'Bilibili', zh: 'Bilibili' }, href: 'https://space.bilibili.com/1105878584', icon: faBilibili },
       ],

--- a/src/theme/AnnouncementBar/Content/index.js
+++ b/src/theme/AnnouncementBar/Content/index.js
@@ -14,6 +14,11 @@ const announcementMessagesByLocale = {
 export default function AnnouncementBarContent(props) {
   const {announcementBar} = useThemeConfig();
   const {i18n} = useDocusaurusContext();
+
+  if (!announcementBar) {
+    return null;
+  }
+
   const {content} = announcementBar;
   const localeMessages = announcementMessagesByLocale[i18n.currentLocale] ?? {};
   const fallbackMessages = announcementMessagesByLocale.en ?? {};

--- a/src/theme/AnnouncementBar/index.js
+++ b/src/theme/AnnouncementBar/index.js
@@ -1,0 +1,12 @@
+import AnnouncementBar from '@theme-original/AnnouncementBar';
+import { useThemeConfig } from '@docusaurus/theme-common';
+
+export default function AnnouncementBarWrapper(props) {
+  const { announcementBar } = useThemeConfig();
+
+  if (!announcementBar) {
+    return null;
+  }
+
+  return <AnnouncementBar {...props} />;
+}

--- a/src/theme/Footer/index.js
+++ b/src/theme/Footer/index.js
@@ -122,7 +122,7 @@ function Footer() {
     安装: faDownload,
     'Quick Start': faRocket,
     快速开始: faRocket,
-    'Slack ': faSlack,
+    'Slack (#hami-dev)': faSlack,
     Discord: faDiscord,
     GitHub: faGithub,
     Adoption: faUsers,


### PR DESCRIPTION
Commented out the Docusaurus `announcementBar` config and added null checks in both the custom `AnnouncementBar` wrapper and content component to prevent rendering/runtime issues when no announcement is configured.

Also updated community/footer Slack labels to `Slack (#hami-dev)` (including localized text) and reordered chat links so users know exactly which channel to join.fix(theme): safely disable announcement bar and refine chat links

Signed-off-by: Jimmy Song <jimmy@dynamia.ai>