### PR TITLE
fix: correct two typos in Ascend sharing documentation

### DIFF
--- a/docs/userguide/ascend-device/enable-ascend-sharing.md
+++ b/docs/userguide/ascend-device/enable-ascend-sharing.md
@@ -2,7 +2,7 @@
 title: Enable Ascend sharing
 ---
 
-Memory slicing is supported based on virtualization template, lease available template is automatically used. For detailed information, check [device-template](./device-template.md).
+Memory slicing is supported based on virtualization template, latest available template is automatically used. For detailed information, check [device-template](./device-template.md).
 
 ## Prerequisites
 
@@ -50,7 +50,7 @@ Memory slicing is supported based on virtualization template, lease available te
 * [Download YAML for Ascend-vgpu-device-plugin](https://github.com/Project-HAMi/ascend-device-plugin/blob/master/build/ascendplugin-hami.yaml) from HAMi Project, and run the following commands to deploy
 
   ```bash
-  wge https://raw.githubusercontent.com/Project-HAMi/ascend-device-plugin/refs/heads/main/ascend-device-plugin.yaml
+  wget https://raw.githubusercontent.com/Project-HAMi/ascend-device-plugin/refs/heads/main/ascend-device-plugin.yaml
   kubectl apply -f ascend-device-plugin.yaml
   ```
 


### PR DESCRIPTION
## What

Fixed two typos in the Ascend device sharing documentation.

Fix 1: broken download command on line 53

Before: wge https://raw.githubusercontent.com/...
After: wget https://raw.githubusercontent.com/...

The command wge does not exist. Users who copy-paste this will get a command not found error and be unable to deploy the Ascend device plugin.

Fix 2: wrong word on line 5

Before: lease available template is automatically used
After: latest available template is automatically used

The word lease makes no sense in this context.

## File

docs/userguide/ascend-device/enable-ascend-sharing.md