### PR TITLE
docs: remove first-person language from nvidia example, prerequisites, and contribute-docs

### DIFF
--- a/docs/contributor/contribute-docs.md
+++ b/docs/contributor/contribute-docs.md
@@ -77,7 +77,7 @@ Contributors mainly contribute documentation to the current version.
 
 It's important for your article to specify metadata concerning an article at the top of the Markdown file, in a section called **Front Matter**.
 
-For now, let's take a look at a quick example which should explain the most relevant entries in **Front Matter**:
+Here is a quick example covering the most relevant **Front Matter** entries:
 
 ```yaml
 ---

--- a/docs/installation/prerequisites.md
+++ b/docs/installation/prerequisites.md
@@ -63,7 +63,7 @@ sudo systemctl daemon-reload && sudo systemctl restart containerd
 
 ### Label your nodes
 
-Label your GPU nodes for scheduling with HAMi by adding the label "gpu=on". Without this label, the nodes cannot be managed by our scheduler.
+Label your GPU nodes for scheduling with HAMi by adding the label "gpu=on". Without this label, the nodes cannot be managed by the HAMi scheduler.
 
 ```bash
 kubectl label nodes {nodeid} gpu=on

--- a/docs/userguide/nvidia-device/examples/specify-card-type-to-use.md
+++ b/docs/userguide/nvidia-device/examples/specify-card-type-to-use.md
@@ -11,7 +11,7 @@ metadata:
   name: gpu-pod
   annotations:
     nvidia.com/use-gputype: "A100,V100"
-    #In this example, we want to run this job on A100 or V100
+    #In this example, the job runs on A100 or V100
 spec:
   containers:
     - name: ubuntu-container
@@ -22,4 +22,4 @@ spec:
           nvidia.com/gpu: 2 # requesting 2 vGPUs
 ```
 
-> **NOTICE:** *You can assign this task to multiple GPU types, use comma to separate,In this example, we want to run this job on A100 or V100*
+> **NOTICE:** *You can assign this task to multiple GPU types, use comma to separate. In this example, the job runs on A100 or V100.*


### PR DESCRIPTION
Removes remaining first-person language from three English docs files.

No content changes, phrasing only.