### PR TITLE
fix: clean up trailing whitespace in configure.md

### DIFF
--- a/docs/userguide/configure.md
+++ b/docs/userguide/configure.md
@@ -41,7 +41,9 @@ You can update these configurations using one of the following methods:
    | `nvidia.resourcePriorityName` | String | vGPU job priority name. | `"nvidia.com/priority"` |
 
 ## Node Configs: ConfigMap
-HAMi allows configuring per-node behavior for device plugin. Edit 
+
+HAMi allows configuring per-node behavior for device plugin. Edit the ConfigMap:
+
 ```sh
 kubectl -n <namespace> edit cm hami-device-plugin
 ```


### PR DESCRIPTION
Fixed a line with trailing whitespace and improved sentence structure in the Node Configs section.

Removed trailing spaces after "Edit" and completed the incomplete sentence by adding "the ConfigMap:" for better readability.

Also added proper spacing around the section for consistency with the rest of the document.

The sentence was awkwardly broken and had trailing whitespace. This improves clarity for readers and keeps the formatting consistent.