### PR TITLE
blog: remove emoji from meetup beijing and shanghai 2025 posts

### DIFF
--- a/blog/hami-meetup-beijing-2025/index.md
+++ b/blog/hami-meetup-beijing-2025/index.md
@@ -15,4 +15,4 @@ This article about the HAMi Meetup Beijing event is **only available in Chinese*
 
 ---
 
-👉 Use the language selector in the top right corner to switch to **简体中文** (Simplified Chinese).
+Use the language selector in the top right corner to switch to **简体中文** (Simplified Chinese).

--- a/blog/hami-meetup-shanghai-2025/index.md
+++ b/blog/hami-meetup-shanghai-2025/index.md
@@ -15,4 +15,4 @@ This article about the HAMi Meetup Shanghai event is **only available in Chinese
 
 ---
 
-👉 Use the language selector in the top right corner to switch to **简体中文** (Simplified Chinese).
+Use the language selector in the top right corner to switch to **简体中文** (Simplified Chinese).


### PR DESCRIPTION
Remove the 👉 emoji from the language-switch note in the Beijing and Shanghai meetup 2025 blog posts.