### PR TITLE
docs: fix wrong 'GCU-sharing' heading in awsneuron guide

### DIFF
--- a/docs/userguide/awsneuron-device/enable-awsneuron-managing.md
+++ b/docs/userguide/awsneuron-device/enable-awsneuron-managing.md
@@ -17,7 +17,7 @@ HAMi now integrates with [my-scheduler](https://awsdocs-neuron.readthedocs-hoste
 * Neuron-device-plugin
 * EC2 instance of type `Inf` or `Trn`
 
-## Enabling GCU-sharing Support
+## Enabling Neuron-sharing Support
 
 * Deploy neuron-device-plugin on EC2 neuron nodes according to the AWS document: [Neuro Device Plugin](https://awsdocs-neuron.readthedocs-hosted.com/en/latest/containers/kubernetes-getting-started.html#neuron-device-plugin)
 


### PR DESCRIPTION
The awsneuron guide had a section titled 'Enabling GCU-sharing Support', but GCU is the Enflame term, not AWS Neuron. Looks like a copy/paste leftover from the enflame guide. Renamed to 'Enabling Neuron-sharing Support' to match the device this file documents.