### PR TITLE
fix: add missing space before '(i.e.,' in device guide notes

### DIFF
--- a/docs/userguide/awsneuron-device/enable-awsneuron-managing.md
+++ b/docs/userguide/awsneuron-device/enable-awsneuron-managing.md
@@ -129,6 +129,6 @@ Look for annotations containing device information in the node status.
 
 ## Notes
 
-1. AWS Neuron sharing takes effect only for containers that apply for one AWS Neuron device(i.e., `aws.amazon.com/neuroncore`=1).
+1. AWS Neuron sharing takes effect only for containers that apply for one AWS Neuron device (i.e., `aws.amazon.com/neuroncore`=1).
 
 2. `neuron-ls` inside container shows the total device memory, which is NOT a bug. Device memory will be properly limited when tasks are running.

--- a/docs/userguide/enflame-device/enable-enflame-gcu-sharing.md
+++ b/docs/userguide/enflame-device/enable-enflame-gcu-sharing.md
@@ -118,7 +118,7 @@ Look for annotations containing device information in the node status.
 
 ## Notes
 
-1. GCUshare takes effect only for containers that apply for one GCU(i.e., enflame.com/vgcu=1 ).
+1. GCUshare takes effect only for containers that apply for one GCU (i.e., enflame.com/vgcu=1 ).
 
 2. Multiple GCU allocation in one container is not supported yet
 

--- a/docs/userguide/hygon-device/enable-hygon-dcu-sharing.md
+++ b/docs/userguide/hygon-device/enable-hygon-dcu-sharing.md
@@ -10,7 +10,7 @@ title: Enable Hygon DCU sharing
 
 ***Device Memory Control***: DCUs can be allocated with certain device memory size on certain type(i.e., Z100) and have made it that it does not exceed the boundary.
 
-***Device compute core limitation***: DCUs can be allocated with certain percentage of device core(i.e., hygon.com/dcucores:60 indicates this container uses 60% compute cores of this device)
+***Device compute core limitation***: DCUs can be allocated with certain percentage of device core (i.e., hygon.com/dcucores:60 indicates this container uses 60% compute cores of this device)
 
 ***DCU Type Specification***: You can specify which type of DCU to use or to avoid for a certain task, by setting "hygon.com/use-dcutype" or "hygon.com/nouse-dcutype" annotations.
 

--- a/docs/userguide/iluvatar-device/enable-iluvatar-gpu-sharing.md
+++ b/docs/userguide/iluvatar-device/enable-iluvatar-gpu-sharing.md
@@ -160,7 +160,7 @@ Look for annotations containing device information in the node status.
       source /root/.bashrc
 ```
 
-1. Virtualization takes effect only for containers that apply for one GPU(i.e., iluvatar.ai/vgpu=1). When requesting multiple GPUs, the system will automatically set the core resources based on the number of GPUs requested.
+1. Virtualization takes effect only for containers that apply for one GPU (i.e., iluvatar.ai/vgpu=1). When requesting multiple GPUs, the system will automatically set the core resources based on the number of GPUs requested.
 
 2. The `iluvatar.ai/<card-type>.vMem` resource is only effective when `iluvatar.ai/<card-type>-vgpu=1`.
 


### PR DESCRIPTION
Add missing space before `(i.e.,` in four device guides:

- iluvatar-device/enable-iluvatar-gpu-sharing.md:163 - `GPU(i.e.,` -> `GPU (i.e.,`
- enflame-device/enable-enflame-gcu-sharing.md:121 - `GCU(i.e.,` -> `GCU (i.e.,`
- hygon-device/enable-hygon-dcu-sharing.md:13 - `core(i.e.,` -> `core (i.e.,`
- awsneuron-device/enable-awsneuron-managing.md:132 - `device(i.e.,` -> `device (i.e.,`