### PR TITLE
fix: add missing closing parenthesis in dynamic-mig.md example

### DIFF
--- a/docs/developers/dynamic-mig.md
+++ b/docs/developers/dynamic-mig.md
@@ -140,7 +140,7 @@ spec:
       resources:
         limits:
           nvidia.com/gpu: 2 # requesting 2 vGPUs
-          nvidia.com/gpumem: 8000 # Each vGPU contains 8000m device memory (Optional,Integer
+          nvidia.com/gpumem: 8000 # Each vGPU contains 8000m device memory (Optional,Integer)
 ```
 
 ## Procedures


### PR DESCRIPTION
## What

The second YAML example in docs/developers/dynamic-mig.md has an unclosed parenthesis in the inline comment for nvidia.com/gpumem.

## Before

```
nvidia.com/gpumem: 8000 # Each vGPU contains 8000m device memory (Optional,Integer
```

## After

```
nvidia.com/gpumem: 8000 # Each vGPU contains 8000m device memory (Optional,Integer)
```

The first example on line 123 already has the closing bracket, so this change makes the two examples consistent.

Signed-off-by: mesutoezdil <mesudozdil@gmail.com>