### PR TITLE
docs: rewrite contributing guides and fix technical errors

### DIFF
--- a/docs/contributor/contribute-docs.md
+++ b/docs/contributor/contribute-docs.md
@@ -1,207 +1,257 @@
 ---
-title: How to contribute docs
+title: How to Contribute Docs
+sidebar_label: Contribute Docs
 ---
 
-Starting from version 1.3, the community documentation will be available on the HAMi website.
-This document explains how to contribute docs to
-the `Project-HAMi/website` repository.
+This guide covers everything needed to contribute to the HAMi documentation website - from setting up the local environment to writing, previewing, and submitting changes.
+
+The documentation site is built with [Docusaurus 3](https://docusaurus.io/) and supports English (primary) and Simplified Chinese. English is the source language for all content.
 
 ## Prerequisites
 
-- Docs, like codes, are also categorized and stored by version.
-  1.3 is the first archived version.
-- Docs need to be translated into multiple languages for readers from different regions.
-  The community now supports both Chinese and English.
-  English is the official language of documentation.
-- Docs are written in Markdown. If you are unfamiliar with Markdown,
-  please see [https://guides.github.com/features/mastering-markdown/](https://guides.github.com/features/mastering-markdown/) or
-  [https://www.markdownguide.org/](https://www.markdownguide.org/) if you are looking for something more substantial.
-- The site uses [Docusaurus 2](https://docusaurus.io/), a modern static website generator.
+- Node.js v20 (required - other versions are not supported)
+- npm
+- Git with a GitHub account
+
+Verify your Node version:
+
+```bash
+node -v   # should print v20.x.x
+```
 
 ## Setup
 
-Set up your local environment by cloning the website repository.
+Fork the [Project-HAMi/website](https://github.com/Project-HAMi/website) repository on GitHub, then clone your fork:
 
-```shell
-git clone https://github.com/Project-HAMi/website.git
+```bash
+git clone https://github.com/<your-username>/website.git
 cd website
+git remote add upstream https://github.com/Project-HAMi/website.git
+npm install
 ```
 
-The website is organized like this:
+## Local Development
 
-```text
-website
-├── sidebars.json        # sidebar for the current docs version
-├── docs                 # docs directory for the current docs version
-│   ├── foo
-│   │   └── bar.md       # https://mysite.com/docs/next/foo/bar
-│   └── hello.md         # https://mysite.com/docs/next/hello
-├── versions.json        # file to indicate what versions are available
-├── versioned_docs
-│   ├── version-1.1.0
-│   │   ├── foo
-│   │   │   └── bar.md   # https://mysite.com/docs/foo/bar
-│   │   └── hello.md
-│   └── version-1.0.0
-│       ├── foo
-│       │   └── bar.md   # https://mysite.com/docs/1.0.0/foo/bar
-│       └── hello.md
-├── versioned_sidebars
-│   ├── version-1.1.0-sidebars.json
-│   └── version-1.0.0-sidebars.json
-├── docusaurus.config.js
-└── package.json
+```bash
+npm run start          # dev server at http://localhost:3000 with hot-reload
+npm run start:network  # same, but accessible on your local network
+npm run build:fast     # English-only production build, ~45 seconds (use for validation)
+npm run build          # full build including Chinese and all versions, ~80 seconds (mirrors CI)
+npm run clear          # clear Docusaurus cache (use when you see stale build errors)
 ```
 
-The `versions.json` file is a list of versions, from the latest to earliest.
-The table below explains how a versioned file maps to its version and the generated URL.
+Use `npm run start` while writing. Use `npm run build:fast` before opening a PR. CI runs the full `npm run build` on every PR to `master`.
 
-| Path                                    | Version        | URL               |
-| --------------------------------------- | -------------- | ----------------- |
-| `versioned_docs/version-1.0.0/hello.md` | 1.0.0          | /docs/1.0.0/hello |
-| `versioned_docs/version-1.1.0/hello.md` | 1.1.0 (latest) | /docs/hello       |
-| `docs/hello.md`                         | current        | /docs/next/hello  |
+## Repository Structure
 
-:::tip
+```
+website/
+├── docs/                          # English source docs (authoritative)
+├── i18n/zh/
+│   └── docusaurus-plugin-content-docs/
+│       └── current/               # Chinese translations
+├── versioned_docs/version-vX.Y.Z/ # archived doc snapshots
+├── blog/                          # blog posts
+├── sidebars.js                    # navigation structure
+├── docusaurus.config.js           # site configuration
+└── versions.json                  # available versioned snapshots
+```
 
-The files in the `docs` directory belong to the `current` docs version.
+Contributors primarily work in `docs/` (English source) and `i18n/zh/` (Chinese translations).
 
-The `current` docs version is labeled as `Next` and hosted under `/docs/next/*`.
+## Adding a New Document
 
-Contributors mainly contribute documentation to the current version.
-:::
+### 1. Create the file
 
-## Writing docs
+Place the file in the appropriate subdirectory under `docs/`:
 
-### Starting a title at the top
+```
+docs/userguide/nvidia-device/new-feature.md
+docs/get-started/new-guide.md
+docs/contributor/new-policy.md
+```
 
-It's important for your article to specify metadata concerning an article at the top of the Markdown file, in a section called **Front Matter**.
+### 2. Add frontmatter
 
-Here is a quick example covering the most relevant **Front Matter** entries:
+Every document must start with frontmatter:
 
 ```yaml
 ---
-title: A doc with tags
+title: Full Page Title
+sidebar_label: Short Nav Label
 ---
-
-## secondary title
 ```
 
-The top section between two lines of --- is the Front Matter section.
-The following entries tell Docusaurus how to handle the article:
+- `title` - used as the page `<h1>` heading and in metadata
+- `sidebar_label` - shorter version shown in the sidebar; omit if the same as `title`
 
-- Title is the equivalent of the `<h1>` in an HTML document or `# <title>` in a Markdown article.
-- Each document has a unique ID. By default, a document ID is the name of the document
-  (without the extension) related to the root docs directory.
+### 3. Register in sidebars.js
 
-### Linking to other docs
-
-You can easily route to other places by adding any of the following links:
-
-- Absolute URLs to external sites like `https://github.com` or `https://k8s.io` -
-  you can use any of the Markdown notations for this, so
-  - `<https://github.com>` or
-  - `[kubernetes](https://k8s.io)` will work.
-- Link to markdown files or the resulting path.
-  You can use relative paths to index the corresponding files.
-- Link to pictures or other resources.
-If your article contains images, prefer storing them in `/static/img/docs/` and linking
-  with absolute paths. Language-aware folders:
-  - `/static/img/docs/common/` for shared images
-  - `/static/img/docs/en/` for English-only images
-  - `/static/img/docs/zh/` for Chinese-only images
-Example:
-  - `![WebUI Overview](/img/docs/en/userguide/webui-overview.png)`
-  - `![WebUI 集群概览](/img/docs/zh/userguide/webui-overview.png)`
-  - `![Architecture](/img/docs/common/architecture/hami-arch.png)`
-
-### Directory organization
-
-Docusaurus 2 uses a sidebar to manage documents.
-
-Creating a sidebar is useful to:
-
-- Group multiple related documents
-- Display a sidebar on each of those documents
-- Provide paginated navigation, with next/previous button
-
-The document organization is defined in
-[sidebars.js](https://github.com/Project-HAMi/website/blob/main/sidebars.js).
+Every new document must be added to `sidebars.js` to appear in navigation. Find the right category and add the doc ID (path relative to `docs/`, without `.md`):
 
 ```js
-module.exports = {
-    docs: [
-        {
-            type: "category",
-            label: "Core Concepts",
-            collapsed: false,
-            items: [
-                "core-concepts/introduction",
-                "core-concepts/concepts",
-                "core-concepts/architecture",
-            ],
-        },
-        {
-            type: "doc",
-            id: "key-features/features",
-        },
-        {
-            type: "category",
-            label: "Get Started",
-            items: [
-                "get-started/deploy-with-helm"
-            ],
-        },
-....
+{
+  type: "category",
+  label: "Get Started",
+  items: [
+    "get-started/deploy-with-helm",
+    "get-started/verify-hami",
+    "get-started/your-new-doc"   // add here
+  ]
+}
 ```
 
-The order of documents in a directory is strictly in the order of items.
+If you are unsure which category fits, mention it in the PR and a maintainer will help.
 
-```yaml
-type: "category",
-label: "Core Concepts",
-collapsed: false,
-items: [
-  "core-concepts/introduction",
-  "core-concepts/concepts",
-  "core-concepts/architecture",
-],
+### 4. Add a Chinese translation (optional)
+
+Mirror the file path under `i18n/zh/docusaurus-plugin-content-docs/current/`. The structure is identical to `docs/`. Keep the frontmatter the same; translate only the content.
+
+If the translation is not ready, a placeholder body is acceptable:
+
+```md
+---
+title: Full Page Title
+sidebar_label: Short Nav Label
+---
+
+(Translation in progress)
 ```
 
-If you add a document, you must add it to `sidebars.js` to make it display properly.
-If you're not sure where your docs are located, you can ask community members in the PR.
+## Linking
 
-### About Chinese docs
+**Internal links** - link to other docs using relative paths to the `.md` file:
 
-There are two situations about the Chinese version of the document:
+```md
+[GitHub Workflow](github-workflow.md)
+[Installation](../get-started/deploy-with-helm.md)
+```
 
-- You want to translate existing English docs to Chinese. In this case,
-  modify the corresponding file in
-  [https://github.com/Project-HAMi/website/tree/main/i18n/zh/docusaurus-plugin-content-docs/current](https://github.com/Project-HAMi/website/tree/main/i18n/zh/docusaurus-plugin-content-docs/current).
-  The organization of this directory is exactly the same as the outer layer.
-  `current.json` holds translations for the documentation directory.
-  You can edit it if you want to translate the name of directory.
-- You want to contribute Chinese docs without English version.
-  Any articles of any kind are welcomed. In this case, you can add
-  articles and titles to the main directory first. Article content can be TBD first, like this.
-  Then add the corresponding Chinese content to the Chinese directory.
+Docusaurus resolves these to correct URLs automatically, including version and locale.
 
-## Debugging docs
+**External links** - use full URLs:
 
-Now you have already completed docs. After you start a PR to `Project-HAMi/website`,
-if you have passed CI, you can get a preview of your document on the website.
+```md
+[Kubernetes](https://kubernetes.io)
+```
 
-Click **Details** marked in red, and you will enter the preview view of the website.
+**Broken links** - the full build (`npm run build`) reports broken internal links. Fix them before opening a PR.
 
-Click **Next** and you can see the corresponding changes. If you have changes
-related to the Chinese version, click the language drop-down box next to it to switch to Chinese.
+## Images
 
-If the previewed page is not what you expected, please check your docs again.
+Store images under `/static/img/docs/` using language-aware subdirectories:
+
+| Path | Use for |
+| --- | --- |
+| `/static/img/docs/common/` | Images shared across languages |
+| `/static/img/docs/en/` | English-only images |
+| `/static/img/docs/zh/` | Chinese-only images |
+
+Reference images with absolute paths from the site root:
+
+```md
+![Architecture diagram](/img/docs/common/architecture/hami-arch.png)
+![WebUI Overview](/img/docs/en/userguide/webui-overview.png)
+```
+
+Use descriptive alt text. Do not link to external images - host them in the repository.
+
+## Writing Style
+
+The following rules apply to all documentation on this site.
+
+**Language and tone:**
+- Short, direct sentences
+- Active voice
+- Casual but professional - write like a developer explaining something to another developer
+- No filler words: "simply", "just", "Note that", "It's worth noting", "Please note"
+- No first-person: avoid "I", "we", "our", "let's"
+- Exception: direct quotes or official project announcements where "we" refers to the HAMi project team
+
+**Formatting:**
+- Use `-` for unordered lists, never `*` or `•`
+- Use regular hyphens (`-`), never em-dashes (`—`)
+- Headings: use `##` and `###` hierarchy; do not skip levels
+- Code: always specify the language in fenced code blocks (` ```bash`, ` ```yaml`, ` ```go`)
+- No emoji in documentation content
+
+**Avoid marketing language:**
+- Do not use: "innovative", "seamless", "robust", "powerful", "cutting-edge", "state-of-the-art"
+- Do not use: "streamline", "leverage", "intuitive", "comprehensive"
+- Do not use: "In conclusion,", "In summary,", "To summarize,"
+
+## Versioning
+
+HAMi docs are versioned alongside each release:
+
+| Location | Version | URL |
+| --- | --- | --- |
+| `docs/` | current (unreleased) | `/docs/next/*` |
+| `versioned_docs/version-v2.8.0/` | v2.8.0 (latest stable) | `/docs/*` |
+| `versioned_docs/version-v2.7.0/` | v2.7.0 | `/docs/v2.7.0/*` |
+
+**Contribute to `docs/`** for changes that apply to the next release. These are the files most contributors should edit.
+
+Fixes to existing versioned docs are handled by maintainers through cherry-picks. If you find an error in a versioned doc, open an issue or submit a fix to `docs/` - a maintainer will backport if needed.
+
+## Chinese Translation Workflow
+
+There are two cases:
+
+**Translating an existing English doc:**
+
+1. Find the corresponding file path under `i18n/zh/docusaurus-plugin-content-docs/current/`.
+2. The directory structure mirrors `docs/` exactly.
+3. Translate the content; keep frontmatter fields identical to the English source.
+4. To translate a sidebar category label, edit `i18n/zh/docusaurus-plugin-content-docs/current.json`.
+
+**Adding a Chinese doc without an English version:**
+
+This is not recommended. English is the source language. If you want to contribute in Chinese, write the English version first (even a draft), then add the Chinese translation.
+
+## Previewing Changes
+
+The dev server shows English only:
+
+```bash
+npm run start
+```
+
+To preview Chinese translations locally:
+
+```bash
+npm run start -- --locale zh
+```
+
+To preview both languages, run the full build and serve it:
+
+```bash
+npm run build
+npm run serve
+```
+
+## CI and PR Preview
+
+When you open a PR against `master`, CI runs `npm run build` (full build). If the build fails, the PR cannot be merged.
+
+PRs also receive a preview deployment link automatically. Click it to see your changes rendered on the live site before requesting review. Use this to verify links, images, and formatting.
+
+## Changelog
+
+The changelog is auto-generated from `CHANGELOG.md` at the repo root by a custom Docusaurus plugin. Do not edit files under `changelog/source/` directly - they are overwritten on every build.
+
+To update the changelog, edit `CHANGELOG.md` directly.
 
 ## FAQ
 
-### Versioning
+**The build fails with a broken link error.**
+Run `npm run build` locally to see the exact file and line. Fix the link and rebuild.
 
-Newly supplemented documents for each version are synchronized to the latest version
-on the release date of each version, and the documents of the old version will not be modified.
-Errata found in the documentation are fixed with every release.
+**My new page does not appear in the sidebar.**
+Check that the doc ID in `sidebars.js` matches the file path exactly (relative to `docs/`, no `.md` extension).
+
+**The dev server shows a cached version of my changes.**
+Stop the server and run `npm run clear`, then restart.
+
+**How do I document a new feature for an upcoming release?**
+Add the documentation to `docs/` (not `versioned_docs/`). It will be snapshotted into `versioned_docs/` when the release is cut.

--- a/docs/contributor/contributing.md
+++ b/docs/contributor/contributing.md
@@ -1,88 +1,381 @@
 ---
-title: Contributing
+title: Contributing to HAMi
+sidebar_label: Contributing
 ---
 
-Welcome to HAMi!
+HAMi is a CNCF Sandbox project that brings GPU and AI accelerator virtualization to Kubernetes. The scheduler, device plugins, documentation, and tooling are all built and maintained by community contributors.
+
+This guide is the starting point for any contribution, whether you are fixing a typo or implementing a new hardware backend.
+
+## The Critical Rule
+
+**You must understand every change you submit.**
+
+Using tools to help write code or documentation is fine. Submitting a change you cannot explain is not. If a reviewer asks why a piece of code works the way it does and you cannot answer, the PR will not be merged. This applies to every contribution, regardless of how it was produced.
+
+This matters more in HAMi than in most projects. Code that manages GPU memory, device scheduling, or accelerator lifecycle can cause data corruption, hardware faults, or silent misallocation if it is wrong. "It looked right" is not enough.
 
 ## Code of Conduct
 
-Please make sure to read and observe our [Code of Conduct](https://github.com/cncf/foundation/blob/main/code-of-conduct.md)
+All community members must follow the [CNCF Code of Conduct](https://github.com/cncf/foundation/blob/main/code-of-conduct.md). Report violations to the CNCF CoC committee via cncf-coc@lists.cncf.io.
 
-## Community Expectations
+## Ways to Contribute
 
-HAMi is a community project driven by its community which strives to promote a healthy, friendly and productive environment.
+Writing code is not the only way to contribute.
 
-## Getting started
+| Contribution type | What it involves |
+| --- | --- |
+| Bug reports | Open a detailed issue with reproduction steps and environment info |
+| Bug fixes | Submit a PR with a test case that covers the fix |
+| New features | Open an issue first to align on approach, then submit a PR |
+| Documentation | Fix errors, fill gaps, add examples, improve clarity |
+| Blog posts | Write about HAMi use cases, integrations, or release highlights |
+| Translations | Translate English docs into Chinese or help maintain the existing Chinese translations |
+| Code review | Read open PRs and share technical feedback |
+| Issue triage | Reproduce bugs, ask for missing info, close stale issues |
+| Community support | Answer questions in Slack or GitHub Discussions |
 
-- Fork the repository on GitHub.
-- Make your changes on your fork repository.
-- Submit a PR.
+## Community
 
-## Your First Contribution
+| Channel | Purpose |
+| --- | --- |
+| [GitHub Issues](https://github.com/Project-HAMi/HAMi/issues) | Bug reports and feature requests |
+| [GitHub Discussions](https://github.com/Project-HAMi/HAMi/discussions) | Questions, ideas, design proposals |
+| [CNCF Slack #hami](https://cloud-native.slack.com/archives/C03E57Q30FY) | Real-time chat |
+| [MAINTAINERS](https://github.com/Project-HAMi/HAMi/blob/master/MAINTAINERS.md) | Current maintainer list |
+| [Community Meetings](https://github.com/Project-HAMi/community) | Bi-weekly video meetings |
 
-Help is available for contributing in different areas: filing issues, developing features, fixing critical bugs and
-getting work reviewed and merged.
+Before opening an issue or PR, search existing issues and discussions for related work.
 
-If you have questions about the development process,
-feel free to [file an issue](https://github.com/Project-HAMi/HAMi/issues/new/choose).
+**New to HAMi?** Join [CNCF Slack](https://cloud-native.slack.com/archives/C03E57Q30FY) and introduce yourself in `#hami`. Maintainers and existing contributors are happy to help you find a good first issue, review a draft, or answer questions before you open a PR.
 
-## Find something to work on
+## Prerequisites
 
-The project always needs help, be it fixing documentation, reporting bugs or writing code.
-Look at places where you feel best coding practices aren't followed, code refactoring is needed or tests are missing.
-Here is how you get started.
+**For all contributions:**
+- Git with a GitHub account
+- You must be able to certify contributions under the [Developer Certificate of Origin](https://developercertificate.org/)
 
-### Find a good first topic
+**For HAMi core (Go):**
+- Go 1.21+
+- `kubectl` and access to a Kubernetes cluster with a supported GPU or accelerator
 
-There are [multiple repositories](https://github.com/Project-HAMi/) within the HAMi organization.
-Each repository has beginner-friendly issues that provide a good first issue.
-For example, [Project-HAMi/HAMi](https://github.com/Project-HAMi/HAMi) has
-[help wanted](https://github.com/Project-HAMi/HAMi/issues?q=is%3Aopen+is%3Aissue+label%3A%22help+wanted%22) and
-[good first issue](https://github.com/Project-HAMi/HAMi/issues?q=is%3Aopen+is%3Aissue+label%3A%22good+first+issue%22)
-labels for issues that should not need deep knowledge of the system.
-New contributors working on such issues can reach out for help.
+**For documentation (website):**
+- Node.js v20
+- npm
 
-Another good way to contribute is to find a documentation improvement, such as a missing/broken link.
-Please see [Contributor Workflow](#contributor-workflow) below for the workflow.
+## Setup
 
-#### Work on an issue
+### Fork and Clone
 
-When you are willing to take on an issue, reply on the issue. The maintainer will assign it to you.
+Fork the target repository on GitHub, then clone your fork:
 
-### File an Issue
+```bash
+export user="your-github-username"
 
-Code contributions are welcome, but reporting an issue is equally appreciated.
-Issues should be filed under the appropriate HAMi sub-repository.
+# For core HAMi
+git clone https://github.com/$user/HAMi.git
+cd HAMi
+git remote add upstream https://github.com/Project-HAMi/HAMi.git
+git remote set-url --push upstream no_push   # prevent accidental upstream push
 
-*Example:* a HAMi issue should be opened to [Project-HAMi/HAMi](https://github.com/Project-HAMi/HAMi/issues).
+# For the docs website
+git clone https://github.com/$user/website.git
+cd website
+git remote add upstream https://github.com/Project-HAMi/website.git
+npm install
+```
 
-Please follow the prompted submission guidelines while opening an issue.
+### Stay in Sync
+
+Keep your local master branch current with upstream before starting new work:
+
+```bash
+git fetch upstream
+git checkout master
+git rebase upstream/master
+```
+
+Use `rebase`, not `merge`, to keep a clean commit history.
+
+For a detailed walkthrough of the full Git workflow, see the [GitHub Workflow guide](github-workflow.md).
+
+## Finding Work
+
+Good starting points:
+
+- [`good first issue`](https://github.com/Project-HAMi/HAMi/issues?q=is%3Aopen+is%3Aissue+label%3A%22good+first+issue%22) - scoped, well-documented, friendly to new contributors
+- [`help wanted`](https://github.com/Project-HAMi/HAMi/issues?q=is%3Aopen+is%3Aissue+label%3A%22help+wanted%22) - open for contributions, may need domain knowledge
+- Documentation gaps and broken links in the [website repository](https://github.com/Project-HAMi/website/issues)
+
+When you decide to work on an issue, comment on it. A maintainer will assign it to you to prevent duplicate effort.
 
 ## Contributor Workflow
 
-Please do not ever hesitate to ask a question or send a pull request.
+### Branch Naming
 
-This is a rough outline of what a contributor's workflow looks like:
+Use short, descriptive branch names that reflect the change:
 
-- Create a topic branch from where to base the contribution. This is usually master.
-- Make commits of logical units.
-- Push changes in a topic branch to a personal fork of the repository.
-- Submit a pull request to [Project-HAMi/HAMi](https://github.com/Project-HAMi/HAMi).
+```bash
+git checkout -b fix/gpu-memory-calculation
+git checkout -b feat/kunlunxin-multi-card
+git checkout -b docs/update-ascend-guide
+```
 
-## Creating Pull Requests
+### Small vs. Large Changes
 
-Pull requests are often called "PR".
-HAMi generally follows the standard [github pull request](https://help.github.com/articles/about-pull-requests/) process.
-To submit a proposed change, please develop the code/fix and add new test cases.
-After that, run these local verifications before submitting a pull request to predict the pass or
-fail of continuous integration.
+**Any PR that adds or changes more than 100 lines of code or documentation requires a GitHub issue or discussion first.** Open the issue, describe what you want to do and why, and wait for maintainer feedback before writing the code. Only then open the PR.
 
-- Run and pass `make verify`
+**Small changes** (bug fixes, typo corrections, docs improvements under 100 lines): open a PR directly, no issue required.
+
+**Large changes** (new features, API changes, new hardware backends, refactors spanning multiple packages, docs additions over 100 lines):
+
+1. Open a GitHub issue describing the problem and your proposed approach.
+2. Get alignment from maintainers before investing significant time.
+3. Open a draft PR early once you have direction - share progress before the implementation is final.
+
+PRs opened without a prior issue for large changes will be asked to go back and open one first.
+
+### Validate Before Pushing
+
+For Go code:
+
+```bash
+make verify
+make test
+```
+
+For documentation:
+
+```bash
+npm run build:fast   # English-only, ~45 seconds - use during development
+npm run build        # Full build with all locales, ~80 seconds - mirrors CI
+```
+
+## Code Style
+
+### Go
+
+- Format all code with `gofmt` before committing. Unformatted code will fail CI.
+- Follow [Go Code Review Comments](https://github.com/golang/go/wiki/CodeReviewComments) for style decisions.
+- Write table-driven tests where it makes sense. Test names should describe the scenario, not the function.
+- Keep functions small and focused. If a function needs a long comment to explain what it does, consider splitting it.
+- Error messages should be lowercase and not end with punctuation (Go convention).
+
+### Documentation
+
+See the [Writing Style](contribute-docs.md#writing-style) section in the docs contribution guide.
+
+## Commit Standards
+
+### Format
+
+HAMi uses [Conventional Commits](https://www.conventionalcommits.org/):
+
+```
+<type>(<optional scope>): <description>
+
+[optional body]
+
+[optional footer(s)]
+```
+
+**Types:**
+
+| Type | Use for |
+| --- | --- |
+| `feat` | New functionality |
+| `fix` | Bug fix |
+| `docs` | Documentation changes only |
+| `chore` | Maintenance: deps, build config, CI |
+| `refactor` | Code restructure with no behavior change |
+| `test` | Adding or updating tests |
+| `perf` | Performance improvement |
+
+**Good examples:**
+
+```
+feat(scheduler): add memory oversell ratio config option
+fix(deviceplugin): handle graceful shutdown on SIGTERM
+docs: correct vGPU memory limit example in Ascend guide
+chore: bump Go to 1.22
+test: add unit tests for MLU device discovery
+```
+
+**Rules:**
+- Subject line: 72 characters or fewer
+- Imperative mood: "add", "fix", "update" - not "added", "fixed", "updates"
+- Body: explain *what* and *why*, not *how*
+- No period at the end of the subject line
+
+### DCO Sign-off (Required)
+
+Every commit must include a `Signed-off-by` line. CI blocks PRs that are missing it.
+
+```bash
+git commit -s -m "fix: correct memory calculation for MLU"
+```
+
+The `-s` flag appends:
+
+```
+Signed-off-by: Your Name <your@email.com>
+```
+
+This certifies you have the right to submit the work under the project's license. See the [Developer Certificate of Origin](https://developercertificate.org/) for the full text.
+
+**Forgot to sign off?** Fix it before pushing:
+
+```bash
+# Single commit
+git commit --amend -s --no-edit
+
+# Multiple commits on the branch
+git rebase HEAD~<n> --signoff
+```
+
+## Pull Requests
+
+### Before Opening
+
+- [ ] Every commit has a `Signed-off-by` line
+- [ ] Commit messages follow Conventional Commits format
+- [ ] If this PR changes more than 100 lines, a GitHub issue was opened first and is linked below
+- [ ] Local checks pass (`make verify` for Go, `npm run build:fast` for docs)
+- [ ] Tests added or updated for code changes
+- [ ] Docs updated if user-facing behavior changed
+- [ ] Related issue linked in the PR description
+
+### PR Description
+
+Keep it short and factual:
+
+- What does this change do?
+- Why is it needed?
+- How was it tested?
+- Reference related issues: `Fixes #123` or `Relates to #456`
+
+**Formatting rules for PR descriptions, issue bodies, and commit messages:**
+- No em-dashes (`—`) - use a regular hyphen (`-`) instead
+- No emojis
+- No filler phrases ("This PR aims to...", "In this PR, we...")
+- No marketing language ("seamless", "robust", "powerful", "innovative")
+- Write in your own words - short, direct sentences
+
+### Keeping PRs Focused
+
+One logical change per PR. Large, unfocused PRs take longer to review and are harder to revert if something breaks. If you are fixing multiple independent issues, open separate PRs.
+
+### Squashing Commits
+
+Before merge, clean up your commit history. Squash fixup commits, review-feedback commits, and typo corrections into the relevant logical commit. Each remaining commit should represent a meaningful unit of work that compiles and passes tests independently.
+
+For step-by-step squash instructions, see the [GitHub Workflow guide](github-workflow.md#squash-commits).
+
+### Review Process
+
+1. After the PR is opened, a maintainer or reviewer is assigned.
+2. Address all review comments. If you disagree with feedback, explain why in the thread.
+3. Update the PR by pushing to the same branch - do not close and reopen.
+4. CI must pass before merge.
+5. Once an approver marks the PR approved, it will be merged.
 
 ## Code Review
 
-To make it easier for your PR to receive reviews, consider the reviewers will need you to:
+When reviewing others' PRs:
 
-- follow [good coding guidelines](https://github.com/golang/go/wiki/CodeReviewComments).
-- write [good commit messages](https://chris.beams.io/posts/git-commit/).
-- break large changes into a logical series of smaller patches which individually make easily understandable changes, and in aggregate solve a broader issue.
+- Reference the exact line and explain the concern - do not just flag something as wrong.
+- Distinguish blocking issues from optional suggestions. Use `nit:` for minor style notes that should not block merge.
+- Acknowledge what works well. A review that only lists problems is harder to act on.
+- If you spot something minor (typo, formatting), use a GitHub suggestion so the author can apply it in one click.
+- Reviews are collaborative. Assume good intent.
+
+## AI Usage
+
+AI tools may be used to assist with writing code, documentation, or commit messages. There is one hard rule:
+
+**Do not submit AI-generated text directly as your PR description, issue body, or commit message.**
+
+Maintainers need to communicate with the person behind the contribution - not with a language model. Write in your own words, even if AI helped you draft a starting point. Text that is clearly AI-generated (verbose summaries, excessive lists, filler phrases, "In conclusion") will be flagged and the author asked to rewrite.
+
+What is acceptable:
+- Using AI to help understand unfamiliar code
+- Using AI to draft a commit message that you then edit and own
+- Using AI to check grammar or clarity
+- Using AI to generate code that you review, test, and understand
+
+What is not acceptable:
+- Pasting an AI-generated PR description without reading and rewriting it
+- Submitting code you cannot explain if asked during review
+- Using AI-generated text as issue comments or discussion posts
+
+If AI played a significant role beyond autocomplete, mention it briefly in the PR description. This helps reviewers calibrate their review depth.
+
+## Documentation Contributions
+
+Documentation lives in the [Project-HAMi/website](https://github.com/Project-HAMi/website) repository and is built with Docusaurus 3.
+
+For a complete guide covering frontmatter, sidebar registration, image paths, local preview, and Chinese translation workflow, see [How to Contribute Docs](contribute-docs.md).
+
+**Quick rules:**
+- English is the source language. All new docs go to `docs/` first.
+- Chinese translations go under `i18n/zh/docusaurus-plugin-content-docs/current/`.
+- Every new doc must be added to `sidebars.js`.
+- Run `npm run build:fast` to validate before opening a PR.
+
+## Hardware Vendor Contributions
+
+HAMi supports multiple GPU and accelerator vendors. If you are adding support for a new device or fixing vendor-specific behavior:
+
+- Follow the existing structure in `pkg/device/` (one directory per vendor).
+- Test on real hardware where possible. Simulated tests are acceptable for CI, but hardware validation is expected for new backends before merge.
+- Follow the documentation pattern under `docs/userguide/<vendor>-device/`.
+- Include working YAML examples under `docs/userguide/<vendor>-device/examples/`.
+
+Supported vendors: NVIDIA, Cambricon (MLU), Hygon (DCU), Mthreads, Iluvatar, Enflame (GCU), AWS Neuron, Kunlunxin (XPU), Metax, Ascend.
+
+## Translations
+
+The HAMi website supports two languages: **English** (primary) and **Simplified Chinese**. No other languages are currently supported.
+
+English is the authoritative source. All new documentation is written in English first. Chinese translations live in `i18n/zh/`.
+
+To add or update a translation:
+
+1. Find the corresponding file under `i18n/zh/docusaurus-plugin-content-docs/current/`.
+2. Translate the content, keeping frontmatter and document structure identical to the English source.
+3. Submit a PR with only translation changes - do not mix translation and content edits in the same PR.
+
+If an English page has no Chinese counterpart yet, you can create one. A placeholder (`TBD`) in the body is acceptable if you want to register the page before completing the translation.
+
+## Contributor Roles
+
+HAMi uses a defined contributor ladder with progressively more responsibility and access:
+
+- **Community Participant** - follows the CoC, participates in discussions
+- **Contributor** - submits PRs and issues, helps other users
+- **Organization Member** - established contributor with at least 5 accepted PRs, enabled 2FA, and two sponsors
+- **Reviewer** - responsible for reviewing PRs in a specific area, at least 10 reviews on record
+- **Maintainer** - responsible for the project as a whole, approves and merges PRs
+
+For full role requirements, the promotion path, and how to nominate yourself or others, see the [Contributor Ladder](ladder.md).
+
+## Filing Issues
+
+Use the [HAMi issue tracker](https://github.com/Project-HAMi/HAMi/issues) for bugs and feature requests. Before filing:
+
+- Search for existing issues that cover the same problem.
+- For security vulnerabilities, follow the [security policy](https://github.com/Project-HAMi/HAMi/blob/master/SECURITY.md) instead of opening a public issue.
+
+For website issues, use the [website issue tracker](https://github.com/Project-HAMi/website/issues).
+
+When filing a bug, include:
+- HAMi version and installation method
+- Kubernetes version and cluster setup
+- GPU or accelerator type and driver version
+- Steps to reproduce
+- Actual vs. expected behavior
+- Relevant logs or error output
+
+## License
+
+By contributing to HAMi, you agree that your contributions will be licensed under the [Apache License 2.0](https://github.com/Project-HAMi/HAMi/blob/master/LICENSE).

--- a/docs/installation/webui-installation.md
+++ b/docs/installation/webui-installation.md
@@ -81,8 +81,8 @@ When troubleshooting, check the HAMi WebUI component logs.
 Run:
 
 ```bash
-kubectl logs --namespace=hami deploy/my-hami-webui -c hami-webui-fe-oss
-kubectl logs --namespace=hami deploy/my-hami-webui -c hami-webui-be-oss
+kubectl logs --namespace=kube-system deploy/my-hami-webui -c hami-webui-fe-oss
+kubectl logs --namespace=kube-system deploy/my-hami-webui -c hami-webui-be-oss
 ```
 
 For more information, see [Pods](https://kubernetes.io/docs/reference/kubectl/cheatsheet/#interacting-with-running-pods) and [Deployments](https://kubernetes.io/docs/reference/kubectl/cheatsheet/#interacting-with-deployments-and-services).
@@ -91,18 +91,8 @@ For more information, see [Pods](https://kubernetes.io/docs/reference/kubectl/ch
 
 To remove the Helm release, use:
 
-`helm uninstall <RELEASE-NAME> <NAMESPACE-NAME>`
-
 ```bash
-helm uninstall my-hami-webui -n hami
-```
-
-This removes the resources associated with that release in the `hami` namespace.
-
-To delete the `hami` namespace (if you no longer need it):
-
-```bash
-kubectl delete namespace hami
+helm uninstall my-hami-webui -n kube-system
 ```
 
 ## Related documentation

--- a/docs/userguide/ascend-device/enable-ascend-sharing.md
+++ b/docs/userguide/ascend-device/enable-ascend-sharing.md
@@ -104,5 +104,5 @@ spec:
 
 1. Ascend-sharing in init container is not supported.
 
-1. `huawei.com/Ascend910B-memory` only works when `huawei.com/Ascend91B0=1`.
-   `huawe.com/Ascend310P-memory` only works when `huawei.com/Ascend310P=1`.
+1. `huawei.com/Ascend910B-memory` only works when `huawei.com/Ascend910B=1`.
+   `huawei.com/Ascend310P-memory` only works when `huawei.com/Ascend310P=1`.

--- a/docs/userguide/configure.md
+++ b/docs/userguide/configure.md
@@ -37,7 +37,7 @@ You can update these configurations using one of the following methods:
    | `nvidia.resourceCountName` | String | vGPU number resource name. | `"nvidia.com/gpu"` |
    | `nvidia.resourceMemoryName` | String | vGPU memory size resource name. | `"nvidia.com/gpumem"` |
    | `nvidia.resourceMemoryPercentageName` | String | vGPU memory fraction resource name. | `"nvidia.com/gpumem-percentage"` |
-   | `nvidia.resourceCoreName` | String | vGPU core resource name. | `"nvidia.com/cores"` |
+   | `nvidia.resourceCoreName` | String | vGPU core resource name. | `"nvidia.com/gpucores"` |
    | `nvidia.resourcePriorityName` | String | vGPU job priority name. | `"nvidia.com/priority"` |
 
 ## Node Configs: ConfigMap

--- a/sidebars.js
+++ b/sidebars.js
@@ -369,6 +369,8 @@ module.exports = {
       },
       "items": [
         "contributor/contributing",
+        "contributor/contribute-docs",
+        "contributor/github-workflow",
         "contributor/governance",
         "contributor/ladder"
       ]

--- a/versioned_docs/version-v1.3.0/installation/prerequisites.md
+++ b/versioned_docs/version-v1.3.0/installation/prerequisites.md
@@ -48,7 +48,7 @@ When running `Kubernetes` with `Docker`, edit the configuration file, typically 
 And then restart `Docker`:
 
 ```
-sudo systemctl daemon-reload && systemctl restart docker
+sudo systemctl daemon-reload && sudo systemctl restart docker
 ```
 
 

--- a/versioned_docs/version-v1.3.0/userguide/ascend-device/enable-ascend-sharing.md
+++ b/versioned_docs/version-v1.3.0/userguide/ascend-device/enable-ascend-sharing.md
@@ -105,4 +105,4 @@ spec:
 
 1. Ascend-sharing in init container is not supported.
 
-2. `huawei.com/Ascend910B-memory` only work when `huawei.com/Ascend91B0=1`, `huawe.com/Ascend310P-memory` only work when `huawei.com/Ascend310P=1`,etc..
+2. `huawei.com/Ascend910B-memory` only work when `huawei.com/Ascend910B=1`, `huawei.com/Ascend310P-memory` only work when `huawei.com/Ascend310P=1`,etc..

--- a/versioned_docs/version-v2.4.1/installation/prerequisites.md
+++ b/versioned_docs/version-v2.4.1/installation/prerequisites.md
@@ -48,7 +48,7 @@ When running `Kubernetes` with `Docker`, edit the configuration file, typically 
 And then restart `Docker`:
 
 ```
-sudo systemctl daemon-reload && systemctl restart docker
+sudo systemctl daemon-reload && sudo systemctl restart docker
 ```
 
 

--- a/versioned_docs/version-v2.4.1/userguide/ascend-device/enable-ascend-sharing.md
+++ b/versioned_docs/version-v2.4.1/userguide/ascend-device/enable-ascend-sharing.md
@@ -105,4 +105,4 @@ spec:
 
 1. Ascend-sharing in init container is not supported.
 
-2. `huawei.com/Ascend910B-memory` only work when `huawei.com/Ascend91B0=1`, `huawe.com/Ascend310P-memory` only work when `huawei.com/Ascend310P=1`,etc..
+2. `huawei.com/Ascend910B-memory` only work when `huawei.com/Ascend910B=1`, `huawei.com/Ascend310P-memory` only work when `huawei.com/Ascend310P=1`,etc..

--- a/versioned_docs/version-v2.5.0/installation/prerequisites.md
+++ b/versioned_docs/version-v2.5.0/installation/prerequisites.md
@@ -48,7 +48,7 @@ When running `Kubernetes` with `Docker`, edit the configuration file, typically 
 And then restart `Docker`:
 
 ```
-sudo systemctl daemon-reload && systemctl restart docker
+sudo systemctl daemon-reload && sudo systemctl restart docker
 ```
 
 

--- a/versioned_docs/version-v2.5.0/userguide/ascend-device/enable-ascend-sharing.md
+++ b/versioned_docs/version-v2.5.0/userguide/ascend-device/enable-ascend-sharing.md
@@ -105,4 +105,4 @@ spec:
 
 1. Ascend-sharing in init container is not supported.
 
-2. `huawei.com/Ascend910B-memory` only work when `huawei.com/Ascend91B0=1`, `huawe.com/Ascend310P-memory` only work when `huawei.com/Ascend310P=1`,etc..
+2. `huawei.com/Ascend910B-memory` only work when `huawei.com/Ascend910B=1`, `huawei.com/Ascend310P-memory` only work when `huawei.com/Ascend310P=1`,etc..

--- a/versioned_docs/version-v2.5.1/installation/prerequisites.md
+++ b/versioned_docs/version-v2.5.1/installation/prerequisites.md
@@ -48,7 +48,7 @@ When running `Kubernetes` with `Docker`, edit the configuration file, typically 
 And then restart `Docker`:
 
 ```
-sudo systemctl daemon-reload && systemctl restart docker
+sudo systemctl daemon-reload && sudo systemctl restart docker
 ```
 
 

--- a/versioned_docs/version-v2.5.1/userguide/ascend-device/enable-ascend-sharing.md
+++ b/versioned_docs/version-v2.5.1/userguide/ascend-device/enable-ascend-sharing.md
@@ -104,5 +104,5 @@ spec:
 
 1. Ascend-sharing in init container is not supported.
 
-2. `huawei.com/Ascend910B-memory` only works when `huawei.com/Ascend91B0=1`.
-   `huawe.com/Ascend310P-memory` only works when `huawei.com/Ascend310P=1`.
+2. `huawei.com/Ascend910B-memory` only works when `huawei.com/Ascend910B=1`.
+   `huawei.com/Ascend310P-memory` only works when `huawei.com/Ascend310P=1`.

--- a/versioned_docs/version-v2.5.1/userguide/configure.md
+++ b/versioned_docs/version-v2.5.1/userguide/configure.md
@@ -37,7 +37,7 @@ You can update these configurations using one of the following methods:
    | `nvidia.resourceCountName` | String | vGPU number resource name. | `"nvidia.com/gpu"` |
    | `nvidia.resourceMemoryName` | String | vGPU memory size resource name. | `"nvidia.com/gpumem"` |
    | `nvidia.resourceMemoryPercentageName` | String | vGPU memory fraction resource name. | `"nvidia.com/gpumem-percentage"` |
-   | `nvidia.resourceCoreName` | String | vGPU core resource name. | `"nvidia.com/cores"` |
+   | `nvidia.resourceCoreName` | String | vGPU core resource name. | `"nvidia.com/gpucores"` |
    | `nvidia.resourcePriorityName` | String | vGPU job priority name. | `"nvidia.com/priority"` |
 
 ## Chart Configs: arguments

--- a/versioned_docs/version-v2.6.0/installation/prerequisites.md
+++ b/versioned_docs/version-v2.6.0/installation/prerequisites.md
@@ -40,7 +40,7 @@ sudo nvidia-ctk runtime configure --runtime=docker
 And then restart `Docker`:
 
 ```bash
-sudo systemctl daemon-reload && systemctl restart docker
+sudo systemctl daemon-reload && sudo systemctl restart docker
 ```
 
 

--- a/versioned_docs/version-v2.6.0/userguide/ascend-device/enable-ascend-sharing.md
+++ b/versioned_docs/version-v2.6.0/userguide/ascend-device/enable-ascend-sharing.md
@@ -104,5 +104,5 @@ spec:
 
 1. Ascend-sharing in init container is not supported.
 
-2. `huawei.com/Ascend910B-memory` only works when `huawei.com/Ascend91B0=1`.
-   `huawe.com/Ascend310P-memory` only works when `huawei.com/Ascend310P=1`.
+2. `huawei.com/Ascend910B-memory` only works when `huawei.com/Ascend910B=1`.
+   `huawei.com/Ascend310P-memory` only works when `huawei.com/Ascend310P=1`.

--- a/versioned_docs/version-v2.6.0/userguide/configure.md
+++ b/versioned_docs/version-v2.6.0/userguide/configure.md
@@ -37,7 +37,7 @@ You can update these configurations using one of the following methods:
    | `nvidia.resourceCountName` | String | vGPU number resource name. | `"nvidia.com/gpu"` |
    | `nvidia.resourceMemoryName` | String | vGPU memory size resource name. | `"nvidia.com/gpumem"` |
    | `nvidia.resourceMemoryPercentageName` | String | vGPU memory fraction resource name. | `"nvidia.com/gpumem-percentage"` |
-   | `nvidia.resourceCoreName` | String | vGPU core resource name. | `"nvidia.com/cores"` |
+   | `nvidia.resourceCoreName` | String | vGPU core resource name. | `"nvidia.com/gpucores"` |
    | `nvidia.resourcePriorityName` | String | vGPU job priority name. | `"nvidia.com/priority"` |
 
 ## Chart Configs: arguments

--- a/versioned_docs/version-v2.7.0/installation/prerequisites.md
+++ b/versioned_docs/version-v2.7.0/installation/prerequisites.md
@@ -40,7 +40,7 @@ sudo nvidia-ctk runtime configure --runtime=docker
 And then restart Docker:
 
 ```bash
-sudo systemctl daemon-reload && systemctl restart docker
+sudo systemctl daemon-reload && sudo systemctl restart docker
 ```
 
 #### Configure containerd

--- a/versioned_docs/version-v2.7.0/userguide/ascend-device/enable-ascend-sharing.md
+++ b/versioned_docs/version-v2.7.0/userguide/ascend-device/enable-ascend-sharing.md
@@ -104,5 +104,5 @@ spec:
 
 1. Ascend-sharing in init container is not supported.
 
-2. `huawei.com/Ascend910B-memory` only works when `huawei.com/Ascend91B0=1`.
-   `huawe.com/Ascend310P-memory` only works when `huawei.com/Ascend310P=1`.
+2. `huawei.com/Ascend910B-memory` only works when `huawei.com/Ascend910B=1`.
+   `huawei.com/Ascend310P-memory` only works when `huawei.com/Ascend310P=1`.

--- a/versioned_docs/version-v2.7.0/userguide/configure.md
+++ b/versioned_docs/version-v2.7.0/userguide/configure.md
@@ -37,7 +37,7 @@ You can update these configurations using one of the following methods:
    | `nvidia.resourceCountName` | String | vGPU number resource name. | `"nvidia.com/gpu"` |
    | `nvidia.resourceMemoryName` | String | vGPU memory size resource name. | `"nvidia.com/gpumem"` |
    | `nvidia.resourceMemoryPercentageName` | String | vGPU memory fraction resource name. | `"nvidia.com/gpumem-percentage"` |
-   | `nvidia.resourceCoreName` | String | vGPU core resource name. | `"nvidia.com/cores"` |
+   | `nvidia.resourceCoreName` | String | vGPU core resource name. | `"nvidia.com/gpucores"` |
    | `nvidia.resourcePriorityName` | String | vGPU job priority name. | `"nvidia.com/priority"` |
 
 ## Node Configs: ConfigMap

--- a/versioned_docs/version-v2.8.0/installation/prerequisites.md
+++ b/versioned_docs/version-v2.8.0/installation/prerequisites.md
@@ -43,7 +43,7 @@ sudo nvidia-ctk runtime configure --runtime=docker
 And then restart Docker:
 
 ```bash
-sudo systemctl daemon-reload && systemctl restart docker
+sudo systemctl daemon-reload && sudo systemctl restart docker
 ```
 
 #### Configure containerd

--- a/versioned_docs/version-v2.8.0/userguide/ascend-device/enable-ascend-sharing.md
+++ b/versioned_docs/version-v2.8.0/userguide/ascend-device/enable-ascend-sharing.md
@@ -104,5 +104,5 @@ spec:
 
 1. Ascend-sharing in init container is not supported.
 
-1. `huawei.com/Ascend910B-memory` only works when `huawei.com/Ascend91B0=1`.
-   `huawe.com/Ascend310P-memory` only works when `huawei.com/Ascend310P=1`.
+1. `huawei.com/Ascend910B-memory` only works when `huawei.com/Ascend910B=1`.
+   `huawei.com/Ascend310P-memory` only works when `huawei.com/Ascend310P=1`.

--- a/versioned_docs/version-v2.8.0/userguide/configure.md
+++ b/versioned_docs/version-v2.8.0/userguide/configure.md
@@ -36,7 +36,7 @@ You can update these configurations using one of the following methods:
    | `nvidia.resourceCountName` | String | vGPU number resource name. | `"nvidia.com/gpu"` |
    | `nvidia.resourceMemoryName` | String | vGPU memory size resource name. | `"nvidia.com/gpumem"` |
    | `nvidia.resourceMemoryPercentageName` | String | vGPU memory fraction resource name. | `"nvidia.com/gpumem-percentage"` |
-   | `nvidia.resourceCoreName` | String | vGPU core resource name. | `"nvidia.com/cores"` |
+   | `nvidia.resourceCoreName` | String | vGPU core resource name. | `"nvidia.com/gpucores"` |
    | `nvidia.resourcePriorityName` | String | vGPU job priority name. | `"nvidia.com/priority"` |
 
 ## Node Configs: ConfigMap


### PR DESCRIPTION
## Technical fixes

- `configure.md`: corrected `nvidia.resourceCoreName` default from `nvidia.com/cores` to `nvidia.com/gpucores` across docs and versioned snapshots (v2.5.1, v2.6.0, v2.7.0, v2.8.0)
- `enable-ascend-sharing.md`: fixed `Ascend91B0` to `Ascend910B` and `huawe.com` to `huawei.com` across docs and versioned snapshots (v1.3.0, v2.4.1, v2.5.0, v2.5.1, v2.6.0, v2.7.0, v2.8.0)
- `prerequisites.md`: added missing `sudo` to `systemctl restart docker` in all versioned snapshots
- `webui-installation.md`: aligned namespace references from `hami` to `kube-system` in troubleshooting and uninstall sections

## Contributing guide rewrite

`docs/contributor/contributing.md` rewritten from scratch:
- Critical Rule section at the top (understand every change you submit)
- Ways to contribute including blog posts
- New-contributor Slack invite in Community section
- Prerequisites split by contribution type (Go core vs docs)
- Small vs. large changes with explicit 100-line threshold requiring a prior issue
- Go code style (gofmt, CodeReviewComments, table-driven tests)
- Conventional Commits format with HAMi-specific examples
- DCO sign-off instructions with amend and rebase fix commands
- PR checklist including 100-line issue requirement
- PR description formatting rules (no em-dashes, no emojis, no filler)
- AI usage policy
- Hardware vendor contribution guidelines
- Translations scoped to English and Chinese only
- Filing issues with required bug report fields

`docs/contributor/contribute-docs.md` modernized:
- Updated to Docusaurus 3, Node.js v20
- Correct build commands (build:fast vs full build)
- Frontmatter, sidebar registration, linking, image path conventions
- Writing style rules (em-dashes, emojis, marketing language, first-person)
- Versioning explanation, Chinese translation workflow, local preview, FAQ

`sidebars.js`: added `contribute-docs` and `github-workflow` to Contributor Guide section