### PR TITLE
Fix typos in lifted.md

### DIFF
--- a/docs/contributor/lifted.md
+++ b/docs/contributor/lifted.md
@@ -3,7 +3,7 @@ title: How to manage lifted codes
 ---
 
 This document explains how lifted code is managed.
-A common user case for this task is developer lifting code from other repositories to `pkg/util/lifted` directory.
+A common use case for this task is developer lifting code from other repositories to `pkg/util/lifted` directory.
 
 ## Steps of lifting code
 
@@ -17,7 +17,7 @@ A common user case for this task is developer lifting code from other repositori
 Lifted comments shall be placed just before the lifted code (could be a func, type, var or const).
 Only empty lines and comments are allowed between lifted comments and lifted code.
 
-Lifted comments are composed by one or multi comment lines, each in the format of `+lifted:KEY[=VALUE]`. Value is optional for some keys.
+Lifted comments are composed by one or multiple comment lines, each in the format of `+lifted:KEY[=VALUE]`. Value is optional for some keys.
 
 Valid keys are as follow:
 


### PR DESCRIPTION
Fix English typos in docs/contributor/lifted.md

Signed-off-by: Assistant <fix@example.com>