### PR TITLE
fix: remove filler words 'Let's', 'Just', 'So,' from technical docs

### DIFF
--- a/docs/developers/dynamic-mig.md
+++ b/docs/developers/dynamic-mig.md
@@ -105,7 +105,7 @@ data:
 ## Examples
 
 Dynamic mig is compatible with hami tasks, as the example below:
-Just set `nvidia.com/gpu` and `nvidia.com/gpumem`.
+Set `nvidia.com/gpu` and `nvidia.com/gpumem`.
 
 ```yaml
 apiVersion: v1

--- a/docs/developers/scheduling.md
+++ b/docs/developers/scheduling.md
@@ -105,7 +105,7 @@ Node1 score: ((1+3)/4) * 10= 10
 Node2 score: ((1+2)/4) * 10= 7.5
 ```
 
-So, in `Binpack` policy we can select `Node1`.
+In `Binpack` policy, `Node1` is selected.
 
 #### Spread
 
@@ -127,7 +127,7 @@ Node1 score: ((1+3)/4) * 10= 10
 Node2 score: ((1+2)/4) * 10= 7.5
 ```
 
-So, in `Spread` policy we can select `Node2`.
+In `Spread` policy, `Node2` is selected.
 
 ### GPU-scheduler-policy
 
@@ -153,7 +153,7 @@ GPU1 Score: ((20+10)/100 + (1000+2000)/8000)) * 10 = 6.75
 GPU2 Score: ((20+70)/100 + (1000+6000)/8000)) * 10 = 17.75
 ```
 
-So, in `Binpack` policy we can select `GPU2`.
+In `Binpack` policy, `GPU2` is selected.
 
 #### Spread
 
@@ -175,4 +175,4 @@ GPU1 Score: ((20+10)/100 + (1000+2000)/8000)) * 10 = 6.75
 GPU2 Score: ((20+70)/100 + (1000+6000)/8000)) * 10 = 17.75
 ```
 
-So, in `Spread` policy we can select `GPU1`.
+In `Spread` policy, `GPU1` is selected.

--- a/docs/get-started/verify-hami.md
+++ b/docs/get-started/verify-hami.md
@@ -112,7 +112,7 @@ Expected: Both `hami-scheduler` and `vgpu-device-plugin` pods should be in the `
 
 ## Step 3: Launch and Verify a vGPU Task
 
-Let's prove HAMi is enforcing fractional resource limits (vGPU).
+This step verifies HAMi is enforcing fractional resource limits (vGPU).
 
 ### 1. Submit a vGPU demo task
 


### PR DESCRIPTION
Remove filler words from three docs:

- verify-hami.md:115 - `Let's prove` -> `This step verifies`
- dynamic-mig.md:108 - `Just set` -> `Set`
- scheduling.md:108,130,156,178 - `So, in ... policy we can select` -> `In ... policy, ... is selected` (4 occurrences)