### PR TITLE
docs: remove duplicated word in monitoring endpoint description

### DIFF
--- a/docs/userguide/monitoring/real-time-device-usage.md
+++ b/docs/userguide/monitoring/real-time-device-usage.md
@@ -3,7 +3,7 @@ title: Real-time device usage endpoint
 linktitle: Real-time device usage
 ---
 
-You can get the real-time device memory and core utilization by visiting `{GPU node node ip}:31992/metrics`, or add it to a prometheus endpoint, as the command below:
+You can get the real-time device memory and core utilization by visiting `{GPU node ip}:31992/metrics`, or add it to a prometheus endpoint, as the command below:
 
 ```bash
 curl {GPU node ip}:31992/metrics


### PR DESCRIPTION
## Summary

The real-time device usage page contains a duplicated word in the URL placeholder description: `{GPU node node ip}` should be `{GPU node ip}`. The following line in the same paragraph already uses the correct form, so this is clearly a typo.

## Changes

- `docs/userguide/monitoring/real-time-device-usage.md`: fix `GPU node node ip` → `GPU node ip`

## Test plan

- [x] Rendered the page locally and verified the sentence reads correctly
- [x] Confirmed consistency with the `curl {GPU node ip}:31992/metrics` example immediately below