### PR TITLE
fix: remove extra spaces before commas in volcano-vgpu and hygon-device docs

### DIFF
--- a/docs/userguide/hygon-device/enable-hygon-dcu-sharing.md
+++ b/docs/userguide/hygon-device/enable-hygon-dcu-sharing.md
@@ -26,7 +26,7 @@ title: Enable Hygon DCU sharing
 ## Running DCU jobs
 
 Hygon DCUs can now be requested by a container
-using the `hygon.com/dcunum` , `hygon.com/dcumem` and `hygon.com/dcucores` resource type:
+using the `hygon.com/dcunum`, `hygon.com/dcumem` and `hygon.com/dcucores` resource type:
 
 ```yaml
 apiVersion: v1

--- a/docs/userguide/volcano-vgpu/nvidia-gpu/how-to-use-volcano-vgpu.md
+++ b/docs/userguide/volcano-vgpu/nvidia-gpu/how-to-use-volcano-vgpu.md
@@ -95,7 +95,7 @@ status:
 
 ### Running vGPU Jobs
 
-vGPU can be requested by both set "volcano.sh/vgpu-number" , "volcano.sh/vgpu-cores" and "volcano.sh/vgpu-memory" in resource.limit
+vGPU can be requested by both set "volcano.sh/vgpu-number", "volcano.sh/vgpu-cores" and "volcano.sh/vgpu-memory" in resource.limit
 
 ```shell
 cat <<EOF | kubectl apply -f -


### PR DESCRIPTION
found a couple places with extra space before commas. cleaned them up in volcano-vgpu and hygon-device docs.