### PR TITLE
docs: remove redundant article in architecture page

### DIFF
--- a/docs/core-concepts/architecture.md
+++ b/docs/core-concepts/architecture.md
@@ -6,7 +6,7 @@ The overall architecture of HAMi is shown as below:
 
 ![Architecture](/img/docs/common/core-concepts/architect.jpg)
 
-The HAMi consists of the following components:
+HAMi consists of the following components:
 
 - HAMi MutatingWebhook
 - HAMi scheduler-extender


### PR DESCRIPTION
"The HAMi" -> "HAMi"