### PR TITLE
fix: correct article 'an YAML' to 'a YAML' in cambricon guide

### DIFF
--- a/docs/userguide/cambricon-device/enable-cambricon-mlu-sharing.md
+++ b/docs/userguide/cambricon-device/enable-cambricon-mlu-sharing.md
@@ -59,7 +59,7 @@ To request shared MLU resources in a container, use the following resource types
 * `cambricon.com/mlu.smlu.vmemory`
 * `cambricon.com/mlu.smlu.vcore`
 
-Here is an YAML example:
+Here is a YAML example:
 
 ```yaml
 apiVersion: apps/v1


### PR DESCRIPTION
YAML is pronounced with a consonant 'y' sound, so the indefinite article should be 'a', not 'an'.