### PR TITLE
docs: fix 'PaiSwitch' typo and awkward phrasing in metax guide

### DIFF
--- a/docs/userguide/metax-device/metax-gpu/enable-metax-gpu-schedule.md
+++ b/docs/userguide/metax-device/metax-gpu/enable-metax-gpu-schedule.md
@@ -19,11 +19,11 @@ the GPU device plugin (gpu-device) handles fine-grained allocation based on the 
    - A connection is considered a MetaXLink connection when there is a MetaXLink connection and a PCIe Switch connection between the two cards.
    - When both the MetaXLink and the PCIe Switch can meet the job request, equipped with MetaXLink interconnected resources.
 
-2. When using `node-scheduler-policy=spread`, allocate Metax resources to be under the same MetaXLink or PaiSwitch as much as possible, as shown below:
+2. When using `node-scheduler-policy=spread`, allocate Metax resources to be under the same MetaXLink or PCIe Switch as much as possible, as shown below:
 
    ![Metax spread scheduling policy diagram showing resource allocation](/img/docs/common/userguide/metax-device/metax-gpu/metax-spread.jpg)
 
-3. When using `node-scheduler-policy=binpack`, assign GPU resources, so minimize the damage to MetaXLink topology, as shown below:
+3. When using `node-scheduler-policy=binpack`, assign GPU resources so as to minimize the damage to MetaXLink topology, as shown below:
 
    ![Metax binpack scheduling policy diagram showing topology-aware allocation](/img/docs/common/userguide/metax-device/metax-gpu/metax-binpack.jpg)
 


### PR DESCRIPTION
Two small prose fixes in the metax scheduling guide:

- `PaiSwitch` -> `PCIe Switch` to match the rest of the section
- `assign GPU resources, so minimize` -> `assign GPU resources so as to minimize` for more natural reading