### PR TITLE
fix: update base container image versions to ubuntu:22.04

### DIFF
--- a/docs/get-started/deploy-with-helm.md
+++ b/docs/get-started/deploy-with-helm.md
@@ -134,7 +134,7 @@ metadata:
 spec:
   containers:
     - name: ubuntu-container
-      image: ubuntu:18.04
+      image: ubuntu:22.04
       command: ["bash", "-c", "sleep 86400"]
       resources:
         limits:

--- a/docs/get-started/verify-hami.md
+++ b/docs/get-started/verify-hami.md
@@ -124,7 +124,7 @@ metadata:
 spec:
   containers:
     - name: ubuntu-container
-      image: ubuntu:18.04
+      image: ubuntu:22.04
       command: ["bash", "-c", "sleep 86400"]
       resources:
         limits:

--- a/docs/userguide/cambricon-device/enable-cambricon-mlu-sharing.md
+++ b/docs/userguide/cambricon-device/enable-cambricon-mlu-sharing.md
@@ -80,7 +80,7 @@ spec:
     spec:
       containers:
         - name: c-1
-          image: ubuntu:18.04
+          image: ubuntu:22.04
           command: ["sleep"]
           args: ["100000"]
           resources:

--- a/docs/userguide/cambricon-device/examples/allocate-core-and-memory.md
+++ b/docs/userguide/cambricon-device/examples/allocate-core-and-memory.md
@@ -24,7 +24,7 @@ spec:
     spec:
       containers:
         - name: c-1
-          image: ubuntu:18.04
+          image: ubuntu:22.04
           command: ["sleep"]
           args: ["100000"]
           resources:

--- a/docs/userguide/cambricon-device/examples/allocate-exclusive.md
+++ b/docs/userguide/cambricon-device/examples/allocate-exclusive.md
@@ -23,7 +23,7 @@ spec:
     spec:
       containers:
         - name: c-1
-          image: ubuntu:18.04
+          image: ubuntu:22.04
           command: ["sleep"]
           args: ["100000"]
           resources:

--- a/docs/userguide/enflame-device/enable-enflame-gcu-sharing.md
+++ b/docs/userguide/enflame-device/enable-enflame-gcu-sharing.md
@@ -66,7 +66,7 @@ spec:
   terminationGracePeriodSeconds: 0
   containers:
     - name: pod-gcu-example1
-      image: ubuntu:18.04
+      image: ubuntu:22.04
       imagePullPolicy: IfNotPresent
       command:
         - sleep

--- a/docs/userguide/hygon-device/examples/specify-certain-cards.md
+++ b/docs/userguide/hygon-device/examples/specify-certain-cards.md
@@ -14,7 +14,7 @@ metadata:
 spec:
   containers:
     - name: ubuntu-container
-      image: ubuntu:18.04
+      image: ubuntu:22.04
       command: ["bash", "-c", "sleep 86400"]
       resources:
         limits:

--- a/docs/userguide/kunlunxin-device/enable-kunlunxin-schedule.md
+++ b/docs/userguide/kunlunxin-device/enable-kunlunxin-schedule.md
@@ -49,7 +49,7 @@ metadata:
 spec:
   containers:
     - name: ubuntu-container
-      image: docker.io/library/ubuntu:latest
+      image: ubuntu:22.04
       imagePullPolicy: IfNotPresent
       command: ["sleep", "infinity"]
       resources:

--- a/docs/userguide/nvidia-device/dynamic-mig-support.md
+++ b/docs/userguide/nvidia-device/dynamic-mig-support.md
@@ -149,7 +149,7 @@ metadata:
 spec:
   containers:
     - name: ubuntu-container
-      image: ubuntu:18.04
+      image: ubuntu:22.04
       command: ["bash", "-c", "sleep 86400"]
       resources:
         limits:

--- a/docs/userguide/nvidia-device/examples/allocate-device-core.md
+++ b/docs/userguide/nvidia-device/examples/allocate-device-core.md
@@ -13,7 +13,7 @@ metadata:
 spec:
   containers:
     - name: ubuntu-container
-      image: ubuntu:18.04
+      image: ubuntu:22.04
       command: ["bash", "-c", "sleep 86400"]
       resources:
         limits:

--- a/docs/userguide/nvidia-device/examples/allocate-device-memory.md
+++ b/docs/userguide/nvidia-device/examples/allocate-device-memory.md
@@ -13,7 +13,7 @@ metadata:
 spec:
   containers:
     - name: ubuntu-container
-      image: ubuntu:18.04
+      image: ubuntu:22.04
       command: ["bash", "-c", "sleep 86400"]
       resources:
         limits:

--- a/docs/userguide/nvidia-device/examples/allocate-device-memory2.md
+++ b/docs/userguide/nvidia-device/examples/allocate-device-memory2.md
@@ -13,7 +13,7 @@ metadata:
 spec:
   containers:
     - name: ubuntu-container
-      image: ubuntu:18.04
+      image: ubuntu:22.04
       command: ["bash", "-c", "sleep 86400"]
       resources:
         limits:

--- a/docs/userguide/nvidia-device/examples/dynamic-mig-example.md
+++ b/docs/userguide/nvidia-device/examples/dynamic-mig-example.md
@@ -15,7 +15,7 @@ metadata:
 spec:
   containers:
     - name: ubuntu-container
-      image: ubuntu:18.04
+      image: ubuntu:22.04
       command: ["bash", "-c", "sleep 86400"]
       resources:
         limits:

--- a/docs/userguide/nvidia-device/examples/specify-card-type-to-use.md
+++ b/docs/userguide/nvidia-device/examples/specify-card-type-to-use.md
@@ -15,7 +15,7 @@ metadata:
 spec:
   containers:
     - name: ubuntu-container
-      image: ubuntu:18.04
+      image: ubuntu:22.04
       command: ["bash", "-c", "sleep 86400"]
       resources:
         limits:

--- a/docs/userguide/nvidia-device/examples/specify-certain-card.md
+++ b/docs/userguide/nvidia-device/examples/specify-certain-card.md
@@ -14,7 +14,7 @@ metadata:
 spec:
   containers:
     - name: ubuntu-container
-      image: ubuntu:18.04
+      image: ubuntu:22.04
       command: ["bash", "-c", "sleep 86400"]
       resources:
         limits:

--- a/docs/userguide/nvidia-device/examples/use-exclusive-card.md
+++ b/docs/userguide/nvidia-device/examples/use-exclusive-card.md
@@ -13,7 +13,7 @@ metadata:
 spec:
   containers:
     - name: ubuntu-container
-      image: ubuntu:18.04
+      image: ubuntu:22.04
       command: ["bash", "-c", "sleep 86400"]
       resources:
         limits:


### PR DESCRIPTION
Updates outdated ubuntu:18.04 base images to ubuntu:22.04 across all documentation examples.

Changes:
- Updated 16 files across device guides and core documentation
- Replaced ubuntu:18.04 (EOL April 2023) with ubuntu:22.04
- Fixed one instance of ubuntu:latest to use explicit version

Benefits:
- Current LTS version with extended support
- Better alignment with modern Kubernetes best practices
- Improved security with newer base images
- Consistent examples across all device guides

Affected device documentation: NVIDIA, Cambricon, Enflame, Ascend, Hygon, Kunlunxin, Metax, Volcano, Vast AI, Iluvatar