### PR TITLE
fix: remove double space before comma in faq.md

### DIFF
--- a/docs/faq/faq.md
+++ b/docs/faq/faq.md
@@ -158,7 +158,7 @@ Device Plugins can only report a single resource type. GPU memory and compute in
 
 **Why does the Node Capacity show `volcano.sh/vgpu-number` and `volcano.sh/vgpu-memory` when using `volcano-vgpu-device-plugin`?**
 
-- volcano-vgpu-device-plugin creates  **[three independent Device Plugin instances](https://github.com/Project-HAMi/volcano-vgpu-device-plugin/blob/2bf6dfe37f7b716f05d0d3210f89898087c06d99/pkg/plugin/vgpu/mig-strategy.go#L65-L85)** , each registering with kubelet for volcano.sh/vgpu-number, volcano.sh/vgpu-memory, and volcano.sh/vgpu-cores resources respectively. After kubelet receives the registration, it automatically writes the resources into Capacity and Allocatable.
+- volcano-vgpu-device-plugin creates **[three independent Device Plugin instances](https://github.com/Project-HAMi/volcano-vgpu-device-plugin/blob/2bf6dfe37f7b716f05d0d3210f89898087c06d99/pkg/plugin/vgpu/mig-strategy.go#L65-L85)**, each registering with kubelet for volcano.sh/vgpu-number, volcano.sh/vgpu-memory, and volcano.sh/vgpu-cores resources respectively. After kubelet receives the registration, it automatically writes the resources into Capacity and Allocatable.
 - **Note** : volcano.sh/vgpu-memory resource is subject to Kubernetes extended resources quantity limit (**maximum 32,767** ). For GPUs with large memory (e.g., A100 80GB), configure the `--gpu-memory-factor` parameter to avoid exceeding the limit.
 
 ## Why don’t some domestic vendors require a runtime for installation?


### PR DESCRIPTION
## What

Fixed formatting inconsistency in FAQ documentation. Line 161 had extra whitespace before the comma.

## Before
\`\`\`
instances](...)** , each
\`\`\`

## After
\`\`\`
instances](...)**, each
\`\`\`

Minor formatting cleanup for consistency with the rest of the document.

Signed-off-by: mesutoezdil <mesudozdil@gmail.com>