### PR TITLE
fix: drop stray NOTICE1 numbering in iluvatar and mthreads guides

### DIFF
--- a/docs/userguide/iluvatar-device/enable-iluvatar-gpu-sharing.md
+++ b/docs/userguide/iluvatar-device/enable-iluvatar-gpu-sharing.md
@@ -112,7 +112,7 @@ spec:
         iluvatar.ai/BI-V150.vMem: 64
 ```
 
-> **NOTICE1:** *Each unit of vcuda-memory indicates 256M device memory*
+> **NOTICE:** *Each unit of vcuda-memory indicates 256M device memory*
 
 ## Device UUID Selection
 

--- a/docs/userguide/mthreads-device/enable-mthreads-gpu-sharing.md
+++ b/docs/userguide/mthreads-device/enable-mthreads-gpu-sharing.md
@@ -64,5 +64,5 @@ spec:
           mthreads.com/sgpu-core: 8
 ```
 
-> **NOTICE1:** *Each unit of sgpu-memory indicates 512M device memory*
+> **NOTICE:** *Each unit of sgpu-memory indicates 512M device memory*
 > **NOTICE:** *You can find more examples in [examples/mthreads folder](https://github.com/Project-HAMi/HAMi/tree/master/examples/mthreads/)*


### PR DESCRIPTION
Two device guides had a `> **NOTICE1:**` callout even though there was no matching `NOTICE2:`, which looks like a leftover from an earlier numbered style. Drop the digit so the two callouts match the `NOTICE:` format used throughout the rest of the same files and the other device guides.

Changes
- `docs/userguide/iluvatar-device/enable-iluvatar-gpu-sharing.md` line 115
- `docs/userguide/mthreads-device/enable-mthreads-gpu-sharing.md` line 67

In the mthreads file specifically, line 67 was `NOTICE1:` while the very next line (line 68) is already `NOTICE:`, so they read oddly next to each other.

#203 is standardizing `NOTE:` / `Note:` to `NOTICE:` across the docs but does not touch the `NOTICE1` leftovers. This PR is a small follow-up covering those two lines.