### PR TITLE
fix: remove duplicate corrupted text from end of ladder.md

### DIFF
--- a/docs/contributor/ladder.md
+++ b/docs/contributor/ladder.md
@@ -166,6 +166,3 @@ Involuntary removal/demotion of a contributor happens when responsibilities and 
 Involuntary removal or demotion is handled through a vote by a majority of the current Maintainers.
 
 [two-factor authentication]: https://help.github.com/articles/about-two-factor-authentication
-ibutor happens when responsibilities and requirements aren't being met. This may include repeated patterns of inactivity, extended period of inactivity, a period of failing to meet the requirements of your role, and/or a violation of the Code of Conduct. This process is important because it protects the community and its deliverables while also opens up opportunities for new contributors to step in.
-
-Involuntary removal or demotion is handled through a vote by a majority of the current Maintainers.


### PR DESCRIPTION
Remove duplicate paragraph and corrupted text that appears to have been leftover from a previous edit. The text was causing the file to end with incomplete and corrupted content.