### PR TITLE
fix: update outdated Kubernetes version example from v1.16.8 to v1.29.0

### DIFF
--- a/docs/get-started/deploy-with-helm.md
+++ b/docs/get-started/deploy-with-helm.md
@@ -110,11 +110,11 @@ Add the Helm repository:
 helm repo add hami-charts https://project-hami.github.io/HAMi/
 ```
 
-During installation, set the Kubernetes scheduler image to match your cluster version. For example, if your cluster version is 1.16.8:
+During installation, set the Kubernetes scheduler image to match your cluster version. For example, if your cluster version is 1.29.0:
 
 ```bash
 helm install hami hami-charts/hami \
-  --set scheduler.kubeScheduler.imageTag=v1.16.8 \
+  --set scheduler.kubeScheduler.imageTag=v1.29.0 \
   -n kube-system
 ```
 

--- a/docs/installation/online-installation.md
+++ b/docs/installation/online-installation.md
@@ -24,10 +24,10 @@ kubectl version --short
 ## Installation
 
 Ensure the `scheduler.kubeScheduler.imageTag` matches your Kubernetes server version.
-For instance, if your cluster server is v1.16.8, use the following command to deploy:
+For instance, if your cluster server is v1.29.0, use the following command to deploy:
 
 ```bash
-helm install hami hami-charts/hami --set scheduler.kubeScheduler.imageTag=v1.16.8 -n kube-system
+helm install hami hami-charts/hami --set scheduler.kubeScheduler.imageTag=v1.29.0 -n kube-system
 ```
 
 Customize your installation by editing the [configurations](../userguide/configure.md).


### PR DESCRIPTION
## What

The documentation used v1.16.8 as an example Kubernetes version in two places. v1.16.8 was released in 2019 and reached end-of-life years ago. Any user following this example today would be using a version that is no longer supported.

Updated both files to use v1.29.0 as the example, which is a recent supported release.

## Files changed

docs/installation/online-installation.md (line 27 and 30)
docs/get-started/deploy-with-helm.md (line 113 and 117)