### PR TITLE
fix: add missing title frontmatter to adopters.md

### DIFF
--- a/docs/contributor/adopters.md
+++ b/docs/contributor/adopters.md
@@ -1,3 +1,7 @@
+---
+title: HAMi Adopters
+---
+
 # HAMi Adopters
 
 So you and your organisation are using HAMi? That's great. We would love to hear from you! 💖


### PR DESCRIPTION
docs/contributor/adopters.md had no frontmatter. Added `title:` so Docusaurus generates correct page metadata.