### PR TITLE
fix: rewrite broken sentence in cherry-picks unsupported releases section

### DIFF
--- a/docs/contributor/cherry-picks.md
+++ b/docs/contributor/cherry-picks.md
@@ -116,6 +116,6 @@ cherry pick.
 
 ## Cherry Picks for Unsupported Releases
 
-The community supports & patches releases need to be discussed.
+Community support and patches for these releases need to be discussed.
 
 [cherry-pick-script]: https://github.com/Project-HAMi/HAMi/blob/master/hack/cherry_pick_pull.sh


### PR DESCRIPTION
The original sentence 'The community supports \& patches releases need to be discussed.' is ungrammatical - two clauses were merged incorrectly. Rewritten for clarity.