### PR TITLE
fix: remove buzzwords from docs prose

### DIFF
--- a/docs/faq/faq.md
+++ b/docs/faq/faq.md
@@ -69,7 +69,7 @@ In summary, while HAMi's own priority serves a different, device-specific purpos
 **Currently Supported**:
 
 - **Volcano**: Can be integrated with Volcano by using the [`volcano-vgpu-device-plugin`](https://github.com/Project-HAMi/volcano-vgpu-device-plugin) under the HAMi project for GPU resource scheduling and management.
-- **Koordinator**: HAMi can also be integrated with Koordinator to provide end-to-end GPU sharing solutions. By deploying HAMi-core on nodes and configuring the appropriate labels and resource requests in Pods, Koordinator can leverage HAMi’s GPU isolation capabilities, allowing multiple Pods to share the same GPU and significantly improve GPU resource utilization.
+- **Koordinator**: HAMi can also be integrated with Koordinator to provide end-to-end GPU sharing solutions. By deploying HAMi-core on nodes and configuring the appropriate labels and resource requests in Pods, Koordinator uses HAMi’s GPU isolation capabilities, allowing multiple Pods to share the same GPU and improve GPU resource utilization.
 
   For detailed configuration and usage instructions, refer to the Koordinator documentation:
   [Device Scheduling - GPU Share With HAMi](https://koordinator.sh/docs/user-manuals/device-scheduling-gpu-share-with-hami/)

--- a/docs/key-features/device-sharing.md
+++ b/docs/key-features/device-sharing.md
@@ -2,7 +2,7 @@
 title: Device sharing
 ---
 
-HAMi offers robust device-sharing capabilities, enabling multiple tasks to share the same GPU, MLU, or NPU device,
+HAMi lets multiple tasks share the same GPU, MLU, or NPU device,
 maximizing the utilization of heterogeneous AI computing resources.
 
 ## Device Sharing {#device-sharing}

--- a/docs/userguide/hami-webui-user-guide.md
+++ b/docs/userguide/hami-webui-user-guide.md
@@ -4,7 +4,7 @@ linktitle: HAMi WebUI
 ---
 
 [HAMi WebUI](https://github.com/Project-HAMi/HAMi-WebUI) is the visual interface provided by HAMi for unified monitoring and analysis of GPU resources and workloads.
-With a unified visualization, users can intuitively view the cluster running status, including GPU usage, node information, and workload status, so that they can more efficiently understand resource distribution and the overall system state.
+It provides a unified view of cluster GPU usage, node information, and workload status.
 
 ## Core capabilities
 


### PR DESCRIPTION
Replaced vague or inflated words with direct alternatives:

- 'intuitively view ... so that they can more efficiently understand' -> plain description of what the UI shows
- 'offers robust device-sharing capabilities' -> 'lets multiple tasks share'
- 'leverage HAMi's GPU isolation capabilities' -> 'uses HAMi's GPU isolation capabilities'
- also dropped 'significantly' (unsupported claim) from the same sentence

## Files changed

- `docs/userguide/hami-webui-user-guide.md`
- `docs/key-features/device-sharing.md`
- `docs/faq/faq.md`