### PR TITLE
fix: correct i.e. formatting in enflame documentation

### DIFF
--- a/docs/userguide/enflame-device/enable-enflame-gcu-sharing.md
+++ b/docs/userguide/enflame-device/enable-enflame-gcu-sharing.md
@@ -5,7 +5,7 @@ title: Enable Enflame GPU Sharing
 
 ## Introduction
 
-**We now support sharing on enflame.com/gcu(i.e S60) by implementing most device-sharing features as nvidia-GPU**, including:
+**We now support sharing on enflame.com/gcu(i.e., S60) by implementing most device-sharing features as nvidia-GPU**, including:
 
 ***GCU sharing***: Each task can allocate a portion of GCU instead of a whole GCU card, thus GCU can be shared among multiple tasks.
 
@@ -118,7 +118,7 @@ Look for annotations containing device information in the node status.
 
 ## Notes
 
-1. GCUshare takes effect only for containers that apply for one GCU(i.e enflame.com/vgcu=1 ).
+1. GCUshare takes effect only for containers that apply for one GCU(i.e., enflame.com/vgcu=1 ).
 
 2. Multiple GCU allocation in one container is not supported yet
 


### PR DESCRIPTION
Fixed informal "i.e" to proper "i.e.," formatting in the Enflame device doc.

- Changed "i.e S60" to "i.e., S60"
- Changed "i.e enflame.com/vgcu=1" to "i.e., enflame.com/vgcu=1"

"i.e." is the correct abbreviation for "that is" and should include a period. Adding the comma after makes it follow standard English writing conventions.