### PR TITLE
fix: replace deprecated apt-key with gpg keyring for nvidia-container-toolkit

### DIFF
--- a/docs/get-started/deploy-with-helm.md
+++ b/docs/get-started/deploy-with-helm.md
@@ -32,9 +32,11 @@ The following example applies to Debian-based systems using Docker or containerd
 
 ```bash
 distribution=$(. /etc/os-release;echo $ID$VERSION_ID)
-curl -s -L https://nvidia.github.io/libnvidia-container/gpgkey | sudo apt-key add -
-curl -s -L https://nvidia.github.io/libnvidia-container/$distribution/libnvidia-container.list | \
-  sudo tee /etc/apt/sources.list.d/libnvidia-container.list
+curl -fsSL https://nvidia.github.io/libnvidia-container/gpgkey \
+  | sudo gpg --dearmor -o /usr/share/keyrings/nvidia-container-toolkit-keyring.gpg
+curl -s -L https://nvidia.github.io/libnvidia-container/$distribution/libnvidia-container.list \
+  | sed 's#deb https://#deb [signed-by=/usr/share/keyrings/nvidia-container-toolkit-keyring.gpg] https://#g' \
+  | sudo tee /etc/apt/sources.list.d/nvidia-container-toolkit.list
 
 sudo apt-get update && sudo apt-get install -y nvidia-container-toolkit
 ```

--- a/docs/installation/prerequisites.md
+++ b/docs/installation/prerequisites.md
@@ -26,8 +26,11 @@ For details see [Installing the NVIDIA Container Toolkit](https://docs.nvidia.co
 
 ```bash
 distribution=$(. /etc/os-release;echo $ID$VERSION_ID)
-curl -s -L https://nvidia.github.io/libnvidia-container/gpgkey | sudo apt-key add -
-curl -s -L https://nvidia.github.io/libnvidia-container/$distribution/libnvidia-container.list | sudo tee /etc/apt/sources.list.d/libnvidia-container.list
+curl -fsSL https://nvidia.github.io/libnvidia-container/gpgkey \
+  | sudo gpg --dearmor -o /usr/share/keyrings/nvidia-container-toolkit-keyring.gpg
+curl -s -L https://nvidia.github.io/libnvidia-container/$distribution/libnvidia-container.list \
+  | sed 's#deb https://#deb [signed-by=/usr/share/keyrings/nvidia-container-toolkit-keyring.gpg] https://#g' \
+  | sudo tee /etc/apt/sources.list.d/nvidia-container-toolkit.list
 
 sudo apt-get update && sudo apt-get install -y nvidia-container-toolkit
 ```


### PR DESCRIPTION
The `apt-key add` command is deprecated since Ubuntu 22.04 and causes warnings. On newer Ubuntu versions it no longer works at all.

This PR replaces the old approach in two files with the modern method recommended by the official NVIDIA Container Toolkit documentation. The new approach uses `gpg --dearmor` to store the key in a dedicated keyring file, and references it via the `signed-by` option in the apt sources list.

Before
```bash
curl -s -L https://nvidia.github.io/libnvidia-container/gpgkey | sudo apt-key add -
curl -s -L https://nvidia.github.io/libnvidia-container/$distribution/libnvidia-container.list | sudo tee /etc/apt/sources.list.d/libnvidia-container.list
```

After
```bash
curl -fsSL https://nvidia.github.io/libnvidia-container/gpgkey \
  | sudo gpg --dearmor -o /usr/share/keyrings/nvidia-container-toolkit-keyring.gpg
curl -s -L https://nvidia.github.io/libnvidia-container/$distribution/libnvidia-container.list \
  | sed 's#deb https://#deb [signed-by=/usr/share/keyrings/nvidia-container-toolkit-keyring.gpg] https://#g' \
  | sudo tee /etc/apt/sources.list.d/nvidia-container-toolkit.list
```

Files changed

docs/installation/prerequisites.md
docs/get-started/deploy-with-helm.md