### PR TITLE
docs: fix small typos and mislabeled link text

### DIFF
--- a/docs/contributor/adopters.md
+++ b/docs/contributor/adopters.md
@@ -10,7 +10,7 @@ You just need to add an entry for your company and upon merging it will automati
 
 To add your organisation follow these steps:
 
-1. Fork the [HAMi-io/website](https://github.com/Project-HAMi/website) repository.
+1. Fork the [Project-HAMi/website](https://github.com/Project-HAMi/website) repository.
 2. Clone it locally with `git clone https://github.com/<YOUR-GH-USERNAME>/website.git`.
 3. (Optional) Add the logo of your organisation to `static/img/supporters`. Good practice is for the logo to be called e.g. `<company>.png`.
    This will not be used for commercial purposes.
@@ -19,10 +19,10 @@ To add your organisation follow these steps:
 
    | Organization | Contact                           | Environment | Description of Use                            |
    | ------------ | --------------------------------- | ----------- | --------------------------------------------- |
-   | My Company   | [email](mailto:email@company.com) | Production  | We use HAMi to Manage our GPU infrastructure. |
+   | My Company   | [email](mailto:email@company.com) | Production  | We use HAMi to manage our GPU infrastructure. |
 
 5. Save the file, then do `git add -A` and commit using `git commit -s -m "Add MY-ORG to adopters"`.
 6. Push the commit with `git push origin main`.
-7. Open a Pull Request to [HAMi-io/website](https://github.com/Project-HAMi/website) and a preview build will turn up.
+7. Open a Pull Request to [Project-HAMi/website](https://github.com/Project-HAMi/website) and a preview build will turn up.
 
 Thanks a lot for being part of our community - we very much appreciate it!

--- a/docs/userguide/vastai/enable-vastai-sharing.md
+++ b/docs/userguide/vastai/enable-vastai-sharing.md
@@ -4,7 +4,7 @@ title: Enable Vastai Sharing
 
 ## Introduction
 
-We now support sharing `vastaitech.com/va` (Vastaitech) devices and provides the following capabilities:
+We now support sharing `vastaitech.com/va` (Vastaitech) devices and provide the following capabilities:
 
 ***Supports both Full-Card mode and Die mode***: Only Full-Card mode and Die mode are supported currently.
 

--- a/docs/userguide/vastai/examples/default-use.md
+++ b/docs/userguide/vastai/examples/default-use.md
@@ -3,7 +3,7 @@ title: Allocate Vastai Device
 ---
 
 This example shows how to request a single Vastai device in a plain Kubernetes Pod.
-The Pod simply runs a long‑running container image provided by Vastaitech and asks for one `vastaitech.com/va` device through the `resources.limits` section.
+The Pod simply runs a long-running container image provided by Vastaitech and asks for one `vastaitech.com/va` device through the `resources.limits` section.
 You can use this as a starting point and adjust the image and resource limits to fit your own workloads.
 
 ```yaml

--- a/docs/userguide/volcano-vgpu/nvidia-gpu/monitor.md
+++ b/docs/userguide/volcano-vgpu/nvidia-gpu/monitor.md
@@ -14,7 +14,7 @@ It contains the following metrics:
 | ------- | ----------- | ------- |
 | volcano_vgpu_device_allocated_cores | The percentage of GPU compute cores allocated in this card | `{NodeName="aio-node67",devID="GPU-00552014-5c87-89ac-b1a6-7b53aa24b0ec"}` 0 |
 | volcano_vgpu_device_allocated_memory | vGPU memory allocated in this card | `{NodeName="aio-node67",devID="GPU-00552014-5c87-89ac-b1a6-7b53aa24b0ec"}` 32768 |
-| volcano_vgpu_device_core_allocation_for_a_vertain_pod | The vGPU device core allocated for a certain pod | `{NodeName="aio-node67",devID="GPU-00552014-5c87-89ac-b1a6-7b53aa24b0ec",podName="resnet101-deployment-7b487d974d-jjc8p"}` 0 |
+| volcano_vgpu_device_core_allocation_for_a_certain_pod | The vGPU device core allocated for a certain pod | `{NodeName="aio-node67",devID="GPU-00552014-5c87-89ac-b1a6-7b53aa24b0ec",podName="resnet101-deployment-7b487d974d-jjc8p"}` 0 |
 | volcano_vgpu_device_memory_allocation_for_a_certain_pod | The vGPU device memory allocated for a certain pod | `{NodeName="aio-node67",devID="GPU-00552014-5c87-89ac-b1a6-7b53aa24b0ec",podName="resnet101-deployment-7b487d974d-jjc8p"}` 16384 |
 | volcano_vgpu_device_memory_limit | The number of total device memory in this card | `{NodeName="m5-cloudinfra-online01",devID="GPU-a88b5d0e-eb85-924b-b3cd-c6cad732f745"}` 32768 |
 | volcano_vgpu_device_shared_number | The number of vGPU tasks sharing this card | `{NodeName="aio-node67",devID="GPU-00552014-5c87-89ac-b1a6-7b53aa24b0ec"}` 2 |


### PR DESCRIPTION
## Summary

A handful of small prose-level issues surfaced while reading through the docs. None of these are style preferences: each one is an objective fix:

- `docs/userguide/volcano-vgpu/nvidia-gpu/monitor.md`: the metrics table listed `volcano_vgpu_device_core_allocation_for_a_vertain_pod`. The actual metric name in volcano's source is `..._for_a_certain_pod` (see `pkg/scheduler/api/devices/nvidia/vgpu/metrics.go` in volcano-sh/volcano), so the docs were misleading.
- `docs/userguide/vastai/enable-vastai-sharing.md`: subject/verb slip: \"We now support sharing ... devices and **provides** the following capabilities\" → `provide` (subject is \"We\").
- `docs/contributor/adopters.md`: two link markdowns showed `[HAMi-io/website]` as display text while the URL correctly pointed to `https://github.com/Project-HAMi/website`. `HAMi-io` is not the org name; aligned display text with the actual repo. Also lowercased an accidental capital in the sample table (\"to Manage\" → \"to manage\").
- `docs/userguide/vastai/examples/default-use.md`: \"long‑running\" used a non-breaking hyphen (U+2011) instead of an ASCII hyphen; replaced with regular `-` so the word remains searchable and copy-pastes cleanly.