### PR TITLE
fix: correct grammar from 'Just Setting' to 'Just set' in dynamic-mig.md

### DIFF
--- a/docs/developers/dynamic-mig.md
+++ b/docs/developers/dynamic-mig.md
@@ -105,7 +105,7 @@ data:
 ## Examples
 
 Dynamic mig is compatible with hami tasks, as the example below:
-Just Setting `nvidia.com/gpu` and `nvidia.com/gpumem`.
+Just set `nvidia.com/gpu` and `nvidia.com/gpumem`.
 
 ```yaml
 apiVersion: v1


### PR DESCRIPTION
## What

The Examples section in docs/developers/dynamic-mig.md reads:

> Just Setting \`nvidia.com/gpu\` and \`nvidia.com/gpumem\`.

The capitalised gerund 'Setting' is awkward as a standalone sentence. Using the imperative 'set' matches the instructional tone used elsewhere in the documentation.

## Change

```
- Just Setting \`nvidia.com/gpu\` and \`nvidia.com/gpumem\`.
+ Just set \`nvidia.com/gpu\` and \`nvidia.com/gpumem\`.
```

Signed-off-by: mesutoezdil <mesudozdil@gmail.com>