### PR TITLE
docs: fix duplicate page titles in nvidia device guides

### DIFF
--- a/docs/userguide/nvidia-device/examples/use-exclusive-card.md
+++ b/docs/userguide/nvidia-device/examples/use-exclusive-card.md
@@ -1,5 +1,5 @@
 ---
-title: Allocate device core to container
+title: Use Exclusive GPU
 linktitle: Use exclusive GPU
 ---
 

--- a/docs/userguide/nvidia-device/specify-device-uuid-to-use.md
+++ b/docs/userguide/nvidia-device/specify-device-uuid-to-use.md
@@ -1,5 +1,5 @@
 ---
-title: Assign to certain device type
+title: Assign to Certain Device UUID
 linktitle: Assign to certain device
 ---
 


### PR DESCRIPTION
Two pages had incorrect titles copied from other pages.