### PR TITLE
fix: improve governance documentation clarity

### DIFF
--- a/docs/contributor/governance.md
+++ b/docs/contributor/governance.md
@@ -34,8 +34,7 @@ change as the community grows, such as by adopting an elected steering committee
 ## Meetings
 
 Time zones permitting, Maintainers are expected to participate in the public
-developer meeting, which occurs
-[Google Docs](https://docs.google.com/document/d/1YC6hco03_oXbF9IOUPJ29VWEddmITIKIfSmBX8JtGBw/edit).  
+developer meeting. Details can be found in this [Google Docs](https://docs.google.com/document/d/1YC6hco03_oXbF9IOUPJ29VWEddmITIKIfSmBX8JtGBw/edit) document.
 
 Maintainers will also have closed meetings in order to discuss security reports
 or Code of Conduct violations. Such meetings should be scheduled by any


### PR DESCRIPTION
Fixed an incomplete sentence in the Meetings section of the governance doc.

Rewrote the sentence from "which occurs [link]" to "Details can be found in this [link] document" for better clarity and proper grammar.

Also removed trailing whitespace on that line.

The original phrasing was awkward and incomplete. This makes it clearer where maintainers can find info about the developer meetings.