### PR TITLE
fix: remove 'simply' filler word from docs

### DIFF
--- a/docs/installation/uninstall.md
+++ b/docs/installation/uninstall.md
@@ -88,7 +88,7 @@ All commands should return no results if uninstallation was successful.
 
 ## Reinstalling HAMi
 
-If you need to reinstall HAMi after uninstalling, simply follow the [installation guide](./online-installation.md) again. Your cluster will be ready for HAMi deployment without any residual configuration.
+To reinstall HAMi, follow the [installation guide](./online-installation.md).
 
 ## Troubleshooting
 

--- a/docs/userguide/nvidia-device/dynamic-mig-support.md
+++ b/docs/userguide/nvidia-device/dynamic-mig-support.md
@@ -137,7 +137,7 @@ Please note that HAMi will identify and use the first MIG template that matches 
 ## Running MIG jobs
 
 A MIG instance can now be requested by a container in the same way as `hami-core`,
-simply by specifying the `nvidia.com/gpu` and `nvidia.com/gpumem` resource types.
+by specifying the `nvidia.com/gpu` and `nvidia.com/gpumem` resource types.
 
 ```yaml
 apiVersion: v1

--- a/docs/userguide/vastai/examples/default-use.md
+++ b/docs/userguide/vastai/examples/default-use.md
@@ -3,7 +3,7 @@ title: Allocate Vastai Device
 ---
 
 This example shows how to request a single Vastai device in a plain Kubernetes Pod.
-The Pod simply runs a long-running container image provided by Vastaitech and asks for one `vastaitech.com/va` device through the `resources.limits` section.
+The Pod runs a long-running container image provided by Vastaitech and requests one `vastaitech.com/va` device through the `resources.limits` section.
 You can use this as a starting point and adjust the image and resource limits to fit your own workloads.
 
 ```yaml


### PR DESCRIPTION
'simply' was used as a filler word in three places. Removed it and rephrased where needed.