### PR TITLE
docs: collapse double space in dynamic-mig-example intro

### DIFF
--- a/docs/userguide/nvidia-device/examples/dynamic-mig-example.md
+++ b/docs/userguide/nvidia-device/examples/dynamic-mig-example.md
@@ -2,7 +2,7 @@
 title: Assign task to mig instance
 ---
 
-This example will allocate `2g.10gb * 2` for A100-40GB-PCIE device  or `1g.10gb * 2` for A100-80GB-XSM device.
+This example will allocate `2g.10gb * 2` for A100-40GB-PCIE device or `1g.10gb * 2` for A100-80GB-XSM device.
 
 ```yaml
 apiVersion: v1


### PR DESCRIPTION
`for A100-40GB-PCIE device  or` had two spaces between "device" and "or". Collapsed to one.