### PR TITLE
docs: fix typo in device-supported table header

### DIFF
--- a/docs/userguide/device-supported.md
+++ b/docs/userguide/device-supported.md
@@ -4,7 +4,7 @@ title: Device supported by HAMi
 
 The table below lists the devices supported by HAMi:
 
-| Type | Manufactor | Models | MemoryIsolation | CoreIsolation | MultiCard Support |
+| Type | Manufacturer | Models | MemoryIsolation | CoreIsolation | MultiCard Support |
 | ---- | ---------- | ------ | --------------- | ------------- | ----------------- |
 | GPU | NVIDIA | All | ✅ | ✅ | ✅ |
 | MLU | Cambricon | 370, 590 | ✅ | ✅ | ❌ |


### PR DESCRIPTION
The column header in the supported devices table uses "Manufactor" which is a misspelling of "Manufacturer".

- `docs/userguide/device-supported.md`: `Manufactor` → `Manufacturer`