### PR TITLE
docs: collapse double space before 'resource type:' in device guides

### DIFF
--- a/docs/userguide/enflame-device/enable-enflame-gcu-sharing.md
+++ b/docs/userguide/enflame-device/enable-enflame-gcu-sharing.md
@@ -54,7 +54,7 @@ HAMi divides each Enflame GCU into 100 units for resource allocation. When you r
 ## Running Enflame jobs
 
 Enflame GCUs can now be requested by a container
-using the `enflame.com/vgcu` and `enflame.com/vgcu-percentage`  resource type:
+using the `enflame.com/vgcu` and `enflame.com/vgcu-percentage` resource type:
 
 ```yaml
 apiVersion: v1

--- a/docs/userguide/iluvatar-device/enable-iluvatar-gpu-sharing.md
+++ b/docs/userguide/iluvatar-device/enable-iluvatar-gpu-sharing.md
@@ -78,7 +78,7 @@ HAMi divides each Iluvatar GPU into 100 units for resource allocation. When you 
 ## Running Iluvatar jobs
 
 Iluvatar GPUs can now be requested by a container
-using the `iluvatar.ai/BI-V150-vgpu`, `iluvatar.ai/BI-V150.vMem` and `iluvatar.ai/BI-V150.vCore`  resource type:
+using the `iluvatar.ai/BI-V150-vgpu`, `iluvatar.ai/BI-V150.vMem` and `iluvatar.ai/BI-V150.vCore` resource type:
 
 ```yaml
 apiVersion: v1

--- a/docs/userguide/mthreads-device/enable-mthreads-gpu-sharing.md
+++ b/docs/userguide/mthreads-device/enable-mthreads-gpu-sharing.md
@@ -42,7 +42,7 @@ helm install hami hami-charts/hami --set scheduler.kubeScheduler.imageTag={your 
 ## Running Mthreads jobs
 
 Mthreads GPUs can now be requested by a container
-using the `mthreads.com/vgpu`, `mthreads.com/sgpu-memory` and `mthreads.com/sgpu-core`  resource type:
+using the `mthreads.com/vgpu`, `mthreads.com/sgpu-memory` and `mthreads.com/sgpu-core` resource type:
 
 ```yaml
 apiVersion: v1


### PR DESCRIPTION
The iluvatar, enflame and mthreads guides each had a stray double space between the last backticked resource name and the words `resource type:`. Collapsed to a single space.