### PR TITLE
docs: fix 'lost of trust' typo in ladder.md

### DIFF
--- a/docs/contributor/ladder.md
+++ b/docs/contributor/ladder.md
@@ -149,7 +149,7 @@ It is normal for maintainers to come and go based on their other responsibilitie
 
 ## Inactivity
 
-It is important for contributors to be and stay active to set an example and show commitment to the project. Inactivity is harmful to the project as it may lead to unexpected delays, contributor attrition, and a lost of trust in the project.
+It is important for contributors to be and stay active to set an example and show commitment to the project. Inactivity is harmful to the project as it may lead to unexpected delays, contributor attrition, and a loss of trust in the project.
 
 * Inactivity is measured by:
   * Periods of no contributions for longer than 3 months


### PR DESCRIPTION
Small typo in the Inactivity section of the contributor ladder: `a lost of trust` should be `a loss of trust`. 'Lost' is an adjective/past participle while the noun required here is 'loss'.
