### PR TITLE
fix: add missing article 'a' before 'pull request' in contributing guide

### DIFF
--- a/docs/contributor/contributing.md
+++ b/docs/contributor/contributing.md
@@ -74,7 +74,7 @@ This is a rough outline of what a contributor's workflow looks like:
 Pull requests are often called simply "PR".
 HAMi generally follows the standard [github pull request](https://help.github.com/articles/about-pull-requests/) process.
 To submit a proposed change, please develop the code/fix and add new test cases.
-After that, run these local verifications before submitting pull request to predict the pass or
+After that, run these local verifications before submitting a pull request to predict the pass or
 fail of continuous integration.
 
 - Run and pass `make verify`


### PR DESCRIPTION
Missing indefinite article before 'pull request' in the local verification step.