### PR TITLE
fix: standardize helm install namespace specification

### DIFF
--- a/docs/userguide/configure.md
+++ b/docs/userguide/configure.md
@@ -62,7 +62,7 @@ kubectl -n <namespace> edit cm hami-device-plugin
 You can customize your vGPU support by setting the following arguments using `-set`, for example
 
 ```bash
-helm install hami hami-charts/hami --set devicePlugin.deviceMemoryScaling=5 ...
+helm install hami hami-charts/hami --set devicePlugin.deviceMemoryScaling=5 -n kube-system
 ```
 
 | Argument | Type | Description | Default |

--- a/docs/userguide/iluvatar-device/enable-iluvatar-gpu-sharing.md
+++ b/docs/userguide/iluvatar-device/enable-iluvatar-gpu-sharing.md
@@ -30,7 +30,7 @@ title: Enable Iluvatar GPU Sharing
 * set the devices.iluvatar.enabled=true when install hami
 
 ```bash
-helm install hami hami-charts/hami --set scheduler.kubeScheduler.imageTag={your kubernetes version} --set devices.iluvatar.enabled=true
+helm install hami hami-charts/hami --set scheduler.kubeScheduler.imageTag={your kubernetes version} --set devices.iluvatar.enabled=true -n kube-system
 ```
 
 **Note:** The currently supported GPU models and resource names are defined in ([https://github.com/Project-HAMi/HAMi/blob/master/charts/hami/templates/scheduler/device-configmap.yaml](https://github.com/Project-HAMi/HAMi/blob/master/charts/hami/templates/scheduler/device-configmap.yaml)):


### PR DESCRIPTION
This PR addresses inconsistency in helm install commands across device guides.

Changes:
- Added missing -n kube-system flag to iluvatar GPU sharing guide to match other device guides
- Replaced incomplete helm install example in configure.md with complete, deployable command

All helm install commands now consistently specify -n kube-system namespace. This ensures users follow the correct deployment pattern and HAMi components are installed in the expected namespace.