### PR TITLE
docs: fix 'an order or two of magnitude' phrasing in cherry-picks

### DIFF
--- a/docs/contributor/cherry-picks.md
+++ b/docs/contributor/cherry-picks.md
@@ -34,7 +34,7 @@ branches.
 
 Compared to the normal master branch's merge volume across time,
 the release branches see one or two orders of magnitude less PRs.
-This is because there is an order or two of magnitude higher scrutiny.
+This is because there is an order of magnitude or two higher scrutiny.
 Again, the emphasis is on critical bug fixes, e.g.,
 
 - Loss of data


### PR DESCRIPTION
Standard idiom is "an order of magnitude or two", not "an order or two of magnitude". The preceding sentence already uses the right form ("one or two orders of magnitude"), so this one was inconsistent with itself.