### PR TITLE
docs: replace triple-asterisk formatting in vastai, hygon, mthreads, kunlunxin guides

### DIFF
--- a/docs/userguide/hygon-device/enable-hygon-dcu-sharing.md
+++ b/docs/userguide/hygon-device/enable-hygon-dcu-sharing.md
@@ -6,13 +6,13 @@ title: Enable Hygon DCU sharing
 
 **HAMi now supports hygon.com/dcu by implementing most device-sharing features as nvidia-GPU**, including:
 
-***DCU sharing***: Each task can allocate a portion of DCU instead of a whole DCU card, thus DCU can be shared among multiple tasks.
+**DCU sharing**: Each task can allocate a portion of DCU instead of a whole DCU card, thus DCU can be shared among multiple tasks.
 
-***Device Memory Control***: DCUs can be allocated with a specific device memory size on certain types (e.g., Z100), with hard limits enforced to prevent exceeding the allocation.
+**Device Memory Control**: DCUs can be allocated with a specific device memory size on certain types (e.g., Z100), with hard limits enforced to prevent exceeding the allocation.
 
-***Device compute core limitation***: DCUs can be allocated with certain percentage of device core (i.e., hygon.com/dcucores:60 indicates this container uses 60% compute cores of this device)
+**Device compute core limitation**: DCUs can be allocated with certain percentage of device core (i.e., hygon.com/dcucores:60 indicates this container uses 60% compute cores of this device)
 
-***DCU Type Specification***: You can specify which type of DCU to use or to avoid for a certain task, by setting "hygon.com/use-dcutype" or "hygon.com/nouse-dcutype" annotations.
+**DCU Type Specification**: You can specify which type of DCU to use or to avoid for a certain task, by setting "hygon.com/use-dcutype" or "hygon.com/nouse-dcutype" annotations.
 
 ## Prerequisites
 

--- a/docs/userguide/kunlunxin-device/enable-kunlunxin-vxpu.md
+++ b/docs/userguide/kunlunxin-device/enable-kunlunxin-vxpu.md
@@ -6,11 +6,11 @@ title: Enable Kunlunxin VXPU
 
 This component supports multiplexing Kunlunxin XPU devices (P800-OAM) and provides the following vGPU-like multiplexing capabilities, Special thanks for rise-union and kunlunxin for contributing:
 
-***XPU Sharing***: Each task can occupy only a portion of the device, allowing multiple tasks to share a single XPU
+**XPU Sharing**: Each task can occupy only a portion of the device, allowing multiple tasks to share a single XPU
 
-***Memory Allocation Limits***: You can now allocate XPUs using memory values (e.g., 24576M), and the component ensures that tasks do not exceed the allocated memory limit
+**Memory Allocation Limits**: You can now allocate XPUs using memory values (e.g., 24576M), and the component ensures that tasks do not exceed the allocated memory limit
 
-***Device UUID Selection***: You can specify to use or exclude specific XPU devices through annotations
+**Device UUID Selection**: You can specify to use or exclude specific XPU devices through annotations
 
 ## Prerequisites
 

--- a/docs/userguide/mthreads-device/enable-mthreads-gpu-sharing.md
+++ b/docs/userguide/mthreads-device/enable-mthreads-gpu-sharing.md
@@ -6,11 +6,11 @@ title: Enable Mthreads GPU sharing
 
 **HAMi now supports mthreads.com/vgpu by implementing most device-sharing features as nvidia-GPU**, including:
 
-***GPU sharing***: Each task can allocate a portion of GPU instead of a whole GPU card, thus GPU can be shared among multiple tasks.
+**GPU sharing**: Each task can allocate a portion of GPU instead of a whole GPU card, thus GPU can be shared among multiple tasks.
 
-***Device Memory Control***: GPUs can be allocated with a specific device memory size on certain types (e.g., MTT S4000), with hard limits enforced to prevent exceeding the allocation.
+**Device Memory Control**: GPUs can be allocated with a specific device memory size on certain types (e.g., MTT S4000), with hard limits enforced to prevent exceeding the allocation.
 
-***Device Core Control***: GPUs can be allocated with limited compute cores on certain types (e.g., MTT S4000), with hard limits enforced to prevent exceeding the allocation.
+**Device Core Control**: GPUs can be allocated with limited compute cores on certain types (e.g., MTT S4000), with hard limits enforced to prevent exceeding the allocation.
 
 ## Important Notes
 

--- a/docs/userguide/vastai/enable-vastai-sharing.md
+++ b/docs/userguide/vastai/enable-vastai-sharing.md
@@ -6,11 +6,11 @@ title: Enable Vastai Sharing
 
 HAMi now supports sharing `vastaitech.com/va` (Vastaitech) devices and provide the following capabilities:
 
-***Supports both Full-Card mode and Die mode***: Only Full-Card mode and Die mode are supported currently.
+**Supports both Full-Card mode and Die mode**: Only Full-Card mode and Die mode are supported currently.
 
-***die-mode topology awareness***: When multiple resources are requested in die mode, the scheduler will try to allocate them on the same AIC whenever possible.
+**Die-mode topology awareness**: When multiple resources are requested in die mode, the scheduler will try to allocate them on the same AIC whenever possible.
 
-***Device UUID selection***: You can specify or exclude particular devices through annotations.
+**Device UUID selection**: You can specify or exclude particular devices through annotations.
 
 ## Using Vastai Devices
 


### PR DESCRIPTION
Replaces `***text***` (bold-italic) with `**text**` (bold) in the Introduction sections of four device guides: