### PR TITLE
fix: correct capitalization of HAMi-core in dynamic-mig.md

### DIFF
--- a/docs/developers/dynamic-mig.md
+++ b/docs/developers/dynamic-mig.md
@@ -16,7 +16,7 @@ HAMi is done by using [hami-core](https://github.com/Project-HAMi/HAMi-core), wh
 ## Targets
 
 - CPU, Mem, and GPU combined schedule
-- GPU dynamic slice: Hami-core and MIG
+- GPU dynamic slice: HAMi-core and MIG
 - Support node-level binpack and spread by GPU memory, CPU and Mem
 - A unified vGPU Pool different virtualization techniques
 - Tasks can choose to use MIG, use HAMi-core, or use both.


### PR DESCRIPTION
## What

Line 19 of docs/developers/dynamic-mig.md used the incorrect capitalization "Hami-core" instead of "HAMi-core".

The correct form is "HAMi-core" which matches the official project name, the GitHub repository name (github.com/Project-HAMi/HAMi-core), and every other usage in the same file (line 14, line 22) and across the rest of the documentation.

Before: GPU dynamic slice: Hami-core and MIG
After: GPU dynamic slice: HAMi-core and MIG

## File changed

docs/developers/dynamic-mig.md (line 19)