### PR TITLE
fix: standardize notice and note block formatting

### DIFF
--- a/docs/installation/how-to-use-hami-dra.md
+++ b/docs/installation/how-to-use-hami-dra.md
@@ -28,7 +28,7 @@ Then install with the following command:
 helm install hami hami-charts/hami --set dra.enable=true -n hami-system
 ```
 
-> **Note:** *DRA mode is not compatible with traditional mode. Do not enable both at the same time.*
+> **NOTICE:** *DRA mode is not compatible with traditional mode. Do not enable both at the same time.*
 
 ## Supported Devices
 

--- a/docs/userguide/awsneuron-device/enable-awsneuron-managing.md
+++ b/docs/userguide/awsneuron-device/enable-awsneuron-managing.md
@@ -109,7 +109,7 @@ spec:
   # ... rest of pod spec
 ```
 
-> **NOTE:** The device ID format is `{node-name}-AWSNeuron-{index}`. You can find the available device IDs in the node annotations.
+> **NOTICE:** The device ID format is `{node-name}-AWSNeuron-{index}`. You can find the available device IDs in the node annotations.
 
 ### Finding Device UUIDs
 

--- a/docs/userguide/enflame-device/enable-enflame-gcu-sharing.md
+++ b/docs/userguide/enflame-device/enable-enflame-gcu-sharing.md
@@ -27,7 +27,7 @@ title: Enable Enflame GPU Sharing
 * Deploy gcushare-device-plugin on enflame nodes (Please consult your device provider to acquire its package and document)
 
 > **NOTICE:** *Install only gpushare-device-plugin, don't install gpu-scheduler-plugin package.*
-> **NOTE:** The default resource names are:
+> **NOTICE:** The default resource names are:
 >
 > * `enflame.com/vgcu` for GCU count, only support 1 now.
 > * `enflame.com/vgcu-percentage` for the percentage of memory and cores in a gcu slice.
@@ -98,7 +98,7 @@ spec:
   # ... rest of pod spec
 ```
 
-> **NOTE:** The device ID format is `{node-name}-enflame-{index}`. You can find the available device IDs in the node status.
+> **NOTICE:** The device ID format is `{node-name}-enflame-{index}`. You can find the available device IDs in the node status.
 
 ### Finding Device UUIDs
 

--- a/docs/userguide/iluvatar-device/examples/allocate-bi-v150.md
+++ b/docs/userguide/iluvatar-device/examples/allocate-bi-v150.md
@@ -36,4 +36,4 @@ spec:
         iluvatar.ai/BI-V150.vMem: 64
 ```
 
-> **NOTE:** *Each `iluvatar.ai/<card-type>.vCore` unit represents 1% of an available compute core, and each `iluvatar.ai/<card-type>.vMem` unit represents 256MB of device memory*
+> **NOTICE:** *Each `iluvatar.ai/<card-type>.vCore` unit represents 1% of an available compute core, and each `iluvatar.ai/<card-type>.vMem` unit represents 256MB of device memory*

--- a/docs/userguide/iluvatar-device/examples/allocate-exclusive-bi-v150.md
+++ b/docs/userguide/iluvatar-device/examples/allocate-exclusive-bi-v150.md
@@ -32,4 +32,4 @@ spec:
         iluvatar.ai/BI-V150-vgpu: 2
 ```
 
-> **Note:** *When applying for exclusive use of a GPU, `iluvatar.ai/<card-type>-vgpu=1`, you need to set the values of `iluvatar.ai/<card-type>.vCore` and `iluvatar.ai/<card-type>.vMem` to the maximum number of GPU resources. `iluvatar.ai/<card-type>-vgpu>1` no longer supports the vGPU function, so you don't need to fill in the core and memory values*
+> **NOTICE:** *When applying for exclusive use of a GPU, `iluvatar.ai/<card-type>-vgpu=1`, you need to set the values of `iluvatar.ai/<card-type>.vCore` and `iluvatar.ai/<card-type>.vMem` to the maximum number of GPU resources. `iluvatar.ai/<card-type>-vgpu>1` no longer supports the vGPU function, so you don't need to fill in the core and memory values*

--- a/docs/userguide/iluvatar-device/examples/allocate-exclusive-mr-v100.md
+++ b/docs/userguide/iluvatar-device/examples/allocate-exclusive-mr-v100.md
@@ -32,4 +32,4 @@ spec:
         iluvatar.ai/MR-V100-vgpu: 2
 ```
 
