### PR TITLE
docs: remove filler words and first-person from blog posts

### DIFF
--- a/blog/2024-12-31-post/index.md
+++ b/blog/2024-12-31-post/index.md
@@ -824,7 +824,7 @@ metadata:
       GeForce RTX 3090,0,true:
 ```
 
-The `device` is called again here, which we will look into later. For now, let's continue to examine who calls `RegisterFromNodeAnnotations`.
+The `device` is called again here and examined later. Next, looking at who calls `RegisterFromNodeAnnotations`.
 
 `cmd/scheduler/main.go:70`
 
@@ -870,7 +870,7 @@ func InitDevicesWithConfig(config *Config) {
 }
 ```
 
-Since NVIDIA is used here, we mainly need to focus on `InitNvidiaDevice`.
+Since NVIDIA is used here, the focus is on `InitNvidiaDevice`.
 
 `pkg/device/devices.go:42`
 

--- a/blog/hami-webui-v1-1-0-release/index.md
+++ b/blog/hami-webui-v1-1-0-release/index.md
@@ -123,7 +123,7 @@ For detailed instructions, refer to the [HAMi WebUI Installation Guide](/docs/in
 
 ## Documentation
 
-The HAMi community has prepared comprehensive documentation:
+The HAMi community has prepared documentation:
 
 - **[WebUI User Guide](/docs/userguide/hami-webui-user-guide)** — Learn how to use the cluster overview, node management, GPU management, and workload tracking features.
 - **[WebUI Developer Guide](/docs/developers/hami-webui-development-guide)** — Understand the architecture, repository structure, local development setup, and coding conventions for contributing to WebUI.


### PR DESCRIPTION
Two small prose fixes in blog posts.