### PR TITLE
docs: tidy '1080(include 1080Ti)' in nvidia device-type guide

### DIFF
--- a/docs/userguide/nvidia-device/specify-device-type-to-use.md
+++ b/docs/userguide/nvidia-device/specify-device-type-to-use.md
@@ -14,7 +14,7 @@ metadata:
     nvidia.com/use-gputype: "A100,V100" # Specify the card type for this job, use comma to separate, will not launch job on non-specified card
 ```
 
-A task may use `nvidia.com/nouse-gputype` to evade certain type of GPU. In this following example, that job won't be assigned to 1080(include 1080Ti) or 2080(include 2080Ti) type of card. 
+A task may use `nvidia.com/nouse-gputype` to evade certain type of GPU. In this following example, that job won't be assigned to 1080 (including 1080Ti) or 2080 (including 2080Ti) type of card. 
 
 ```yaml
 metadata:


### PR DESCRIPTION
Minor prose fix: `1080(include 1080Ti) or 2080(include 2080Ti)` -> `1080 (including 1080Ti) or 2080 (including 2080Ti)`. Adds missing space before the opening paren and corrects the participle form.