### PR TITLE
fix: add language tags to code blocks in vastai sharing guide

### DIFF
--- a/docs/userguide/vastai/enable-vastai-sharing.md
+++ b/docs/userguide/vastai/enable-vastai-sharing.md
@@ -18,7 +18,7 @@ We now support sharing `vastaitech.com/va` (Vastaitech) devices and provides the
 
 #### Label the Node
 
-```
+```bash
 kubectl label node {vastai-node} vastai=on
 ```
 
@@ -26,7 +26,7 @@ kubectl label node {vastai-node} vastai=on
 
 ##### Full Card Mode
 
-```
+```yaml
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
@@ -120,7 +120,7 @@ spec:
 
 ##### Die Mode
 
-```
+```yaml
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
@@ -214,7 +214,7 @@ spec:
 
 ### Run Vastai jobs
 
-```
+```yaml
 apiVersion: v1
 kind: Pod
 metadata:


### PR DESCRIPTION
Four code blocks in the Vastai sharing documentation were opened with bare triple backticks, so they rendered without syntax highlighting. This PR adds the correct language identifiers.

Changes
- Line 21: kubectl command → tagged as `bash`
- Line 29: Full Card Mode manifest → tagged as `yaml`
- Line 123: Die Mode manifest → tagged as `yaml`
- Line 217: Pod example → tagged as `yaml`

Affected file: `docs/userguide/vastai/enable-vastai-sharing.md`

The rest of the device guides (iluvatar, mthreads, enflame, metax, etc.) consistently declare languages on their code blocks. Without the tag, Docusaurus skips syntax highlighting, which makes the YAML manifests harder to read and copy.