### PR TITLE
docs: add missing space after period in vastai notes

### DIFF
--- a/docs/userguide/vastai/enable-vastai-sharing.md
+++ b/docs/userguide/vastai/enable-vastai-sharing.md
@@ -232,4 +232,4 @@ spec:
 
 ## Notes
 1. When requesting Vastai resources, you cannot specify the memory size.
-2. The `vastai-device-plugin` does not mount the `vasmi` into the container.If you need to use the `vasmi` command inside the container, please mount it manually.
+2. The `vastai-device-plugin` does not mount the `vasmi` into the container. If you need to use the `vasmi` command inside the container, please mount it manually.


### PR DESCRIPTION
Notes section in the vastai guide had `container.If` without a space after the period. Added one.