### PR TITLE
fix: replace yarn deploy with npm run deploy in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ This command generates static content into the `build` directory and can be serv
 ## Deployment
 
 ```console
-GIT_USER=<Your GitHub username> USE_SSH=true yarn deploy
+GIT_USER=<Your GitHub username> USE_SSH=true npm run deploy
 ```
 
 If you are using GitHub pages for hosting, this command is a convenient way to build the website and push to the `gh-pages` branch.


### PR DESCRIPTION
## What

The README.md deployment command used yarn while every other command in the same file uses npm.

A contributor reading the README from top to bottom would install dependencies with npm, start the dev server with npm, build with npm, then suddenly switch to yarn for deployment. This is inconsistent and can cause confusion or errors for contributors who do not have yarn installed.

Before: GIT_USER=<Your GitHub username> USE_SSH=true yarn deploy
After: GIT_USER=<Your GitHub username> USE_SSH=true npm run deploy

## File changed

README.md (line 37)