### PR TITLE
fix: remove corrupted paragraph and add missing link definition in ladder.md

### DIFF
--- a/docs/contributor/ladder.md
+++ b/docs/contributor/ladder.md
@@ -166,6 +166,4 @@ Involuntary removal/demotion of a contributor happens when responsibilities and 
 Involuntary removal or demotion is handled through a vote by a majority of the current Maintainers.
 
 [two-factor authentication]: https://help.github.com/articles/about-two-factor-authentication
-ibutor happens when responsibilities and requirements aren't being met. This may include repeated patterns of inactivity, extended period of inactivity, a period of failing to meet the requirements of your role, and/or a violation of the Code of Conduct. This process is important because it protects the community and its deliverables while also opens up opportunities for new contributors to step in.
-
-Involuntary removal or demotion is handled through a vote by a majority of the current Maintainers.
+[membership request]: https://github.com/Project-HAMi/HAMi/issues/new


### PR DESCRIPTION
## What

Two issues fixed in docs/contributor/ladder.md.

Fix 1: Corrupted duplicate paragraph removed

At the end of the file, after the link definitions, there was a corrupted copy of the "Involuntary Removal" paragraph. It started mid-word with "ibutor happens when..." which is clearly a broken fragment from the word "contributor". The same paragraph already exists correctly above, so the corrupted copy was removed.

Fix 2: Missing link definition added

Line 73 references [membership request] using Markdown reference-style link syntax, but the definition for that reference was never defined anywhere in the file. This caused a broken link. The definition has been added pointing to the HAMi issue tracker.

Before: [Open an issue][membership request] pointed to nothing
After: [membership request] resolves to https://github.com/Project-HAMi/HAMi/issues/new

## File changed

docs/contributor/ladder.md