### PR TITLE
fix: rewrite awkward boundary phrasing in device enable guides

### DIFF
--- a/docs/userguide/hygon-device/enable-hygon-dcu-sharing.md
+++ b/docs/userguide/hygon-device/enable-hygon-dcu-sharing.md
@@ -8,7 +8,7 @@ title: Enable Hygon DCU sharing
 
 ***DCU sharing***: Each task can allocate a portion of DCU instead of a whole DCU card, thus DCU can be shared among multiple tasks.
 
-***Device Memory Control***: DCUs can be allocated with certain device memory size on certain type(i.e., Z100) and have made it that it does not exceed the boundary.
+***Device Memory Control***: DCUs can be allocated with a specific device memory size on certain types (e.g., Z100), with hard limits enforced to prevent exceeding the allocation.
 
 ***Device compute core limitation***: DCUs can be allocated with certain percentage of device core(i.e., hygon.com/dcucores:60 indicates this container uses 60% compute cores of this device)
 

--- a/docs/userguide/iluvatar-device/enable-iluvatar-gpu-sharing.md
+++ b/docs/userguide/iluvatar-device/enable-iluvatar-gpu-sharing.md
@@ -8,9 +8,9 @@ title: Enable Iluvatar GPU Sharing
 
 ***GPU sharing***: Each task can allocate a portion of GPU instead of a whole GPU card, thus GPU can be shared among multiple tasks.
 
-***Device Memory Control***: GPUs can be allocated with certain device memory size and have made it that it does not exceed the boundary.
+***Device Memory Control***: GPUs can be allocated with a specific device memory size, with hard limits enforced to prevent exceeding the allocation.
 
-***Device Core Control***: GPUs can be allocated with limited compute cores and have made it that it does not exceed the boundary.
+***Device Core Control***: GPUs can be allocated with limited compute cores, with hard limits enforced to prevent exceeding the allocation.
 
 ***Device UUID Selection***: You can specify which GPU devices to use or exclude using annotations.
 

--- a/docs/userguide/mthreads-device/enable-mthreads-gpu-sharing.md
+++ b/docs/userguide/mthreads-device/enable-mthreads-gpu-sharing.md
@@ -8,9 +8,9 @@ title: Enable Mthreads GPU sharing
 
 ***GPU sharing***: Each task can allocate a portion of GPU instead of a whole GPU card, thus GPU can be shared among multiple tasks.
 
-***Device Memory Control***: GPUs can be allocated with certain device memory size on certain type(i.e., MTT S4000) and have made it that it does not exceed the boundary.
+***Device Memory Control***: GPUs can be allocated with a specific device memory size on certain types (e.g., MTT S4000), with hard limits enforced to prevent exceeding the allocation.
 
-***Device Core Control***: GPUs can be allocated with limited compute cores on certain type(i.e., MTT S4000) and have made it that it does not exceed the boundary.
+***Device Core Control***: GPUs can be allocated with limited compute cores on certain types (e.g., MTT S4000), with hard limits enforced to prevent exceeding the allocation.
 
 ## Important Notes
 


### PR DESCRIPTION
The phrase 'have made it that it does not exceed the boundary' is unnatural English. Replaced with 'with hard limits enforced to prevent exceeding the allocation' across iluvatar, hygon, and mthreads enable guides.