### PR TITLE
docs: standardize 'i.e.,' punctuation across device guides

### DIFF
--- a/docs/installation/how-to-use-volcano-ascend.md
+++ b/docs/installation/how-to-use-volcano-ascend.md
@@ -5,7 +5,7 @@ title: User Guide for Ascend Devices in Volcano
 
 ## Introduction
 
- Volcano supports vNPU feature for both Ascend 310 and Ascend 910 using the `ascend-device-plugin`. It also supports managing heterogeneous Ascend cluster(Cluster with multiple Ascend types, i.e. 910A,910B2,910B3,310p)
+ Volcano supports vNPU feature for both Ascend 310 and Ascend 910 using the `ascend-device-plugin`. It also supports managing heterogeneous Ascend cluster(Cluster with multiple Ascend types, i.e., 910A, 910B2, 910B3, 310p)
 
 **Use case**:
 

--- a/docs/userguide/awsneuron-device/enable-awsneuron-managing.md
+++ b/docs/userguide/awsneuron-device/enable-awsneuron-managing.md
@@ -129,6 +129,6 @@ Look for annotations containing device information in the node status.
 
 ## Notes
 
-1. AWS Neuron sharing takes effect only for containers that apply for one AWS Neuron device(i.e `aws.amazon.com/neuroncore`=1 ).
+1. AWS Neuron sharing takes effect only for containers that apply for one AWS Neuron device(i.e., `aws.amazon.com/neuroncore`=1).
 
 2. `neuron-ls` inside container shows the total device memory, which is NOT a bug. Device memory will be properly limited when tasks are running.

--- a/docs/userguide/hygon-device/enable-hygon-dcu-sharing.md
+++ b/docs/userguide/hygon-device/enable-hygon-dcu-sharing.md
@@ -8,9 +8,9 @@ title: Enable Hygon DCU sharing
 
 ***DCU sharing***: Each task can allocate a portion of DCU instead of a whole DCU card, thus DCU can be shared among multiple tasks.
 
-***Device Memory Control***: DCUs can be allocated with certain device memory size on certain type(i.e Z100) and have made it that it does not exceed the boundary.
+***Device Memory Control***: DCUs can be allocated with certain device memory size on certain type(i.e., Z100) and have made it that it does not exceed the boundary.
 
-***Device compute core limitation***: DCUs can be allocated with certain percentage of device core(i.e hygon.com/dcucores:60 indicate this container uses 60% compute cores of this device)
+***Device compute core limitation***: DCUs can be allocated with certain percentage of device core(i.e., hygon.com/dcucores:60 indicates this container uses 60% compute cores of this device)
 
 ***DCU Type Specification***: You can specify which type of DCU to use or to avoid for a certain task, by setting "hygon.com/use-dcutype" or "hygon.com/nouse-dcutype" annotations.
 

--- a/docs/userguide/iluvatar-device/enable-iluvatar-gpu-sharing.md
+++ b/docs/userguide/iluvatar-device/enable-iluvatar-gpu-sharing.md
@@ -4,7 +4,7 @@ title: Enable Iluvatar GPU Sharing
 
 ## Introduction
 
-**We now support iluvatar.ai/gpu(i.e MR-V100, BI-V150, BI-V100) by implementing most device-sharing features as nvidia-GPU**, including:
+**We now support iluvatar.ai/gpu(i.e., MR-V100, BI-V150, BI-V100) by implementing most device-sharing features as nvidia-GPU**, including:
 
 ***GPU sharing***: Each task can allocate a portion of GPU instead of a whole GPU card, thus GPU can be shared among multiple tasks.
 
@@ -160,7 +160,7 @@ Look for annotations containing device information in the node status.
       source /root/.bashrc
 ```
 
-1. Virtualization takes effect only for containers that apply for one GPU(i.e iluvatar.ai/vgpu=1 ). When requesting multiple GPUs, the system will automatically set the core resources based on the number of GPUs requested.
+1. Virtualization takes effect only for containers that apply for one GPU(i.e., iluvatar.ai/vgpu=1). When requesting multiple GPUs, the system will automatically set the core resources based on the number of GPUs requested.
 
 2. The `iluvatar.ai/<card-type>.vMem` resource is only effective when `iluvatar.ai/<card-type>-vgpu=1`.
 

--- a/docs/userguide/mthreads-device/enable-mthreads-gpu-sharing.md
+++ b/docs/userguide/mthreads-device/enable-mthreads-gpu-sharing.md
@@ -8,9 +8,9 @@ title: Enable Mthreads GPU sharing
 
 ***GPU sharing***: Each task can allocate a portion of GPU instead of a whole GPU card, thus GPU can be shared among multiple tasks.
 
-***Device Memory Control***: GPUs can be allocated with certain device memory size on certain type(i.e MTT S4000) and have made it that it does not exceed the boundary.
+***Device Memory Control***: GPUs can be allocated with certain device memory size on certain type(i.e., MTT S4000) and have made it that it does not exceed the boundary.
 
-***Device Core Control***: GPUs can be allocated with limited compute cores on certain type(i.e MTT S4000) and have made it that it does not exceed the boundary.
+***Device Core Control***: GPUs can be allocated with limited compute cores on certain type(i.e., MTT S4000) and have made it that it does not exceed the boundary.
 
 ## Important Notes
 


### PR DESCRIPTION
Several device sharing guides used inconsistent or grammatically off forms of the abbreviation \"i.e.\" — for example `i.e Z100`, `i.e MR-V100`, `i.e \`aws.amazon.com/neuroncore\`=1`, or `i.e. 910A,910B2,910B3,310p`. The enflame guide already uses the standard English form `i.e.,` (period + comma), so this change aligns the rest of the device guides with that form, and cleans up a couple of small adjacent issues (stray space before the closing paren, missing spaces after commas, and `indicate` → `indicates` for subject-verb agreement).

Changes

- `docs/installation/how-to-use-volcano-ascend.md`: `i.e.` → `i.e.,` plus spaces after commas in the chip list
- `docs/userguide/awsneuron-device/enable-awsneuron-managing.md`: `(i.e ... =1 )` → `(i.e., ... =1)`
- `docs/userguide/hygon-device/enable-hygon-dcu-sharing.md`: `(i.e Z100)` and `(i.e hygon.com/dcucores:60 indicate ...)` → `(i.e., Z100)` and `(i.e., hygon.com/dcucores:60 indicates ...)`
- `docs/userguide/iluvatar-device/enable-iluvatar-gpu-sharing.md`: `(i.e MR-V100, ...)` and `(i.e iluvatar.ai/vgpu=1 )` → `(i.e., ...)` / `(i.e., iluvatar.ai/vgpu=1)`
- `docs/userguide/mthreads-device/enable-mthreads-gpu-sharing.md`: `(i.e MTT S4000)` → `(i.e., MTT S4000)` (both occurrences)