### PR TITLE
fix: remove incorrect karmada-related commented content

### DIFF
--- a/docs/releases.md
+++ b/docs/releases.md
@@ -77,39 +77,3 @@ The priorities for the release are discussed in the bi-weekly community meetings
 As the release progresses several issues may be moved to the next milestone.
 Hence, if an issue is important it is important to advocate its priority early in the release cycle.
 
-<!-- ### Release Artifacts
-
-The HAMi container images are available at `dockerHub`. 
-You can visit `https://hub.docker.com/r/karmada/<component_name>` to see the details of images.
-For example, [here](https://hub.docker.com/r/karmada/karmada-controller-manager) for karmada-controller-manager.
-
-Since v1.2.0, the following artifacts are uploaded:
-
-* crds.tar.gz
-* karmada-chart-v\<version_number\>.tgz
-* karmadactl-darwin-amd64.tgz
-* karmadactl-darwin-amd64.tgz.sha256
-* karmadactl-darwin-arm64.tgz
-* karmadactl-darwin-arm64.tgz.sha256
-* karmadactl-linux-amd64.tgz
-* karmadactl-linux-amd64.tgz.sha256
-* karmadactl-linux-arm64.tgz
-* karmadactl-linux-arm64.tgz.sha256
-* kubectl-karmada-darwin-amd64.tgz
-* kubectl-karmada-darwin-amd64.tgz.sha256
-* kubectl-karmada-darwin-arm64.tgz
-* kubectl-karmada-darwin-arm64.tgz.sha256
-* kubectl-karmada-linux-amd64.tgz
-* kubectl-karmada-linux-amd64.tgz.sha256
-* kubectl-karmada-linux-arm64.tgz
-* kubectl-karmada-linux-arm64.tgz.sha256
-* Source code(zip)
-* Source code(tar.gz)
-
-You can visit `https://github.com/Project-HAMi/HAMi/releases/download/v<version_number>/<artifact_name>` to download the artifacts above.
-
-For example:
-
-```shell
-wget https://github.com/Project-HAMi/HAMi/releases/download/v1.3.0/karmadactl-darwin-amd64.tgz
-``` -->


### PR DESCRIPTION
Removes 36 lines of orphaned, incorrect HTML-commented content from releases.md that contains karmada project references instead of HAMi.

Problem:
- Commented-out section references 'karmada' components (karmadactl, karmada-controller-manager, etc.)
- Content does not apply to HAMi project
- Appears to be leftover from template copy-paste error
- Confuses readers and clutters documentation

Solution:
- Remove entire commented Release Artifacts section
- Clean up releases.md documentation

Impact:
- Eliminates confusing, incorrect commented content
- Improves documentation clarity
- Reduces maintenance burden of orphaned code blocks