### PR TITLE
docs: fix grammar in governance page

### DIFF
--- a/docs/contributor/governance.md
+++ b/docs/contributor/governance.md
@@ -2,7 +2,7 @@
 title: Governance
 ---
 
-Heterogeneous AI Computing Virtualization Middleware (HAMi), formerly known as k8s-vGPU-scheduler, is an "all-in-one" tools designed to manage Heterogeneous AI Computing Devices in a k8s cluster
+Heterogeneous AI Computing Virtualization Middleware (HAMi), formerly known as k8s-vGPU-scheduler, is an "all-in-one" tool designed to manage Heterogeneous AI Computing Devices in a Kubernetes cluster.
 
 ## Values
 


### PR DESCRIPTION
- `tools` → `tool`
- `k8s` → `Kubernetes`
- added missing period