### PR TITLE
docs: remove marketing word and first-person from versioned docs and contributing guide

### DIFF
--- a/docs/contributor/contributing.md
+++ b/docs/contributor/contributing.md
@@ -6,7 +6,7 @@ Welcome to HAMi!
 
 ## Code of Conduct
 
-Please make sure to read and observe our [Code of Conduct](https://github.com/cncf/foundation/blob/main/code-of-conduct.md)
+Please make sure to read and observe the [Code of Conduct](https://github.com/cncf/foundation/blob/main/code-of-conduct.md)
 
 ## Community Expectations
 

--- a/versioned_docs/version-v1.3.0/contributor/ladder.md
+++ b/versioned_docs/version-v1.3.0/contributor/ladder.md
@@ -140,7 +140,7 @@ The current list of maintainers can be found in the [MAINTAINERS](https://github
 
 New maintainers are added by consensus among the current group of maintainers. This can be done via a private discussion via Slack or email. A majority of maintainers should support the addition of the new person, and no single maintainer should object to adding the new maintainer.
 
-When adding a new maintainer, we should file a PR to [HAMi](https://github.com/Project-HAMi/HAMi) and update [MAINTAINERS](https://github.com/Project-HAMi/HAMi/blob/master/MAINTAINERS.md). Once this PR is merged, you will become a maintainer of HAMi.
+When adding a new maintainer, file a PR to [HAMi](https://github.com/Project-HAMi/HAMi) and update [MAINTAINERS](https://github.com/Project-HAMi/HAMi/blob/master/MAINTAINERS.md). Once this PR is merged, you will become a maintainer of HAMi.
 
 ## Removing Maintainers
 

--- a/versioned_docs/version-v2.4.1/contributor/ladder.md
+++ b/versioned_docs/version-v2.4.1/contributor/ladder.md
@@ -140,7 +140,7 @@ The current list of maintainers can be found in the [MAINTAINERS](https://github
 
 New maintainers are added by consensus among the current group of maintainers. This can be done via a private discussion via Slack or email. A majority of maintainers should support the addition of the new person, and no single maintainer should object to adding the new maintainer.
 
-When adding a new maintainer, we should file a PR to [HAMi](https://github.com/Project-HAMi/HAMi) and update [MAINTAINERS](https://github.com/Project-HAMi/HAMi/blob/master/MAINTAINERS.md). Once this PR is merged, you will become a maintainer of HAMi.
+When adding a new maintainer, file a PR to [HAMi](https://github.com/Project-HAMi/HAMi) and update [MAINTAINERS](https://github.com/Project-HAMi/HAMi/blob/master/MAINTAINERS.md). Once this PR is merged, you will become a maintainer of HAMi.
 
 ## Removing Maintainers
 

--- a/versioned_docs/version-v2.5.0/contributor/ladder.md
+++ b/versioned_docs/version-v2.5.0/contributor/ladder.md
@@ -140,7 +140,7 @@ The current list of maintainers can be found in the [MAINTAINERS](https://github
 
 New maintainers are added by consensus among the current group of maintainers. This can be done via a private discussion via Slack or email. A majority of maintainers should support the addition of the new person, and no single maintainer should object to adding the new maintainer.
 
-When adding a new maintainer, we should file a PR to [HAMi](https://github.com/Project-HAMi/HAMi) and update [MAINTAINERS](https://github.com/Project-HAMi/HAMi/blob/master/MAINTAINERS.md). Once this PR is merged, you will become a maintainer of HAMi.
+When adding a new maintainer, file a PR to [HAMi](https://github.com/Project-HAMi/HAMi) and update [MAINTAINERS](https://github.com/Project-HAMi/HAMi/blob/master/MAINTAINERS.md). Once this PR is merged, you will become a maintainer of HAMi.
 
 ## Removing Maintainers
 

--- a/versioned_docs/version-v2.5.1/contributor/ladder.md
+++ b/versioned_docs/version-v2.5.1/contributor/ladder.md
@@ -140,7 +140,7 @@ The current list of maintainers can be found in the [MAINTAINERS](https://github
 
 New maintainers are added by consensus among the current group of maintainers. This can be done via a private discussion via Slack or email. A majority of maintainers should support the addition of the new person, and no single maintainer should object to adding the new maintainer.
 
-When adding a new maintainer, we should file a PR to [HAMi](https://github.com/Project-HAMi/HAMi) and update [MAINTAINERS](https://github.com/Project-HAMi/HAMi/blob/master/MAINTAINERS.md). Once this PR is merged, you will become a maintainer of HAMi.
+When adding a new maintainer, file a PR to [HAMi](https://github.com/Project-HAMi/HAMi) and update [MAINTAINERS](https://github.com/Project-HAMi/HAMi/blob/master/MAINTAINERS.md). Once this PR is merged, you will become a maintainer of HAMi.
 
 ## Removing Maintainers
 

--- a/versioned_docs/version-v2.5.1/key-features/device-sharing.md
+++ b/versioned_docs/version-v2.5.1/key-features/device-sharing.md
@@ -2,7 +2,7 @@
 title: Device sharing
 ---
 
-HAMi offers robust device-sharing capabilities, enabling multiple tasks to share the same GPU, MLU, or NPU device,
+HAMi provides device-sharing capabilities, enabling multiple tasks to share the same GPU, MLU, or NPU device,
 maximizing the utilization of heterogeneous AI computing resources.  
 
 HAMi's device sharing enables:

--- a/versioned_docs/version-v2.6.0/contributor/ladder.md
+++ b/versioned_docs/version-v2.6.0/contributor/ladder.md
@@ -140,7 +140,7 @@ The current list of maintainers can be found in the [MAINTAINERS](https://github
 
 New maintainers are added by consensus among the current group of maintainers. This can be done via a private discussion via Slack or email. A majority of maintainers should support the addition of the new person, and no single maintainer should object to adding the new maintainer.
 
-When adding a new maintainer, we should file a PR to [HAMi](https://github.com/Project-HAMi/HAMi) and update [MAINTAINERS](https://github.com/Project-HAMi/HAMi/blob/master/MAINTAINERS.md). Once this PR is merged, you will become a maintainer of HAMi.
+When adding a new maintainer, file a PR to [HAMi](https://github.com/Project-HAMi/HAMi) and update [MAINTAINERS](https://github.com/Project-HAMi/HAMi/blob/master/MAINTAINERS.md). Once this PR is merged, you will become a maintainer of HAMi.
 
 ## Removing Maintainers
 

--- a/versioned_docs/version-v2.6.0/key-features/device-sharing.md
+++ b/versioned_docs/version-v2.6.0/key-features/device-sharing.md
@@ -2,7 +2,7 @@
 title: Device sharing
 ---
 
-HAMi offers robust device-sharing capabilities, enabling multiple tasks to share the same GPU, MLU, or NPU device,
+HAMi provides device-sharing capabilities, enabling multiple tasks to share the same GPU, MLU, or NPU device,
 maximizing the utilization of heterogeneous AI computing resources.  
 
 HAMi's device sharing enables:

--- a/versioned_docs/version-v2.7.0/contributor/ladder.md
+++ b/versioned_docs/version-v2.7.0/contributor/ladder.md
@@ -142,7 +142,7 @@ The current list of maintainers can be found in the [MAINTAINERS](https://github
 
 New maintainers are added by consensus among the current group of maintainers. This can be done via a private discussion via Slack or email. A majority of maintainers should support the addition of the new person, and no single maintainer should object to adding the new maintainer.
 
-When adding a new maintainer, we should file a PR to [HAMi](https://github.com/Project-HAMi/HAMi) and update [MAINTAINERS](https://github.com/Project-HAMi/HAMi/blob/master/MAINTAINERS.md). Once this PR is merged, you will become a maintainer of HAMi.
+When adding a new maintainer, file a PR to [HAMi](https://github.com/Project-HAMi/HAMi) and update [MAINTAINERS](https://github.com/Project-HAMi/HAMi/blob/master/MAINTAINERS.md). Once this PR is merged, you will become a maintainer of HAMi.
 
 ## Removing Maintainers
 

--- a/versioned_docs/version-v2.7.0/key-features/device-sharing.md
+++ b/versioned_docs/version-v2.7.0/key-features/device-sharing.md
@@ -2,7 +2,7 @@
 title: Device sharing
 ---
 
-HAMi offers robust device-sharing capabilities, enabling multiple tasks to share the same GPU, MLU, or NPU device,
+HAMi provides device-sharing capabilities, enabling multiple tasks to share the same GPU, MLU, or NPU device,
 maximizing the utilization of heterogeneous AI computing resources.
 
 ## Device Sharing {#device-sharing}

--- a/versioned_docs/version-v2.8.0/contributor/ladder.md
+++ b/versioned_docs/version-v2.8.0/contributor/ladder.md
@@ -140,7 +140,7 @@ The current list of maintainers can be found in the [MAINTAINERS](https://github
 
 New maintainers are added by consensus among the current group of maintainers. This can be done via a private discussion via Slack or email. A majority of maintainers should support the addition of the new person, and no single maintainer should object to adding the new maintainer.
 
-When adding a new maintainer, we should file a PR to [HAMi](https://github.com/Project-HAMi/HAMi) and update [MAINTAINERS](https://github.com/Project-HAMi/HAMi/blob/master/MAINTAINERS.md). Once this PR is merged, you will become a maintainer of HAMi.
+When adding a new maintainer, file a PR to [HAMi](https://github.com/Project-HAMi/HAMi) and update [MAINTAINERS](https://github.com/Project-HAMi/HAMi/blob/master/MAINTAINERS.md). Once this PR is merged, you will become a maintainer of HAMi.
 
 ### Removing Maintainers
 

--- a/versioned_docs/version-v2.8.0/key-features/device-sharing.md
+++ b/versioned_docs/version-v2.8.0/key-features/device-sharing.md
@@ -2,7 +2,7 @@
 title: Device sharing
 ---
 
-HAMi offers robust device-sharing capabilities, enabling multiple tasks to share the same GPU, MLU, or NPU device,
+HAMi provides device-sharing capabilities, enabling multiple tasks to share the same GPU, MLU, or NPU device,
 maximizing the utilization of heterogeneous AI computing resources.
 
 ## Device Sharing {#device-sharing}


### PR DESCRIPTION
- Replace \"robust\" with neutral wording in key-features/device-sharing.md (v2.5.1, v2.6.0, v2.7.0, v2.8.0)
- Replace \"we should file a PR\" with \"file a PR\" in contributor/ladder.md (all versions)
- Replace \"our [Code of Conduct]\" with \"the [Code of Conduct]\" in docs/contributor/contributing.md