### PR TITLE
fix: correct Helm parameter from device.mthreads to devices.mthreads

### DIFF
--- a/docs/userguide/mthreads-device/enable-mthreads-gpu-sharing.md
+++ b/docs/userguide/mthreads-device/enable-mthreads-gpu-sharing.md
@@ -36,7 +36,7 @@ title: Enable Mthreads GPU sharing
 * set the 'devices.mthreads.enabled = true' when installing hami
 
 ```bash
-helm install hami hami-charts/hami --set scheduler.kubeScheduler.imageTag={your kubernetes version} --set device.mthreads.enabled=true -n kube-system
+helm install hami hami-charts/hami --set scheduler.kubeScheduler.imageTag={your kubernetes version} --set devices.mthreads.enabled=true -n kube-system
 ```
 
 ## Running Mthreads jobs


### PR DESCRIPTION
## What

The Mthreads device guide uses `device.mthreads.enabled=true` (singular) in the Helm install command. This is wrong.

The HAMi Helm chart uses `devices` (plural) as the top-level key in values.yaml. All other device guides (iluvatar, enflame, ascend) correctly use `devices.<name>.enabled`. The mthreads guide was the only one using the singular form.

A user following this documentation would run a Helm install command with a key that does not exist in values.yaml, so Mthreads support would silently stay disabled.

## Before

```bash
helm install hami hami-charts/hami ... --set device.mthreads.enabled=true
```

## After

```bash
helm install hami hami-charts/hami ... --set devices.mthreads.enabled=true
```

## Verification

Confirmed by checking the top-level key in the official HAMi Helm chart values.yaml:
https://github.com/Project-HAMi/HAMi/blob/master/charts/hami/values.yaml

## File changed

docs/userguide/mthreads-device/enable-mthreads-gpu-sharing.md (line 39)