### PR TITLE
chore(owners): add rootsongjc to OWNERS reviewers list

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -2,6 +2,7 @@ reviewers:
 - archlitchi
 - wawa0210
 - windsonsea
+- rootsongjc
 approvers:
 - archlitchi
 - wawa0210


### PR DESCRIPTION
Include `rootsongjc` in the `reviewers` section of `OWNERS` to expand review coverage and keep repository ownership up to date.chore(owners): add rootsongjc to OWNERS reviewers list Ref https://github.com/Project-HAMi/website/issues/161 @archlitchi 

Signed-off-by: Jimmy Song <jimmy@dynamia.ai>