### PR TITLE
fix: remove trailing commas in sidebars.js single-item arrays

### DIFF
--- a/sidebars.js
+++ b/sidebars.js
@@ -142,7 +142,7 @@ module.exports = {
               "items": [
                 "userguide/hygon-device/examples/allocate-core-and-memory",
                 "userguide/hygon-device/examples/allocate-exclusive",
-                "userguide/hygon-device/examples/specify-certain-cards",
+                "userguide/hygon-device/examples/specify-certain-cards"
               ]
             }
           ]
@@ -216,7 +216,7 @@ module.exports = {
               "label": "Examples",
               "key": "vastai-examples",
               "items": [
-                "userguide/vastai/examples/default-use",
+                "userguide/vastai/examples/default-use"
               ]
             }
           ]


### PR DESCRIPTION
## What

Two items arrays in sidebars.js kept a trailing comma after their final entry. Other items blocks in the same file omit the trailing comma, so this change aligns them for consistency.

## Affected sections

- hygon-examples (around line 145)
- vastai-examples (around line 219)

## Change

```
- \"userguide/hygon-device/examples/specify-certain-cards\",
+ \"userguide/hygon-device/examples/specify-certain-cards\"
```

```
- \"userguide/vastai/examples/default-use\",
+ \"userguide/vastai/examples/default-use\"
```

No behaviour change. Purely cosmetic consistency with the rest of the file.

Signed-off-by: mesutoezdil <mesudozdil@gmail.com>