### PR TITLE
docs: remove filler phrase 'Note that' from ladder and protocol docs

### DIFF
--- a/docs/contributor/ladder.md
+++ b/docs/contributor/ladder.md
@@ -127,7 +127,7 @@ The current list of maintainers can be found in the [MAINTAINERS](https://github
 
 ### An active maintainer should
 
-* Actively participate in reviewing pull requests and incoming issues. Note that there are no hard rules on what is “active enough” and this is left up to the judgement of the current group of maintainers.
+* Actively participate in reviewing pull requests and incoming issues. There are no hard rules on what is “active enough” - this is left up to the judgement of the current group of maintainers.
 
 * Actively participate in discussions about design and the future of the project.
 

--- a/docs/developers/protocol.md
+++ b/docs/developers/protocol.md
@@ -31,7 +31,7 @@ hami.io/node-nvidia-register: GPU-00552014-5c87-89ac-b1a6-7b53aa24b0ec,10,32768,
 
 In this example, this node has two different AI devices, 2 Nvidia-V100 GPUs, and 2 Cambircon 370-X4 MLUs
 
-Note that a device node may become unavailable due to hardware or network failure, if a node hasn't registered in last 5 minutes, scheduler will mark that node as 'unavailable'.
+A device node may become unavailable due to hardware or network failure. If a node hasn't registered in the last 5 minutes, the scheduler marks it as 'unavailable'.
 
 Since system clock on scheduler node and 'device' node may not align properly, scheduler node will patch the following device node annotations every 30s
 


### PR DESCRIPTION
Remove the "Note that" opener from two places.

Also split the run-on sentence in protocol.md into two cleaner sentences.