### PR TITLE
fix: use consistent Mthreads capitalization in prose

### DIFF
--- a/docs/userguide/mthreads-device/enable-mthreads-gpu-sharing.md
+++ b/docs/userguide/mthreads-device/enable-mthreads-gpu-sharing.md
@@ -16,9 +16,9 @@ title: Enable Mthreads GPU sharing
 
 1. Device sharing for multi-cards is not supported.
 
-2. Only one mthreads device can be shared in a pod(even there are multiple containers).
+2. Only one Mthreads device can be shared in a pod(even there are multiple containers).
 
-3. Support allocating exclusive mthreads GPU by specifying mthreads.com/vgpu only.
+3. Support allocating exclusive Mthreads GPU by specifying mthreads.com/vgpu only.
 
 4. These features are tested on MTT S4000
 
@@ -29,7 +29,7 @@ title: Enable Mthreads GPU sharing
 
 ## Enabling GPU-sharing Support
 
-* Deploy MT-CloudNative Toolkit on mthreads nodes (Please consult your device provider to acquire its package and document)
+* Deploy MT-CloudNative Toolkit on Mthreads nodes (Please consult your device provider to acquire its package and document)
 
 > **NOTICE:** *You can remove mt-mutating-webhook and mt-gpu-scheduler after installation(optional).*
 


### PR DESCRIPTION
The Mthreads GPU sharing guide mixed lowercase `mthreads` and title-case `Mthreads` when referring to the vendor in prose. This PR aligns the remaining three lowercase references with the rest of the file (and the wider docs).

Other files in the repo already use `Mthreads` consistently:
- `docs/faq/faq.md` → "Mthreads"
- `docs/userguide/device-supported.md` → "Mthreads"

Inside `enable-mthreads-gpu-sharing.md` itself, the frontmatter title and the `## Running Mthreads jobs` heading also use `Mthreads`, so the lowercase prose references were the outliers.

Changes
`docs/userguide/mthreads-device/enable-mthreads-gpu-sharing.md`:
- Line 19: `mthreads device` → `Mthreads device`
- Line 21: `exclusive mthreads GPU` → `exclusive Mthreads GPU`
- Line 32: `on mthreads nodes` → `on Mthreads nodes`

