### PR TITLE
 fix incorrect hygon DCU verification command

### DIFF
--- a/docs/userguide/hygon-device/enable-hygon-dcu-sharing.md
+++ b/docs/userguide/hygon-device/enable-hygon-dcu-sharing.md
@@ -60,7 +60,7 @@ source /opt/hygondriver/env.sh
 check if you have successfully enabled vDCU by using following command
 
 ```bash
-hy-virtual -show-device-info
+hy-smi virtual -show-device-info
 ```
 
 If you have an output like this, then you have successfully enabled vDCU inside container.


### PR DESCRIPTION
 Corrects the command used to verify virtual DCU allocation inside containers.

  The actual driver command is `hy-smi virtual -show-device-info`, but the documentation incorrectly references `hy-virtual -show-device-info`. This PR updates all relevant docs to use the correct command.