### PR TITLE
fix(announcement-bar): show bar only with localized copy

### DIFF
--- a/i18n/en/docusaurus-theme-classic/announcementBar.json
+++ b/i18n/en/docusaurus-theme-classic/announcementBar.json
@@ -1,3 +1,3 @@
 {
-  "theme.announcementBar.message": "📍 See HAMi at <a target=\"_blank\" rel=\"noopener noreferrer\" href=\"https://events.linuxfoundation.org/kubecon-cloudnativecon-europe/\">KubeCon Europe</a>! Project Pavilion P-13B | Mar 24: 3:10-7:00 PM | Mar 26: 12:30-2:00 PM"
+  "theme.announcementBar.message": ""
 }

--- a/src/theme/AnnouncementBar/index.js
+++ b/src/theme/AnnouncementBar/index.js
@@ -1,10 +1,27 @@
 import AnnouncementBar from '@theme-original/AnnouncementBar';
 import { useThemeConfig } from '@docusaurus/theme-common';
+import useDocusaurusContext from '@docusaurus/useDocusaurusContext';
+import enAnnouncementBar from '../../../i18n/en/docusaurus-theme-classic/announcementBar.json';
+import zhAnnouncementBar from '../../../i18n/zh/docusaurus-theme-classic/announcementBar.json';
+
+const announcementMessagesByLocale = {
+  en: enAnnouncementBar,
+  zh: zhAnnouncementBar,
+};
 
 export default function AnnouncementBarWrapper(props) {
   const { announcementBar } = useThemeConfig();
+  const { i18n } = useDocusaurusContext();
 
   if (!announcementBar) {
+    return null;
+  }
+
+  const { content } = announcementBar;
+  const localeMessages = announcementMessagesByLocale[i18n.currentLocale] ?? {};
+  const localizedContent = localeMessages[content] ?? '';
+
+  if (!localizedContent) {
     return null;
   }
 


### PR DESCRIPTION
Load announcement bar messages from locale-specific i18n files (en/zh) using the current Docusaurus locale, and skip rendering when the localized message is missing or empty.

Also clear the English announcement text to disable the expired event banner and prevent stale or unintended announcements from displaying.fix(announcement-bar): show bar only with localized copy

Signed-off-by: Jimmy Song <jimmy@dynamia.ai>