### PR TITLE
fix: correct grammar and spelling issues in docs

### DIFF
--- a/docs/contributor/github-workflow.md
+++ b/docs/contributor/github-workflow.md
@@ -25,15 +25,15 @@ Define a local working directory:
 # If your GOPATH has multiple paths, pick
 # just one and use it instead of $GOPATH here.
 # You must follow exactly this pattern,
-# neither `$GOPATH/src/github.com/${your GitHub profile name/`
+# neither `$GOPATH/src/github.com/${your github profile name/`
 # nor any other pattern will work.
 export working_dir="$(go env GOPATH)/src/github.com/Project-HAMi"
 ```
 
-Set `user` to match your GitHub profile name:
+Set `user` to match your github profile name:
 
 ```sh
-export user={your GitHub profile name}
+export user={your github profile name}
 ```
 
 Both `$working_dir` and `$user` are mentioned in the figure above.

--- a/docs/contributor/github-workflow.md
+++ b/docs/contributor/github-workflow.md
@@ -25,15 +25,15 @@ Define a local working directory:
 # If your GOPATH has multiple paths, pick
 # just one and use it instead of $GOPATH here.
 # You must follow exactly this pattern,
-# neither `$GOPATH/src/github.com/${your github profile name/`
+# neither `$GOPATH/src/github.com/${your GitHub profile name/`
 # nor any other pattern will work.
 export working_dir="$(go env GOPATH)/src/github.com/Project-HAMi"
 ```
 
-Set `user` to match your github profile name:
+Set `user` to match your GitHub profile name:
 
 ```sh
-export user={your github profile name}
+export user={your GitHub profile name}
 ```
 
 Both `$working_dir` and `$user` are mentioned in the figure above.

--- a/docs/contributor/ladder.md
+++ b/docs/contributor/ladder.md
@@ -35,7 +35,7 @@ Description: A Contributor contributes directly to the project and adds value to
   * Report and sometimes resolve issues
   * Occasionally submit PRs
   * Contribute to the documentation
-  * Show up at meetings, takes notes
+  * Show up at meetings, take notes
   * Answer questions from other community members
   * Submit feedback on issues and PRs
   * Test releases and patches and submit reviews

--- a/docs/developers/scheduling.md
+++ b/docs/developers/scheduling.md
@@ -4,12 +4,11 @@ title: Scheduler Policy
 
 ## Summary
 
-Current in a cluster with many GPU nodes, nodes are not `binpack` or `spread` when making scheduling decisions, nor are GPU cards `binpack` or `spread` when using vGPU.
+Currently in a cluster with many GPU nodes, nodes are not `binpack` or `spread` when making scheduling decisions, nor are GPU cards `binpack` or `spread` when using vGPU.
 
 ## Proposal
 
-We add a `node-scheduler-policy` and `gpu-scheduler-policy` to config, then scheduler to use this policy can impl node `binpack` or `spread` or GPU `binpack` or `spread`. and
-use can set Pod annotation to change this default policy, use `hami.io/node-scheduler-policy` and `hami.io/gpu-scheduler-policy` to overlay scheduler config.
+We add a `node-scheduler-policy` and `gpu-scheduler-policy` to config, then the scheduler can use this policy to implement node `binpack` or `spread` or GPU `binpack` or `spread`. Users can also set Pod annotation to change this default policy, use `hami.io/node-scheduler-policy` and `hami.io/gpu-scheduler-policy` to overlay scheduler config.
 
 ### User Stories
 


### PR DESCRIPTION
## Description

Fix grammar and spelling issues in documentation:

### Changes:
- **scheduling.md**: Fix 'Current in a cluster' -> 'Currently in a cluster', fix grammar in scheduler description, fix 'and use can set Pod annotation' -> 'Users can set Pod annotation'
- **github-workflow.md**: Fix 'github' -> 'GitHub' (proper noun)
- **ladder.md**: Fix 'takes notes' -> 'take notes'

## Related Issue

N/A

## Test

N/A

Signed-off-by: Haifeng Yao <haifeng.yao@daocloud.io>