### PR TITLE
fix: drop verbose phrasing in docs

### DIFF
--- a/docs/developers/protocol.md
+++ b/docs/developers/protocol.md
@@ -6,7 +6,7 @@ title: Protocol design
 
 <img src="/img/docs/common/developers/protocol/protocol-register.png" width="600px" alt="HAMi device registration protocol diagram showing node annotation process" />
 
-HAMi needs to know the spec of each AI devices in the cluster in order to schedule properly. During device registration, device-plugin needs to keep patching the spec of each device into node annotations every 30 seconds, in the format of the following:
+HAMi needs to know the spec of each AI device in the cluster to schedule properly. During device registration, device-plugin needs to keep patching the spec of each device into node annotations every 30 seconds, in the format of the following:
 
 ```text
 hami.io/node-handshake-\{device-type\}: Reported_\{device_node_current_timestamp\}

--- a/docs/userguide/awsneuron-device/enable-awsneuron-managing.md
+++ b/docs/userguide/awsneuron-device/enable-awsneuron-managing.md
@@ -10,7 +10,7 @@ HAMi now integrates with [my-scheduler](https://awsdocs-neuron.readthedocs-hoste
 
 * **Neuron sharing**: HAMi now supports sharing on aws.amazon.com/neuron by allocating device cores(aws.amazon.com/neuroncore), each Neuron core equals to 1/2 neuron device.
 
-* **Topology awareness**: When allocating multiple aws-neuron devices in a container, HAMi will make sure these devices are connected with one another, so as to minimize the communication cost between neuron devices. For details about how these devices are connected, refer to [Container Device Allocation On Different Instance Types](https://awsdocs-neuron.readthedocs-hosted.com/en/latest/containers/kubernetes-getting-started.html#container-device-allocation-on-different-instance-types).
+* **Topology awareness**: When allocating multiple aws-neuron devices in a container, HAMi ensures these devices are connected to minimize the communication cost between neuron devices. For details about how these devices are connected, refer to [Container Device Allocation On Different Instance Types](https://awsdocs-neuron.readthedocs-hosted.com/en/latest/containers/kubernetes-getting-started.html#container-device-allocation-on-different-instance-types).
 
 ## Prerequisites
 

--- a/docs/userguide/hygon-device/enable-hygon-dcu-sharing.md
+++ b/docs/userguide/hygon-device/enable-hygon-dcu-sharing.md
@@ -51,7 +51,7 @@ spec:
 
 ## Enable vDCU inside container
 
-You need to enable vDCU inside container in order to use it.
+You need to enable vDCU inside the container to use it.
 
 ```bash
 source /opt/hygondriver/env.sh

--- a/docs/userguide/metax-device/metax-gpu/enable-metax-gpu-schedule.md
+++ b/docs/userguide/metax-device/metax-gpu/enable-metax-gpu-schedule.md
@@ -23,7 +23,7 @@ the GPU device plugin (gpu-device) handles fine-grained allocation based on the 
 
    ![Metax spread scheduling policy diagram showing resource allocation](/img/docs/common/userguide/metax-device/metax-gpu/metax-spread.jpg)
 
-3. When using `node-scheduler-policy=binpack`, assign GPU resources so as to minimize the damage to MetaXLink topology, as shown below:
+3. When using `node-scheduler-policy=binpack`, assign GPU resources to minimize the damage to MetaXLink topology, as shown below:
 
    ![Metax binpack scheduling policy diagram showing topology-aware allocation](/img/docs/common/userguide/metax-device/metax-gpu/metax-binpack.jpg)
 


### PR DESCRIPTION
Replaced wordy constructions with shorter equivalents across four files:

- `in order to` -> `to`
- `so as to` -> `to`
- `each AI devices` -> `each AI device` (subject-verb agreement)
- `make sure these devices are connected with one another, so as to minimize` -> `ensures these devices are connected to minimize`
