### PR TITLE
fix: remove malformed code block closing syntax in releases.md

### DIFF
--- a/docs/releases.md
+++ b/docs/releases.md
@@ -112,4 +112,4 @@ For example:
 
 ```shell
 wget https://github.com/Project-HAMi/HAMi/releases/download/v1.3.0/karmadactl-darwin-amd64.tgz
-``` -->
+```


### PR DESCRIPTION
Fix malformed code block syntax in releases.md that would cause documentation rendering issues.

The closing backticks for a shell code block example contained leftover HTML comment syntax (`-->`), making the code block invalid for Docusaurus processing.

Changes
- Removed erroneous `-->` from code block closing syntax
- Affected file: `docs/releases.md`

Impact
- Documentation now renders correctly
- Code block is properly recognized by Docusaurus parser
- Improves documentation build integrity
