### PR TITLE
docs: remove first-person language from developer and user guides

### DIFF
--- a/docs/contributor/contribute-docs.md
+++ b/docs/contributor/contribute-docs.md
@@ -9,7 +9,7 @@ the `Project-HAMi/website` repository.
 ## Prerequisites
 
 - Docs, like codes, are also categorized and stored by version.
-  1.3 is the first version we have archived.
+  1.3 is the first archived version.
 - Docs need to be translated into multiple languages for readers from different regions.
   The community now supports both Chinese and English.
   English is the official language of documentation.
@@ -88,7 +88,7 @@ title: A doc with tags
 ```
 
 The top section between two lines of --- is the Front Matter section.
-Here we define a couple of entries which tell Docusaurus how to handle the article:
+The following entries tell Docusaurus how to handle the article:
 
 - Title is the equivalent of the `<h1>` in an HTML document or `# <title>` in a Markdown article.
 - Each document has a unique ID. By default, a document ID is the name of the document
@@ -202,6 +202,6 @@ If the previewed page is not what you expected, please check your docs again.
 
 ### Versioning
 
-For the newly supplemented documents of each version, we will synchronize to the latest version
+Newly supplemented documents for each version are synchronized to the latest version
 on the release date of each version, and the documents of the old version will not be modified.
-For errata found in the documentation, we will fix it with every release.
+Errata found in the documentation are fixed with every release.

--- a/docs/developers/kunlunxin-topology.md
+++ b/docs/developers/kunlunxin-topology.md
@@ -30,7 +30,7 @@ The selection process is shown below:
 ## Score
 
 In the scoring phase, all filtered nodes are evaluated and scored to select the optimal one
-for scheduling. We introduce a metric called **MTF** (Minimized Tasks to Fill),
+for scheduling. The scoring uses a metric called **MTF** (Minimized Tasks to Fill),
 which quantifies how well a node can accommodate future tasks after allocation.
 
 The table below shows examples of XPU occupation and proper MTF values:

--- a/docs/developers/scheduling.md
+++ b/docs/developers/scheduling.md
@@ -8,8 +8,8 @@ Current in a cluster with many GPU nodes, nodes are not `binpack` or `spread` wh
 
 ## Proposal
 
-We add a `node-scheduler-policy` and `gpu-scheduler-policy` to config, then scheduler to use this policy can impl node `binpack` or `spread` or GPU `binpack` or `spread`. and
-use can set Pod annotation to change this default policy, use `hami.io/node-scheduler-policy` and `hami.io/gpu-scheduler-policy` to overlay scheduler config.
+A `node-scheduler-policy` and `gpu-scheduler-policy` can be set in config. The scheduler uses this policy to implement node `binpack` or `spread` or GPU `binpack` or `spread`.
+Pod annotations `hami.io/node-scheduler-policy` and `hami.io/gpu-scheduler-policy` can override the default scheduler config.
 
 ### User Stories
 

--- a/docs/userguide/enflame-device/enable-enflame-gcu-sharing.md
+++ b/docs/userguide/enflame-device/enable-enflame-gcu-sharing.md
@@ -17,7 +17,7 @@ title: Enable Enflame GPU Sharing
 
 ## Prerequisites
 
-* Enflame gcushare-device-plugin >= 2.1.6 (please consult your device provider, gcushare has two components: gcushare-scheduler-plugin and gcushare-device-plugin, we only need gcushare-device-plugin here )
+* Enflame gcushare-device-plugin >= 2.1.6 (please consult your device provider, gcushare has two components: gcushare-scheduler-plugin and gcushare-device-plugin; only gcushare-device-plugin is needed here)
 * driver version >= 1.2.3.14
 * kubernetes >= 1.24
 * enflame-container-toolkit >=2.0.50


### PR DESCRIPTION
Remove remaining first-person pronouns (we, our) from developer and user guide documentation.