### PR TITLE
docs: fix trailing comma in offline installation guide

### DIFF
--- a/docs/installation/offline-installation.md
+++ b/docs/installation/offline-installation.md
@@ -61,4 +61,4 @@ Run the following command:
 kubectl get pods -n kube-system
 ```
 
-If you can see both the 'device-plugin' and 'scheduler' running, then HAMi is installed successfully,
+If you can see both the 'device-plugin' and 'scheduler' running, then HAMi is installed successfully.


### PR DESCRIPTION
Fix a punctuation error at the end of the offline installation verification step.

- `docs/installation/offline-installation.md:64`: trailing comma → period