### PR TITLE
fix: correct spacing in faq.md note and parenthesis

### DIFF
--- a/docs/faq/faq.md
+++ b/docs/faq/faq.md
@@ -159,7 +159,7 @@ Device Plugins can only report a single resource type. GPU memory and compute in
 **Why does the Node Capacity show `volcano.sh/vgpu-number` and `volcano.sh/vgpu-memory` when using `volcano-vgpu-device-plugin`?**
 
 - volcano-vgpu-device-plugin creates **[three independent Device Plugin instances](https://github.com/Project-HAMi/volcano-vgpu-device-plugin/blob/2bf6dfe37f7b716f05d0d3210f89898087c06d99/pkg/plugin/vgpu/mig-strategy.go#L65-L85)**, each registering with kubelet for volcano.sh/vgpu-number, volcano.sh/vgpu-memory, and volcano.sh/vgpu-cores resources respectively. After kubelet receives the registration, it automatically writes the resources into Capacity and Allocatable.
-- **Note** : volcano.sh/vgpu-memory resource is subject to Kubernetes extended resources quantity limit (**maximum 32,767** ). For GPUs with large memory (e.g., A100 80GB), configure the `--gpu-memory-factor` parameter to avoid exceeding the limit.
+- **Note:** volcano.sh/vgpu-memory resource is subject to Kubernetes extended resources quantity limit (**maximum 32,767**). For GPUs with large memory (e.g., A100 80GB), configure the `--gpu-memory-factor` parameter to avoid exceeding the limit.
 
 ## Why don’t some domestic vendors require a runtime for installation?
 


### PR DESCRIPTION
Two small formatting issues on the same line in faq.md:

- `**Note** :` had a stray space before the colon
- `(**maximum 32,767** )` had a stray space before the closing parenthesis