### PR TITLE
fix: correct YAML syntax in metax pod example

### DIFF
--- a/docs/userguide/metax-device/metax-gpu/enable-metax-gpu-schedule.md
+++ b/docs/userguide/metax-device/metax-gpu/enable-metax-gpu-schedule.md
@@ -54,7 +54,8 @@ apiVersion: v1
 kind: Pod
 metadata:
   name: gpu-pod1
-  annotations: hami.io/node-scheduler-policy: "spread" # when this parameter is set to spread, the scheduler will try to find the best topology for this task.
+  annotations:
+    hami.io/node-scheduler-policy: "spread" # when this parameter is set to spread, the scheduler will try to find the best topology for this task.
 spec:
   containers:
     - name: ubuntu-container


### PR DESCRIPTION
Fix incorrect YAML mapping syntax in the Pod example that demonstrates metax GPU scheduling with annotation parameters.

Changes
- Fixed malformed `annotations:` field in metax pod example
- Corrected syntax from `annotations: key: value` to proper YAML nested structure with `annotations:` followed by nested key-value pairs
- Affected file: `docs/userguide/metax-device/metax-gpu/enable-metax-gpu-schedule.md`

Impact
- Pod example now contains valid YAML that can be copied and applied directly
- Users can properly use the node-scheduler-policy annotation for metax GPU allocation
- Improves documentation accuracy for Kubernetes resource examples