### PR TITLE
docs: remove first-person language from contributor and developer guides

### DIFF
--- a/docs/contributor/adopters.md
+++ b/docs/contributor/adopters.md
@@ -4,13 +4,13 @@ title: HAMi Adopters
 
 # HAMi Adopters
 
-So you and your organisation are using HAMi? That's great. We would love to hear from you.
+So you and your organisation are using HAMi? That's great. Reach out and let the community know.
 
 ## Adding yourself
 
 [See the list of HAMi adopters](https://github.com/Project-HAMi/website/blob/master/src/pages/adopters.mdx) for organisations who have adopted the HAMi project in production.
 
-Add an entry for your company and upon merging it will automatically be added to our website.
+Add an entry for your company and upon merging it will automatically be added to the website.
 
 To add your organisation follow these steps:
 
@@ -29,4 +29,4 @@ To add your organisation follow these steps:
 6. Push the commit with `git push origin main`.
 7. Open a Pull Request to [Project-HAMi/website](https://github.com/Project-HAMi/website) and a preview build will turn up.
 
-Thanks a lot for being part of our community - we very much appreciate it!
+Thanks for being part of the community!

--- a/docs/contributor/contribute-docs.md
+++ b/docs/contributor/contribute-docs.md
@@ -13,21 +13,21 @@ the `Project-HAMi/website` repository.
 - Docs need to be translated into multiple languages for readers from different regions.
   The community now supports both Chinese and English.
   English is the official language of documentation.
-- For our docs we use markdown. If you are unfamiliar with Markdown,
+- Docs are written in Markdown. If you are unfamiliar with Markdown,
   please see [https://guides.github.com/features/mastering-markdown/](https://guides.github.com/features/mastering-markdown/) or
   [https://www.markdownguide.org/](https://www.markdownguide.org/) if you are looking for something more substantial.
-- We get some additions through [Docusaurus 2](https://docusaurus.io/), a modern static website generator.
+- The site uses [Docusaurus 2](https://docusaurus.io/), a modern static website generator.
 
 ## Setup
 
-You can set up your local environment by cloning our website repository.
+Set up your local environment by cloning the website repository.
 
 ```shell
 git clone https://github.com/Project-HAMi/website.git
 cd website
 ```
 
-Our website is organized like below:
+The website is organized like this:
 
 ```text
 website
@@ -106,7 +106,7 @@ You can easily route to other places by adding any of the following links:
   You can use relative paths to index the corresponding files.
 - Link to pictures or other resources.
 If your article contains images, prefer storing them in `/static/img/docs/` and linking
-  with absolute paths. We use language-aware folders:
+  with absolute paths. Language-aware folders:
   - `/static/img/docs/common/` for shared images
   - `/static/img/docs/en/` for English-only images
   - `/static/img/docs/zh/` for Chinese-only images
@@ -125,8 +125,8 @@ Creating a sidebar is useful to:
 - Display a sidebar on each of those documents
 - Provide paginated navigation, with next/previous button
 
-For our docs, you can know how our documents are organized from
-[https://github.com/Project-HAMi/website/blob/main/sidebars.js](https://github.com/Project-HAMi/website/blob/main/sidebars.js).
+The document organization is defined in
+[sidebars.js](https://github.com/Project-HAMi/website/blob/main/sidebars.js).
 
 ```js
 module.exports = {
@@ -175,8 +175,8 @@ If you're not sure where your docs are located, you can ask community members in
 
 There are two situations about the Chinese version of the document:
 
-- You want to translate our existing English docs to Chinese. In this case,
-  you need to modify the corresponding file content from
+- You want to translate existing English docs to Chinese. In this case,
+  modify the corresponding file in
   [https://github.com/Project-HAMi/website/tree/main/i18n/zh/docusaurus-plugin-content-docs/current](https://github.com/Project-HAMi/website/tree/main/i18n/zh/docusaurus-plugin-content-docs/current).
   The organization of this directory is exactly the same as the outer layer.
   `current.json` holds translations for the documentation directory.

--- a/docs/contributor/contributing.md
+++ b/docs/contributor/contributing.md
@@ -20,15 +20,15 @@ HAMi is a community project driven by its community which strives to promote a h
 
 ## Your First Contribution
 
-We will help you to contribute in different areas like filing issues, developing features, fixing critical bugs and
-getting your work reviewed and merged.
+Help is available for contributing in different areas: filing issues, developing features, fixing critical bugs and
+getting work reviewed and merged.
 
 If you have questions about the development process,
 feel free to [file an issue](https://github.com/Project-HAMi/HAMi/issues/new/choose).
 
 ## Find something to work on
 
-We are always in need of help, be it fixing documentation, reporting bugs or writing some code.
+The project always needs help, be it fixing documentation, reporting bugs or writing code.
 Look at places where you feel best coding practices aren't followed, code refactoring is needed or tests are missing.
 Here is how you get started.
 
@@ -40,7 +40,7 @@ For example, [Project-HAMi/HAMi](https://github.com/Project-HAMi/HAMi) has
 [help wanted](https://github.com/Project-HAMi/HAMi/issues?q=is%3Aopen+is%3Aissue+label%3A%22help+wanted%22) and
 [good first issue](https://github.com/Project-HAMi/HAMi/issues?q=is%3Aopen+is%3Aissue+label%3A%22good+first+issue%22)
 labels for issues that should not need deep knowledge of the system.
-We can help new contributors who wish to work on such issues.
+New contributors working on such issues can reach out for help.
 
 Another good way to contribute is to find a documentation improvement, such as a missing/broken link.
 Please see [Contributor Workflow](#contributor-workflow) below for the workflow.
@@ -51,7 +51,7 @@ When you are willing to take on an issue, reply on the issue. The maintainer wil
 
 ### File an Issue
 
-While we encourage everyone to contribute code, it is also appreciated when someone reports an issue.
+Code contributions are welcome, but reporting an issue is equally appreciated.
 Issues should be filed under the appropriate HAMi sub-repository.
 
 *Example:* a HAMi issue should be opened to [Project-HAMi/HAMi](https://github.com/Project-HAMi/HAMi/issues).

--- a/docs/contributor/ladder.md
+++ b/docs/contributor/ladder.md
@@ -6,7 +6,7 @@ This document describes different ways to get involved and level up within the p
 
 ## Overview
 
-Hello! We are excited that you want to learn more about our project contributor ladder! This contributor ladder outlines the different contributor roles within the project, along with the responsibilities and privileges that come with them. Community members generally start at the first levels of the "ladder" and advance up it as their involvement in the project grows. Our project members are happy to help you advance along the contributor ladder.
+This contributor ladder outlines the different contributor roles within the project, along with the responsibilities and privileges that come with them. Community members generally start at the first levels of the "ladder" and advance up it as their involvement in the project grows. Project members are happy to help you advance along the contributor ladder.
 
 Each of the contributor roles below is organized into lists of three types of things. "Responsibilities" are things that a contributor is expected to do. "Requirements" are qualifications a person needs to meet to be in that role, and "Privileges" are things contributors on that level are entitled to.
 
@@ -46,7 +46,7 @@ Description: A Contributor contributes directly to the project and adds value to
   * Invitations to contributor events
   * Eligible to become an Organization Member
 
-A very special thanks to the [long list of people](https://github.com/Project-HAMi/HAMi/blob/master/AUTHORS.md) who have contributed to and helped maintain the project. We wouldn't be where we are today without your contributions. Thank you!
+A very special thanks to the [long list of people](https://github.com/Project-HAMi/HAMi/blob/master/AUTHORS.md) who have contributed to and helped maintain the project. The project wouldn't be where it is today without your contributions. Thank you!
 
 As long as you contribute to HAMi, your name will be added to the [AUTHORS.md file](https://github.com/Project-HAMi/HAMi/blob/master/AUTHORS.md). If you don't find your name, please contact us to add it.
 
@@ -141,7 +141,7 @@ The current list of maintainers can be found in the [MAINTAINERS](https://github
 
 New maintainers are added by consensus among the current group of maintainers. This can be done via a private discussion via Slack or email. A majority of maintainers should support the addition of the new person, and no single maintainer should object to adding the new maintainer.
 
-When adding a new maintainer, we should file a PR to [HAMi](https://github.com/Project-HAMi/HAMi) and update [MAINTAINERS](https://github.com/Project-HAMi/HAMi/blob/master/MAINTAINERS.md). Once this PR is merged, you will become a maintainer of HAMi.
+When adding a new maintainer, file a PR to [HAMi](https://github.com/Project-HAMi/HAMi) and update [MAINTAINERS](https://github.com/Project-HAMi/HAMi/blob/master/MAINTAINERS.md). Once this PR is merged, the new person becomes a maintainer of HAMi.
 
 ### Removing Maintainers
 

--- a/docs/developers/dynamic-mig.md
+++ b/docs/developers/dynamic-mig.md
@@ -9,8 +9,8 @@ This feature will not be implemented without the help of @sailorvii.
 
 ## Introduction
 
-The NVIDIA GPU built-in sharing method includes: time-slice, MPS and MIG. The context switch for time slice sharing would waste some time, so we chose the MPS and MIG. The GPU MIG profile is variable, the user could acquire the MIG device in the profile definition, but current implementation only defines the dedicated profile before the user requirement. That limits the usage of MIG. We want to develop an automatic slice plugin and create the slice when the user requires it.
-For the scheduling method, node-level binpack and spread will be supported. Referring to the binpack plugin, we consider the CPU, Mem, GPU memory and other user-defined resource.
+The NVIDIA GPU built-in sharing method includes: time-slice, MPS and MIG. The context switch for time slice sharing would waste some time, so MPS and MIG are preferred. The GPU MIG profile is variable, the user could acquire the MIG device in the profile definition, but current implementation only defines the dedicated profile before the user requirement. That limits the usage of MIG. The goal is to develop an automatic slice plugin and create the slice when the user requires it.
+For the scheduling method, node-level binpack and spread will be supported. Referring to the binpack plugin, the scheduler considers CPU, Mem, GPU memory and other user-defined resources.
 HAMi is done by using [hami-core](https://github.com/Project-HAMi/HAMi-core), which is a cuda-hacking library. But mig is also widely used across the world. A unified API for dynamic-mig and hami-core is needed.
 
 ## Targets


### PR DESCRIPTION
Replaces first-person pronouns (we, our, us) with neutral language across contributor and developer documentation.