### PR TITLE
docs: replace em-dashes with hyphens across versioned MIG and topology docs

### DIFF
--- a/versioned_docs/version-v2.5.1/userguide/nvidia-device/dynamic-mig-support.md
+++ b/versioned_docs/version-v2.5.1/userguide/nvidia-device/dynamic-mig-support.md
@@ -173,7 +173,7 @@ nodeGPUMigInstance{deviceidx="1",deviceuuid="GPU-30f90f49-43ab-0a78-bf5c-93ed41e
 
 :::note
 
-1. No action is required on MIG nodes — everything is managed by `mig-parted` in `hami-device-plugin`.
+1. No action is required on MIG nodes - everything is managed by `mig-parted` in `hami-device-plugin`.
 2. NVIDIA devices older than the Ampere architecture do not support MIG mode.
 3. MIG resources (e.g., `nvidia.com/mig-1g.10gb`) won’t be visible on the node.
    HAMi uses a unified resource name for both MIG and hami-core nodes.

--- a/versioned_docs/version-v2.6.0/userguide/nvidia-device/dynamic-mig-support.md
+++ b/versioned_docs/version-v2.6.0/userguide/nvidia-device/dynamic-mig-support.md
@@ -173,7 +173,7 @@ nodeGPUMigInstance{deviceidx="1",deviceuuid="GPU-30f90f49-43ab-0a78-bf5c-93ed41e
 
 :::note
 
-1. No action is required on MIG nodes — everything is managed by `mig-parted` in `hami-device-plugin`.
+1. No action is required on MIG nodes - everything is managed by `mig-parted` in `hami-device-plugin`.
 2. NVIDIA devices older than the Ampere architecture do not support MIG mode.
 3. MIG resources (e.g., `nvidia.com/mig-1g.10gb`) won’t be visible on the node.
    HAMi uses a unified resource name for both MIG and hami-core nodes.

--- a/versioned_docs/version-v2.7.0/developers/kunlunxin-topology.md
+++ b/versioned_docs/version-v2.7.0/developers/kunlunxin-topology.md
@@ -43,7 +43,7 @@ The table below shows examples of XPU occupation and proper MTF values:
 | 00000001       | 3   | A 4-XPU, 2-XPU, and 1-XPU task can fill it |
 | 00010001       | 4   | Two 2-XPU tasks and two 1-XPU tasks can fill it |
 
-The node score is derived from the **delta(MTF)** — the change in MTF value after allocation.
+The node score is derived from the **delta(MTF)** - the change in MTF value after allocation.
 A smaller delta(MTF) indicates a better fit and results in a higher score.
 The scoring logic is shown below:
 

--- a/versioned_docs/version-v2.7.0/userguide/nvidia-device/dynamic-mig-support.md
+++ b/versioned_docs/version-v2.7.0/userguide/nvidia-device/dynamic-mig-support.md
@@ -173,7 +173,7 @@ nodeGPUMigInstance{deviceidx="1",deviceuuid="GPU-30f90f49-43ab-0a78-bf5c-93ed41e
 
 :::note
 
-1. No action is required on MIG nodes — everything is managed by `mig-parted` in `hami-device-plugin`.
+1. No action is required on MIG nodes - everything is managed by `mig-parted` in `hami-device-plugin`.
 2. NVIDIA devices older than the Ampere architecture do not support MIG mode.
 3. MIG resources (e.g., `nvidia.com/mig-1g.10gb`) won’t be visible on the node.
    HAMi uses a unified resource name for both MIG and hami-core nodes.

--- a/versioned_docs/version-v2.8.0/developers/kunlunxin-topology.md
+++ b/versioned_docs/version-v2.8.0/developers/kunlunxin-topology.md
@@ -43,7 +43,7 @@ The table below shows examples of XPU occupation and proper MTF values:
 | 00000001       | 3   | A 4-XPU, 2-XPU, and 1-XPU task can fill it |
 | 00010001       | 4   | Two 2-XPU tasks and two 1-XPU tasks can fill it |
 
-The node score is derived from the **delta(MTF)** — the change in MTF value after allocation.
+The node score is derived from the **delta(MTF)** - the change in MTF value after allocation.
 A smaller delta(MTF) indicates a better fit and results in a higher score.
 The scoring logic is shown below:
 

--- a/versioned_docs/version-v2.8.0/userguide/nvidia-device/dynamic-mig-support.md
+++ b/versioned_docs/version-v2.8.0/userguide/nvidia-device/dynamic-mig-support.md
@@ -173,7 +173,7 @@ nodeGPUMigInstance{deviceidx="1",deviceuuid="GPU-30f90f49-43ab-0a78-bf5c-93ed41e
 
 :::note
 
-1. No action is required on MIG nodes — everything is managed by `mig-parted` in `hami-device-plugin`.
+1. No action is required on MIG nodes - everything is managed by `mig-parted` in `hami-device-plugin`.
 2. NVIDIA devices older than the Ampere architecture do not support MIG mode.
 3. MIG resources (e.g., `nvidia.com/mig-1g.10gb`) won’t be visible on the node.
    HAMi uses a unified resource name for both MIG and hami-core nodes.


### PR DESCRIPTION
Replace em-dashes with plain hyphens in dynamic-mig-support.md (v2.5.1, v2.6.0, v2.7.0, v2.8.0) and kunlunxin-topology.md (v2.7.0, v2.8.0).