### PR TITLE
docs: strip zero-width space chars from iluvatar exclusive examples

### DIFF
--- a/docs/userguide/iluvatar-device/examples/allocate-exclusive-bi-v150.md
+++ b/docs/userguide/iluvatar-device/examples/allocate-exclusive-bi-v150.md
@@ -32,4 +32,4 @@ spec:
         iluvatar.ai/BI-V150-vgpu: 2
 ```
 
-> **Note:** *When applying for exclusive use of a GPU, `iluvatar.ai/<card-type>-vgpu=1`, you need to set the values ​​of `iluvatar.ai/<card-type>.vCore` and `iluvatar.ai/<card-type>.vMem` to the maximum number of GPU resources. `iluvatar.ai/<card-type>-vgpu>1` no longer supports the vGPU function, so you don't need to fill in the core and memory values*
+> **Note:** *When applying for exclusive use of a GPU, `iluvatar.ai/<card-type>-vgpu=1`, you need to set the values of `iluvatar.ai/<card-type>.vCore` and `iluvatar.ai/<card-type>.vMem` to the maximum number of GPU resources. `iluvatar.ai/<card-type>-vgpu>1` no longer supports the vGPU function, so you don't need to fill in the core and memory values*

--- a/docs/userguide/iluvatar-device/examples/allocate-exclusive-mr-v100.md
+++ b/docs/userguide/iluvatar-device/examples/allocate-exclusive-mr-v100.md
@@ -32,4 +32,4 @@ spec:
         iluvatar.ai/MR-V100-vgpu: 2
 ```
 
-> **Note:** *When applying for exclusive use of a GPU, `iluvatar.ai/<card-type>-vgpu=1`, you need to set the values ​​of `iluvatar.ai/<card-type>.vCore` and `iluvatar.ai/<card-type>.vMem` to the maximum number of GPU resources. `iluvatar.ai/<card-type>-vgpu>1` no longer supports the vGPU function, so you don't need to fill in the core and memory values*
+> **Note:** *When applying for exclusive use of a GPU, `iluvatar.ai/<card-type>-vgpu=1`, you need to set the values of `iluvatar.ai/<card-type>.vCore` and `iluvatar.ai/<card-type>.vMem` to the maximum number of GPU resources. `iluvatar.ai/<card-type>-vgpu>1` no longer supports the vGPU function, so you don't need to fill in the core and memory values*


### PR DESCRIPTION
The two iluvatar exclusive-allocation example notes contained invisible `U+200B` (ZERO WIDTH SPACE) characters in the phrase "values ​​of". These don't render but they break in-file search and copy/paste. Removed them.