-> **Note:** *When applying for exclusive use of a GPU, `iluvatar.ai/<card-type>-vgpu=1`, you need to set the values of `iluvatar.ai/<card-type>.vCore` and `iluvatar.ai/<card-type>.vMem` to the maximum number of GPU resources. `iluvatar.ai/<card-type>-vgpu>1` no longer supports the vGPU function, so you don't need to fill in the core and memory values*
+> **NOTICE:** *When applying for exclusive use of a GPU, `iluvatar.ai/<card-type>-vgpu=1`, you need to set the values of `iluvatar.ai/<card-type>.vCore` and `iluvatar.ai/<card-type>.vMem` to the maximum number of GPU resources. `iluvatar.ai/<card-type>-vgpu>1` no longer supports the vGPU function, so you don't need to fill in the core and memory values*

--- a/docs/userguide/iluvatar-device/examples/allocate-mr-v100.md
+++ b/docs/userguide/iluvatar-device/examples/allocate-mr-v100.md
@@ -37,4 +37,4 @@ spec:
         iluvatar.ai/MR-V100.vMem: 64
 ```
 
-> **NOTE:** *Each `iluvatar.ai/<card-type>.vCore` unit represents 1% of an available compute core, and each `iluvatar.ai/<card-type>.vMem` unit represents 256MB of device memory*
+> **NOTICE:** *Each `iluvatar.ai/<card-type>.vCore` unit represents 1% of an available compute core, and each `iluvatar.ai/<card-type>.vMem` unit represents 256MB of device memory*

--- a/docs/userguide/kunlunxin-device/enable-kunlunxin-vxpu.md
+++ b/docs/userguide/kunlunxin-device/enable-kunlunxin-vxpu.md
@@ -176,7 +176,7 @@ spec:
   # ... rest of Pod configuration
 ```
 
-> **Note:** Device ID format is `{BusID}`. You can find available device IDs in the node status.
+> **NOTICE:** Device ID format is `{BusID}`. You can find available device IDs in the node status.
 
 ### Finding Device UUIDs
 

--- a/docs/userguide/monitoring/device-allocation.md
+++ b/docs/userguide/monitoring/device-allocation.md
@@ -33,4 +33,4 @@ If you are using [HAMi DRA](../../installation/how-to-use-hami-dra), the metrics
 | vGPUDeviceCoreAllocated | vGPU core allocated from a container | `{devicebrand="Tesla",deviceidx="0",devicename="hami-gpu-0",deviceproductname="Tesla P4",deviceuuid="GPU-82be-83fe-3068",nodeid="k8s-node01",podname="pod-0",podnamespace="default"}` 100 |
 | vGPUDeviceMemoryAllocated | vGPU memory allocated from a container | `{devicebrand="Tesla",deviceidx="0",devicename="hami-gpu-0",deviceproductname="Tesla P4",deviceuuid="GPU-82be-83fe-3068",nodeid="k8s-node01",podname="pod-0",podnamespace="default"}` 4000 |
 
-> **Note:** This is the overview of device allocation, it is NOT device real-time usage metrics. For that part, see real-time device usage.
+> **NOTICE:** This is the overview of device allocation, it is NOT device real-time usage metrics. For that part, see real-time device usage.


### PR DESCRIPTION
This PR addresses inconsistent formatting of notice and note blocks across device guides and installation documentation.

Previously, documentation used three different formats:
- NOTICE: (20 instances)
- Note: (5 instances)
- NOTE: (5 instances)

Changes:
- Standardized all notice blocks to use NOTICE: format
- Fixed 9 files across device guides (iluvatar, enflame, awsneuron, kunlunxin) and installation documentation
- Added missing colon in device-allocation.md

This improves documentation consistency and professional appearance while maintaining the same information content.