### PR TITLE
fix: replace first-person 'We now support' with 'HAMi now supports' in device guides

### DIFF
--- a/docs/userguide/enflame-device/enable-enflame-gcu-sharing.md
+++ b/docs/userguide/enflame-device/enable-enflame-gcu-sharing.md
@@ -5,7 +5,7 @@ title: Enable Enflame GPU Sharing
 
 ## Introduction
 
-**We now support sharing on enflame.com/gcu(i.e., S60) by implementing most device-sharing features as nvidia-GPU**, including:
+**HAMi now supports sharing on enflame.com/gcu(i.e., S60) by implementing most device-sharing features as nvidia-GPU**, including:
 
 ***GCU sharing***: Each task can allocate a portion of GCU instead of a whole GCU card, thus GCU can be shared among multiple tasks.
 

--- a/docs/userguide/hygon-device/enable-hygon-dcu-sharing.md
+++ b/docs/userguide/hygon-device/enable-hygon-dcu-sharing.md
@@ -4,7 +4,7 @@ title: Enable Hygon DCU sharing
 
 ## Introduction
 
-**We now support hygon.com/dcu by implementing most device-sharing features as nvidia-GPU**, including:
+**HAMi now supports hygon.com/dcu by implementing most device-sharing features as nvidia-GPU**, including:
 
 ***DCU sharing***: Each task can allocate a portion of DCU instead of a whole DCU card, thus DCU can be shared among multiple tasks.
 

--- a/docs/userguide/iluvatar-device/enable-iluvatar-gpu-sharing.md
+++ b/docs/userguide/iluvatar-device/enable-iluvatar-gpu-sharing.md
@@ -4,7 +4,7 @@ title: Enable Iluvatar GPU Sharing
 
 ## Introduction
 
-**We now support iluvatar.ai/gpu(i.e., MR-V100, BI-V150, BI-V100) by implementing most device-sharing features as nvidia-GPU**, including:
+**HAMi now supports iluvatar.ai/gpu(i.e., MR-V100, BI-V150, BI-V100) by implementing most device-sharing features as nvidia-GPU**, including:
 
 ***GPU sharing***: Each task can allocate a portion of GPU instead of a whole GPU card, thus GPU can be shared among multiple tasks.
 

--- a/docs/userguide/mthreads-device/enable-mthreads-gpu-sharing.md
+++ b/docs/userguide/mthreads-device/enable-mthreads-gpu-sharing.md
@@ -4,7 +4,7 @@ title: Enable Mthreads GPU sharing
 
 ## Introduction
 
-**We now support mthreads.com/vgpu by implementing most device-sharing features as nvidia-GPU**, including:
+**HAMi now supports mthreads.com/vgpu by implementing most device-sharing features as nvidia-GPU**, including:
 
 ***GPU sharing***: Each task can allocate a portion of GPU instead of a whole GPU card, thus GPU can be shared among multiple tasks.
 

--- a/docs/userguide/vastai/enable-vastai-sharing.md
+++ b/docs/userguide/vastai/enable-vastai-sharing.md
@@ -4,7 +4,7 @@ title: Enable Vastai Sharing
 
 ## Introduction
 
-We now support sharing `vastaitech.com/va` (Vastaitech) devices and provide the following capabilities:
+HAMi now supports sharing `vastaitech.com/va` (Vastaitech) devices and provide the following capabilities:
 
 ***Supports both Full-Card mode and Die mode***: Only Full-Card mode and Die mode are supported currently.
 


### PR DESCRIPTION
Replace first-person 'We now support ...' with 'HAMi now supports ...' in five device enable guides:

- iluvatar-device/enable-iluvatar-gpu-sharing.md
- enflame-device/enable-enflame-gcu-sharing.md
- hygon-device/enable-hygon-dcu-sharing.md
- mthreads-device/enable-mthreads-gpu-sharing.md
- vastai/enable-vastai-sharing.md