### PR TITLE
fix: drop verbose phrasing in dynamic-mig-support.md

### DIFF
--- a/docs/userguide/nvidia-device/dynamic-mig-support.md
+++ b/docs/userguide/nvidia-device/dynamic-mig-support.md
@@ -131,7 +131,7 @@ nvidia:
 :::note
 Helm installations and updates will follow the configuration specified in this file, overriding the default Helm settings.
 
-Please note that HAMi will identify and use the first MIG template that matches the job, in the order defined in this configMap.
+HAMi uses the first MIG template that matches the job, in the order defined in this configMap.
 :::
 
 ## Running MIG jobs


### PR DESCRIPTION
'Please note that' is redundant inside a :::note block. Replaced with a direct sentence.