### PR TITLE
docs: replace first-person language in governance and cherry-picks

### DIFF
--- a/docs/contributor/cherry-picks.md
+++ b/docs/contributor/cherry-picks.md
@@ -62,7 +62,7 @@ your case by supplementing your PR with e.g.,
 - Key stakeholder reviewers/approvers attesting to their confidence in the
   change being a required backport
 
-It is critical that our full community is actively engaged on enhancements in
+It is critical that the full community is actively engaged on enhancements in
 the project. If a released feature was not enabled on a particular provider's
 platform, this is a community miss that needs to be resolved in the `master`
 branch for subsequent releases. Such enabling will not be backported to the

--- a/docs/contributor/governance.md
+++ b/docs/contributor/governance.md
@@ -15,7 +15,7 @@ The HAMi and its leadership embrace the following values:
 * Fairness: All stakeholders have the opportunity to provide feedback and submit
   contributions, which will be considered on their merits.
 
-* Community over Product or Company: Sustaining and growing our community takes
+* Community over Product or Company: Sustaining and growing the community takes
   priority over shipping code or sponsors' organizational goals. Each
   contributor participates in the project as an individual.
 


### PR DESCRIPTION
Replace `our` with `the` in two contributor docs.