### PR TITLE
fix: remove TODO placeholders from contributor ladder

### DIFF
--- a/docs/contributor/ladder.md
+++ b/docs/contributor/ladder.md
@@ -42,7 +42,6 @@ Description: A Contributor contributes directly to the project and adds value to
   * Run or helps run events
   * Promote the project in public
   * Help run the project infrastructure
-  * [TODO: other small contributions]
 * Privileges:
   * Invitations to contributor events
   * Eligible to become an Organization Member
@@ -80,7 +79,7 @@ An Organization Member must meet the responsibilities and has the requirements o
 * Privileges:
   * May be assigned Issues and Reviews
   * May give commands to CI/CD automation
-  * Can be added to [TODO: Repo Host] teams
+  * Can be added to HAMi project teams
   * Can recommend other contributors to become Org Members
 
 The process for a Contributor to become an Organization Member is as follows:


### PR DESCRIPTION
Remove vague [TODO: other small contributions] placeholder that was never completed.

Replace [TODO: Repo Host] with clear reference to "HAMi project teams" to improve documentation clarity.