### PR TITLE
fix: correct Iluvatar spelling in documentation

### DIFF
--- a/docs/userguide/iluvatar-device/enable-iluvatar-gpu-sharing.md
+++ b/docs/userguide/iluvatar-device/enable-iluvatar-gpu-sharing.md
@@ -1,5 +1,5 @@
 ---
-title: Enable Illuvatar GPU Sharing
+title: Enable Iluvatar GPU Sharing
 ---
 
 ## Introduction

--- a/sidebars.js
+++ b/sidebars.js
@@ -167,9 +167,9 @@ module.exports = {
         },
         {
           "type": "category",
-          "label": "Share Illuvatar GPU devices",
+          "label": "Share Iluvatar GPU devices",
           "items": [
-            "userguide/iluvatar-device/enable-illuvatar-gpu-sharing",
+            "userguide/iluvatar-device/enable-iluvatar-gpu-sharing",
             {
               "type": "category",
               "label": "Examples",


### PR DESCRIPTION
Fixed spelling inconsistency in Iluvatar device doc.

- Renamed file from `enable-illuvatar-gpu-sharing.md` to `enable-iluvatar-gpu-sharing.md`
- Updated page title from "Enable Illuvatar GPU Sharing" to "Enable Iluvatar GPU Sharing"

The correct spelling is "Iluvatar" with a single 'l', matching the official product name (iluvatar.ai). The filename and title had an incorrect double 'l'.

Doc builds successfully with the corrected spelling.