### PR TITLE
blog: replace em-dash with hyphen in v2.8.0 release title

### DIFF
--- a/blog/hami-v2-8-0-release/index.md
+++ b/blog/hami-v2-8-0-release/index.md
@@ -1,5 +1,5 @@
 ---
-title: "HAMi v2.8.0 Release: Full DRA Support and High Availability Scheduling—Towards Standardized GPU Resource Management"
+title: "HAMi v2.8.0 Release: Full DRA Support and High Availability Scheduling - Towards Standardized GPU Resource Management"
 date: "2026-01-20"
 description: "HAMi v2.8.0 is now officially released. This milestone release delivers architectural completeness, enhanced scheduling reliability, and ecosystem alignment, featuring DRA support, Leader election mechanism, CDI mode support, and more."
 tags: ["Release", "GPU", "Kubernetes", "DRA"]


### PR DESCRIPTION
Replace em-dash with a plain hyphen in the post title frontmatter.