### PR TITLE
docs: pluralize 'GPU card' in volcano-vgpu intro

### DIFF
--- a/docs/userguide/volcano-vgpu/nvidia-gpu/how-to-use-volcano-vgpu.md
+++ b/docs/userguide/volcano-vgpu/nvidia-gpu/how-to-use-volcano-vgpu.md
@@ -8,7 +8,7 @@ linktitle: Use Volcano vGPU
 You *DON'T* need to install HAMi when using volcano-vgpu, only use  
 [Volcano vGPU device-plugin](https://github.com/Project-HAMi/volcano-vgpu-device-plugin) is good enough. It can provide device-sharing mechanism for NVIDIA devices managed by Volcano.
 
-This is based on [Nvidia Device Plugin](https://github.com/NVIDIA/k8s-device-plugin), it uses [HAMi-core](https://github.com/Project-HAMi/HAMi-core) to support hard isolation of GPU card.
+This is based on [Nvidia Device Plugin](https://github.com/NVIDIA/k8s-device-plugin), it uses [HAMi-core](https://github.com/Project-HAMi/HAMi-core) to support hard isolation of GPU cards.
 
 Volcano vGPU is only available in Volcano > v1.9.
 


### PR DESCRIPTION
The feature applies to multiple cards, so `hard isolation of GPU card` -> `hard isolation of GPU cards`.