### PR TITLE
fix: bump ubuntu:20.04 examples to ubuntu:22.04

### DIFF
--- a/docs/developers/dynamic-mig.md
+++ b/docs/developers/dynamic-mig.md
@@ -115,7 +115,7 @@ metadata:
 spec:
   containers:
     - name: ubuntu-container1
-      image: ubuntu:20.04
+      image: ubuntu:22.04
       command: ["bash", "-c", "sleep 86400"]
       resources:
         limits:
@@ -135,7 +135,7 @@ metadata:
 spec:
   containers:
     - name: ubuntu-container1
-      image: ubuntu:20.04
+      image: ubuntu:22.04
       command: ["bash", "-c", "sleep 86400"]
       resources:
         limits:

--- a/docs/userguide/volcano-vgpu/nvidia-gpu/examples/default-use.md
+++ b/docs/userguide/volcano-vgpu/nvidia-gpu/examples/default-use.md
@@ -13,7 +13,7 @@ spec:
   restartPolicy: OnFailure
   schedulerName: volcano
   containers:
-  - image: ubuntu:20.04
+  - image: ubuntu:22.04
     name: pod1-ctr
     command: ["sleep"]
     args: ["100000"]

--- a/docs/userguide/volcano-vgpu/nvidia-gpu/examples/use-exclusive-gpu.md
+++ b/docs/userguide/volcano-vgpu/nvidia-gpu/examples/use-exclusive-gpu.md
@@ -13,7 +13,7 @@ spec:
   restartPolicy: OnFailure
   schedulerName: volcano
   containers:
-  - image: ubuntu:20.04
+  - image: ubuntu:22.04
     name: pod1-ctr
     command: ["sleep"]
     args: ["100000"]


### PR DESCRIPTION
Ubuntu 20.04 (Focal) reaches standard support EOL in April 2025. Bump the remaining four example manifests to Ubuntu 22.04 (Jammy) so the docs don't steer new users toward an almost-EOL base image.

Changes
- `docs/developers/dynamic-mig.md`: two pod examples
- `docs/userguide/volcano-vgpu/nvidia-gpu/examples/default-use.md`
- `docs/userguide/volcano-vgpu/nvidia-gpu/examples/use-exclusive-gpu.md`

Four `ubuntu:20.04` references in total, all switched to `ubuntu:22.04`. This is a small follow-up to #204, which bumped the `ubuntu:18.04` references. After that lands, 20.04 becomes the oldest base image still referenced in the docs, so it makes sense to align the rest before 20.04's EOL.