### PR TITLE
docs: fix grammar in Hygon DCU sharing guide

### DIFF
--- a/docs/userguide/hygon-device/enable-hygon-dcu-sharing.md
+++ b/docs/userguide/hygon-device/enable-hygon-dcu-sharing.md
@@ -57,7 +57,7 @@ You need to enable vDCU inside container in order to use it.
 source /opt/hygondriver/env.sh
 ```
 
-check if you have successfully enabled vDCU by using following command
+Check if you have successfully enabled vDCU by using the following command:
 
 ```bash
 hy-smi virtual -show-device-info


### PR DESCRIPTION
Fix a grammar error in the Hygon DCU sharing guide.

- `docs/userguide/hygon-device/enable-hygon-dcu-sharing.md:60`: missing article "the", missing capitalization, and missing colon
  - Before: `check if you have successfully enabled vDCU by using following command`
  - After: `Check if you have successfully enabled vDCU by using the following command:`