### PR TITLE
fix: add proper spacing in Chinese documentation

### DIFF
--- a/i18n/zh/docusaurus-plugin-content-docs/current/installation/prerequisites.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/current/installation/prerequisites.md
@@ -3,7 +3,7 @@ title: 前提条件
 translated: true
 ---
 
-在安装HAMi之前，确保你的环境中已正确安装以下工具和依赖项：
+在安装 HAMi 之前，确保你的环境中已正确安装以下工具和依赖项：
 
 - NVIDIA 驱动版本 >= 440
 - nvidia-docker 版本 > 2.0


### PR DESCRIPTION
## Description

修复中文文档中的空格问题：

### Changes:
- **prerequisites.md**: 修复 '在安装HAMi之前' -> '在安装 HAMi 之前' (中文和英文之间需要空格)

## Related Issue

N/A

## Test

N/A

Signed-off-by: Haifeng Yao <haifeng.yao@daocloud.io>