### PR TITLE
fix: correct 'by specify' to 'by specifying' in device docs

### DIFF
--- a/docs/userguide/hygon-device/specify-device-core-usage.md
+++ b/docs/userguide/hygon-device/specify-device-core-usage.md
@@ -3,7 +3,7 @@ title: Allocate device core to container
 linktitle: Allocate device core usage
 ---
 
-Allocate a percentage of device core resources by specify resource `hygon.com/dcucores`.
+Allocate a percentage of device core resources by specifying resource `hygon.com/dcucores`.
 Optional, each unit of `hygon.com/dcucores` equals 1% of device cores.
 
 ```yaml

--- a/docs/userguide/hygon-device/specify-device-memory-usage.md
+++ b/docs/userguide/hygon-device/specify-device-memory-usage.md
@@ -2,7 +2,7 @@
 title: Allocate device memory
 ---
 
-Allocate a percentage size of device memory by specify resources such as `hygon.com/dcumem`.
+Allocate a percentage size of device memory by specifying resources such as `hygon.com/dcumem`.
 Optional, each unit of `hygon.com/dcumem` equals 1 MiB of device memory.
 
 ```yaml

--- a/docs/userguide/mthreads-device/specify-device-core-usage.md
+++ b/docs/userguide/mthreads-device/specify-device-core-usage.md
@@ -3,7 +3,7 @@ title: Allocate device core to container
 linktitle: Allocate device core usage
 ---
 
-Allocate a part of device core resources by specify resource `mthreads.com/sgpu-core`.
+Allocate a part of device core resources by specifying resource `mthreads.com/sgpu-core`.
 Optional, each unit of `mthreads.com/smlu-core` equals 1/16 of device cores.
 
 ```yaml

--- a/docs/userguide/mthreads-device/specify-device-memory-usage.md
+++ b/docs/userguide/mthreads-device/specify-device-memory-usage.md
@@ -3,7 +3,7 @@ title: Allocate device memory to container
 linktitle: Allocate device memory
 ---
 
-Allocate a percentage size of device memory by specify resources such as `mthreads.com/sgpu-memory`.
+Allocate a percentage size of device memory by specifying resources such as `mthreads.com/sgpu-memory`.
 Optional, each unit of `mthreads.com/sgpu-memory` equals 512 MiB of device memory.
 
 ```yaml

--- a/docs/userguide/nvidia-device/specify-device-core-usage.md
+++ b/docs/userguide/nvidia-device/specify-device-core-usage.md
@@ -3,7 +3,7 @@ title: Allocate device core to container
 linktitle: Allocate device core usage
 ---
 
-Allocate a percentage of device core resources by specify resource `nvidia.com/gpucores`.
+Allocate a percentage of device core resources by specifying resource `nvidia.com/gpucores`.
 Optional, each unit of `nvidia.com/gpucores` equals 1% of device cores.
 
 ```yaml

--- a/docs/userguide/nvidia-device/specify-device-memory-usage.md
+++ b/docs/userguide/nvidia-device/specify-device-memory-usage.md
@@ -3,7 +3,7 @@ title: Allocate device memory to container
 linktitle: Allocate device memory
 ---
 
-Allocate a certain size of device memory by specify resources such as `nvidia.com/gpumem`.
+Allocate a certain size of device memory by specifying resources such as `nvidia.com/gpumem`.
 Optional, each unit of `nvidia.com/gpumem` equals 1 MiB.
 
 ```yaml
@@ -13,7 +13,7 @@ Optional, each unit of `nvidia.com/gpumem` equals 1 MiB.
           nvidia.com/gpumem: 3000 # Each GPU contains 3000m device memory
 ```
 
-Allocate a percentage of device memory by specify resource `nvidia.com/gpumem-percentage`.
+Allocate a percentage of device memory by specifying resource `nvidia.com/gpumem-percentage`.
 Optional, each unit of `nvidia.com/gpumem-percentage` equals 1% of device memory.
 
 ```yaml


### PR DESCRIPTION
'by specify' is grammatically incorrect - a gerund is required after a preposition. Fixed in all affected files.