### PR TITLE
fix: update stale GitHub branch references to current main branch

### DIFF
--- a/docs/userguide/enflame-device/enable-enflame-gcu-sharing.md
+++ b/docs/userguide/enflame-device/enable-enflame-gcu-sharing.md
@@ -78,7 +78,7 @@ spec:
           enflame.com/vgcu-percentage: 22
 ```
 
-> **NOTICE:** *You can find more examples in [examples/enflame folder](https://github.com/Project-HAMi/HAMi/tree/release-v2.6/examples/enflame/)*
+> **NOTICE:** *You can find more examples in [examples/enflame folder](https://github.com/Project-HAMi/HAMi/tree/master/examples/enflame/)*
 
 ## Device UUID Selection
 

--- a/docs/userguide/metax-device/metax-gpu/enable-metax-gpu-schedule.md
+++ b/docs/userguide/metax-device/metax-gpu/enable-metax-gpu-schedule.md
@@ -66,4 +66,4 @@ spec:
           metax-tech.com/gpu: 1 # requesting 1 GPU
 ```
 
-> **NOTICE:** *You can find more examples in [examples/metax folder](https://github.com/Project-HAMi/HAMi/tree/release-v2.6/examples/metax/gpu)*
+> **NOTICE:** *You can find more examples in [examples/metax folder](https://github.com/Project-HAMi/HAMi/tree/master/examples/metax/gpu)*

--- a/docs/userguide/metax-device/metax-sgpu/enable-metax-gpu-sharing.md
+++ b/docs/userguide/metax-device/metax-sgpu/enable-metax-gpu-sharing.md
@@ -46,4 +46,4 @@ spec:
           metax-tech.com/vmemory: 4 # each GPU require 4 GiB device memory
 ```
 
-> **NOTICE:** *You can find more examples in [examples/metax folder](https://github.com/Project-HAMi/HAMi/tree/release-v2.6/examples/metax/sgpu)*
+> **NOTICE:** *You can find more examples in [examples/metax folder](https://github.com/Project-HAMi/HAMi/tree/master/examples/metax/sgpu)*

--- a/docs/userguide/mthreads-device/enable-mthreads-gpu-sharing.md
+++ b/docs/userguide/mthreads-device/enable-mthreads-gpu-sharing.md
@@ -65,4 +65,4 @@ spec:
 ```
 
 > **NOTICE1:** *Each unit of sgpu-memory indicates 512M device memory*
-> **NOTICE2:** *You can find more examples in [examples/mthreads folder](https://github.com/Project-HAMi/HAMi/tree/release-v2.6/examples/mthreads/)*
+> **NOTICE:** *You can find more examples in [examples/mthreads folder](https://github.com/Project-HAMi/HAMi/tree/master/examples/mthreads/)*


### PR DESCRIPTION
Four device documentation files were linking to the outdated `release-v2.6` branch for example code. Since the project has released multiple versions (v2.7.0, v2.8.0), these links point users to outdated examples instead of the latest code.

Updated the following files to point to `master` branch instead of `release-v2.6`:
- metax-device/metax-gpu/enable-metax-gpu-schedule.md
- metax-device/metax-sgpu/enable-metax-gpu-sharing.md
- enflame-device/enable-enflame-gcu-sharing.md
- mthreads-device/enable-mthreads-gpu-sharing.md

Also fixed a typo: `NOTICE2` → `NOTICE` in mthreads documentation for consistency.

- Users now access current/latest examples instead of outdated v2.6 examples
- Examples will automatically update when new code is pushed to master
- Ensures documentation consistency across device guides

Verified that master branch contains examples for all updated device types.