### PR TITLE
fix: correct 'equals to' grammar in device docs

### DIFF
--- a/docs/userguide/ascend-device/examples/allocate-310p.md
+++ b/docs/userguide/ascend-device/examples/allocate-310p.md
@@ -24,7 +24,7 @@ spec:
           huawei.com/Ascend310P-memory: 1024
 ```
 
-> **NOTICE:** *compute resource of Ascend310P is also limited with `huawei.com/Ascend310P-memory`, equals to the percentage of device memory allocated.*
+> **NOTICE:** *compute resource of Ascend310P is also limited with `huawei.com/Ascend310P-memory`, equal to the percentage of device memory allocated.*
 
 ## Select Device by UUID
 

--- a/docs/userguide/ascend-device/examples/allocate-910b.md
+++ b/docs/userguide/ascend-device/examples/allocate-910b.md
@@ -20,7 +20,7 @@ spec:
           huawei.com/Ascend910-memory: 2000 # requesting 2000m device memory
 ```
 
-> **NOTICE:** *compute resource of Ascend910B is also limited with `huawei.com/Ascend910-memory`, equals to the percentage of device memory allocated.*
+> **NOTICE:** *compute resource of Ascend910B is also limited with `huawei.com/Ascend910-memory`, equal to the percentage of device memory allocated.*
 
 ## Select Device by UUID
 

--- a/docs/userguide/awsneuron-device/enable-awsneuron-managing.md
+++ b/docs/userguide/awsneuron-device/enable-awsneuron-managing.md
@@ -8,7 +8,7 @@ AWS Neuron devices are specialized hardware accelerators designed by AWS to opti
 
 HAMi now integrates with [my-scheduler](https://awsdocs-neuron.readthedocs-hosted.com/en/latest/containers/kubernetes-getting-started.html#deploy-neuron-scheduler-extension), providing the following capabilities:
 
-* **Neuron sharing**: HAMi now supports sharing on aws.amazon.com/neuron by allocating device cores(aws.amazon.com/neuroncore), each Neuron core equals to 1/2 neuron device.
+* **Neuron sharing**: HAMi now supports sharing on aws.amazon.com/neuron by allocating device cores(aws.amazon.com/neuroncore), each Neuron core equals 1/2 of a neuron device.
 
 * **Topology awareness**: When allocating multiple aws-neuron devices in a container, HAMi will make sure these devices are connected with one another, so as to minimize the communication cost between neuron devices. For details about how these devices are connected, refer to [Container Device Allocation On Different Instance Types](https://awsdocs-neuron.readthedocs-hosted.com/en/latest/containers/kubernetes-getting-started.html#container-device-allocation-on-different-instance-types).
 
@@ -35,7 +35,7 @@ HAMi divides each AWS Neuron device into 2 units for resource allocation. You co
 
 * Each unit of `aws.amazon.com/neuroncore` represents 1/2 of neuron device
 * Don't assign `aws.amazon.com/neuron` like other devices, only assigning `aws.amazon.com/neuroncore` is enough
-* When the number of `aws.amazon.com/neuroncore`>=2, it equals to setting `aws.amazon.com/neuron=1/2 * neuronCoreNumber`
+* When the number of `aws.amazon.com/neuroncore`>=2, it is equivalent to setting `aws.amazon.com/neuron=1/2 * neuronCoreNumber`
 * The topology awareness scheduling is automatically enabled when tasks require multiple neuron devices.
 
 ## Running Neuron jobs

--- a/docs/userguide/hygon-device/specify-device-core-usage.md
+++ b/docs/userguide/hygon-device/specify-device-core-usage.md
@@ -4,7 +4,7 @@ linktitle: Allocate device core usage
 ---
 
 Allocate a percentage of device core resources by specify resource `hygon.com/dcucores`.
-Optional, each unit of `hygon.com/dcucores` equals to 1% device cores.
+Optional, each unit of `hygon.com/dcucores` equals 1% of device cores.
 
 ```yaml
       resources:

--- a/docs/userguide/hygon-device/specify-device-memory-usage.md
+++ b/docs/userguide/hygon-device/specify-device-memory-usage.md
@@ -3,7 +3,7 @@ title: Allocate device memory
 ---
 
 Allocate a percentage size of device memory by specify resources such as `hygon.com/dcumem`.
-Optional, Each unit of `hygon.com/dcumem` equals to 1M device memory.
+Optional, each unit of `hygon.com/dcumem` equals 1 MiB of device memory.
 
 ```yaml
       resources:

--- a/docs/userguide/mthreads-device/specify-device-core-usage.md
+++ b/docs/userguide/mthreads-device/specify-device-core-usage.md
@@ -4,7 +4,7 @@ linktitle: Allocate device core usage
 ---
 
 Allocate a part of device core resources by specify resource `mthreads.com/sgpu-core`.
-Optional, each unit of `mthreads.com/smlu-core` equals to 1/16 device cores.
+Optional, each unit of `mthreads.com/smlu-core` equals 1/16 of device cores.
 
 ```yaml
       resources:

--- a/docs/userguide/mthreads-device/specify-device-memory-usage.md
+++ b/docs/userguide/mthreads-device/specify-device-memory-usage.md
@@ -4,7 +4,7 @@ linktitle: Allocate device memory
 ---
 
 Allocate a percentage size of device memory by specify resources such as `mthreads.com/sgpu-memory`.
-Optional, Each unit of `mthreads.com/sgpu-memory` equals to 512M of device memory.
+Optional, each unit of `mthreads.com/sgpu-memory` equals 512 MiB of device memory.
 
 ```yaml
       resources:

--- a/docs/userguide/nvidia-device/specify-device-core-usage.md
+++ b/docs/userguide/nvidia-device/specify-device-core-usage.md
@@ -4,7 +4,7 @@ linktitle: Allocate device core usage
 ---
 
 Allocate a percentage of device core resources by specify resource `nvidia.com/gpucores`.
-Optional, each unit of `nvidia.com/gpucores` equals to 1% device cores.
+Optional, each unit of `nvidia.com/gpucores` equals 1% of device cores.
 
 ```yaml
       resources:

--- a/docs/userguide/nvidia-device/specify-device-memory-usage.md
+++ b/docs/userguide/nvidia-device/specify-device-memory-usage.md
@@ -4,7 +4,7 @@ linktitle: Allocate device memory
 ---
 
 Allocate a certain size of device memory by specify resources such as `nvidia.com/gpumem`.
-Optional, Each unit of `nvidia.com/gpumem` equals to 1M.
+Optional, each unit of `nvidia.com/gpumem` equals 1 MiB.
 
 ```yaml
       resources:
@@ -14,7 +14,7 @@ Optional, Each unit of `nvidia.com/gpumem` equals to 1M.
 ```
 
 Allocate a percentage of device memory by specify resource `nvidia.com/gpumem-percentage`.
-Optional, each unit of `nvidia.com/gpumem-percentage` equals to 1% percentage of device memory.
+Optional, each unit of `nvidia.com/gpumem-percentage` equals 1% of device memory.
 
 ```yaml
       resources:


### PR DESCRIPTION
'equals to' is not correct English - 'equals' already expresses equality on its own. Fixed across all affected device documentation files.

Also cleaned up a few related issues on the same lines:
- 'Each' capitalized mid-sentence in some files, lowercased
- '1% percentage' -> '1%' (percentage is redundant with %)
- '1M' -> '1 MiB' for clarity
- 'equals to setting' -> 'is equivalent to setting' in awsneuron