### PR TITLE
docs: simplify 'Note ... Please note that' in device allocation

### DIFF
--- a/docs/userguide/monitoring/device-allocation.md
+++ b/docs/userguide/monitoring/device-allocation.md
@@ -33,4 +33,4 @@ If you are using [HAMi DRA](../../installation/how-to-use-hami-dra), the metrics
 | vGPUDeviceCoreAllocated | vGPU core allocated from a container | `{devicebrand="Tesla",deviceidx="0",devicename="hami-gpu-0",deviceproductname="Tesla P4",deviceuuid="GPU-82be-83fe-3068",nodeid="k8s-node01",podname="pod-0",podnamespace="default"}` 100 |
 | vGPUDeviceMemoryAllocated | vGPU memory allocated from a container | `{devicebrand="Tesla",deviceidx="0",devicename="hami-gpu-0",deviceproductname="Tesla P4",deviceuuid="GPU-82be-83fe-3068",nodeid="k8s-node01",podname="pod-0",podnamespace="default"}` 4000 |
 
-> **Note** Please note that, this is the overview about device allocation, it is NOT device real-time usage metrics. For that part, see real-time device usage.
+> **Note:** This is the overview of device allocation, it is NOT device real-time usage metrics. For that part, see real-time device usage.


### PR DESCRIPTION
The callout in device-allocation.md opened with `> **Note** Please note that, this is ...` which repeats itself. Simplified to a single `**Note:**` prefix and dropped the redundant "Please note that,".