### PR TITLE
fix: weak modal and missing article in awsneuron and gpu-virtualization docs

### DIFF
--- a/docs/core-concepts/gpu-virtualization.md
+++ b/docs/core-concepts/gpu-virtualization.md
@@ -53,7 +53,7 @@ HAMi currently remains based on Device Plugin, but the official team has launche
 
 ## HAMi Virtual GPU Scheduling Principles
 
-HAMi leverages three Kubernetes extension mechanisms simultaneously (MutatingWebhook, Scheduler Extender, and Device Plugin), each with its own responsibility:
+HAMi uses three Kubernetes extension mechanisms simultaneously (MutatingWebhook, Scheduler Extender, and Device Plugin), each with its own responsibility:
 
 - **Fine-grained resource declaration**: Users can declare `nvidia.com/gpumem` (VRAM in MiB) and `nvidia.com/gpucores` (compute %)
 - **Resource-aware scheduling**: The Scheduler-Extender reads GPU specifications from Node Annotations, performing Filter and Bind based on remaining VRAM/compute capacity

--- a/docs/userguide/awsneuron-device/enable-awsneuron-managing.md
+++ b/docs/userguide/awsneuron-device/enable-awsneuron-managing.md
@@ -29,7 +29,7 @@ helm install hami hami-charts/hami -n kube-system
 
 ## Device Granularity
 
-HAMi divides each AWS Neuron device into 2 units for resource allocation. You could allocate half of neuron device.
+HAMi divides each AWS Neuron device into 2 units for resource allocation. You can allocate half of a neuron device.
 
 ### Neuron Allocation
 

--- a/docs/userguide/awsneuron-device/examples/allocate-neuron-core.md
+++ b/docs/userguide/awsneuron-device/examples/allocate-neuron-core.md
@@ -2,7 +2,7 @@
 title: Allocate AWS Neuron core
 ---
 
-To allocate 1/2 neuron device, you could allocate a neuroncore, like the example below:
+To allocate 1/2 of a neuron device, use `aws.amazon.com/neuroncore`, as shown below:
 
 ```yaml
 apiVersion: v1

--- a/docs/userguide/awsneuron-device/examples/allocate-neuron-device.md
+++ b/docs/userguide/awsneuron-device/examples/allocate-neuron-device.md
@@ -2,7 +2,7 @@
 title: Allocate AWS Neuron core
 ---
 
-To allocate one or more aws neuron devices exclusively, you could allocate using `aws.amazon.com/neuron`
+To allocate one or more AWS Neuron devices exclusively, use `aws.amazon.com/neuron`
 
 ```yaml
 apiVersion: v1


### PR DESCRIPTION
Small language fixes across four files:

- 'you could allocate' -> 'you can allocate' (could implies uncertainty; can is correct here)
- 'half of neuron device' -> 'half of a neuron device' (missing article)
- 'aws neuron' -> 'AWS Neuron' (proper capitalization)
- 'you could allocate a neuroncore, like the example below' -> cleaner phrasing
- 'HAMi leverages' -> 'HAMi uses' (leverages is unnecessarily formal)