### PR TITLE
docs: rewrite cherry-picks guide for HAMi

### DIFF
--- a/docs/contributor/cherry-picks.md
+++ b/docs/contributor/cherry-picks.md
@@ -1,121 +1,70 @@
 ---
 title: How to cherry-pick PRs
+sidebar_label: Cherry Picks
 ---
 
-This document explains how cherry picks are managed on release branches within
-the `Project-HAMi/HAMi` repository.
-A common use case for this task is backporting PRs from master to release
-branches.
-
-> This doc is lifted from [Kubernetes cherry-pick](https://github.com/kubernetes/community/blob/master/contributors/devel/sig-release/cherry-picks.md).
-
-- [Prerequisites](#prerequisites)
-- [What Kind of PRs are Good for Cherry Picks](#what-kind-of-prs-are-good-for-cherry-picks)
-- [Initiate a Cherry Pick](#initiate-a-cherry-pick)
-- [Cherry Pick Review](#cherry-pick-review)
-- [Troubleshooting Cherry Picks](#troubleshooting-cherry-picks)
-- [Cherry Picks for Unsupported Releases](#cherry-picks-for-unsupported-releases)
+This document explains how cherry picks are managed on release branches in the `Project-HAMi/HAMi` repository. The typical use case is backporting a bug fix from master to an active release branch.
 
 ## Prerequisites
 
-- A pull request merged against the `master` branch.
-- The release branch exists (example: [`release-2.4`](https://github.com/Project-HAMi/HAMi/releases))
-- The normal git and GitHub configured shell environment for pushing to your
-  HAMi `origin` fork on GitHub and making a pull request against a
-  configured remote `upstream` that tracks
-  `https://github.com/Project-HAMi/HAMi`, including `GITHUB_USER`.
-- Have GitHub CLI (`gh`) installed following [installation instructions](https://github.com/cli/cli#installation).
-- A github personal access token which has permissions "repo" and "read:org".
-  Permissions are required for [gh auth login](https://cli.github.com/manual/gh_auth_login)
-  and not used for anything unrelated to cherry-pick creation process
-  (creating a branch and initiating PR).
+- A pull request already merged into master.
+- The target release branch exists (for example, `release-2.4`).
+- Git and GitHub configured with your fork as `origin` and the upstream as `upstream`.
+- [GitHub CLI (`gh`)](https://github.com/cli/cli#installation) installed.
+- A GitHub personal access token with `repo` and `read:org` scopes, used for `gh auth login`.
 
-## What Kind of PRs are Good for Cherry Picks
+## What qualifies for a cherry pick
 
-Compared to the normal master branch's merge volume across time,
-the release branches see one or two orders of magnitude less PRs.
-This is because there is an order of magnitude or two higher scrutiny.
-Again, the emphasis is on critical bug fixes, e.g.,
+Release branches receive far fewer merges than master because the bar is higher. Cherry picks are reserved for critical fixes only:
 
-- Loss of data
+- Data loss
 - Memory corruption
-- Panic, crash, hang
-- Security
+- Panic, crash, or hang
+- Security vulnerabilities
 
-A bugfix for a functional issue (not a data loss or security issue) that only
-affects an alpha feature does not qualify as a critical bug fix.
+A bug that affects only an alpha feature does not qualify, even if it is a real bug.
 
-If you are proposing a cherry pick and it is not a clear and obvious critical
-bug fix, please reconsider. If upon reflection you wish to continue, bolster
-your case by supplementing your PR with e.g.,
+If the fix is not clearly critical, support the case with:
 
-- A GitHub issue detailing the problem
-
+- A GitHub issue describing the problem
 - Scope of the change
+- Risks of adding the change
+- Risks of regression
+- Tests added or updated
+- Sign-off from key stakeholders or reviewers
 
-- Risks of adding a change
+Features that were not enabled on a specific vendor's platform belong in master for the next release. They will not be backported.
 
-- Risks of associated regression
+## Initiate a cherry pick
 
-- Testing performed, test cases added
+Run the [cherry pick script][cherry-pick-script]. This example backports PR #1206 to `upstream/release-1.0`:
 
-- Key stakeholder reviewers/approvers attesting to their confidence in the
-  change being a required backport
+```bash
+hack/cherry_pick_pull.sh upstream/release-1.0 1206
+```
 
-It is critical that the full community is actively engaged on enhancements in
-the project. If a released feature was not enabled on a particular provider's
-platform, this is a community miss that needs to be resolved in the `master`
-branch for subsequent releases. Such enabling will not be backported to the
-patch release branches.
+Notes:
 
-## Initiate a Cherry Pick
+- The script expects a remote named `upstream` pointing to `https://github.com/Project-HAMi/HAMi`.
+- Run the script separately for each release branch that needs the fix.
+- If `GITHUB_TOKEN` is not set, the script will prompt for a token. Use a [personal access token](https://github.com/settings/tokens) rather than your account password.
 
-- Run the [cherry pick script][cherry-pick-script]
+## Cherry pick review
 
-  This example applies a master branch PR #1206 to the remote branch
-  `upstream/release-1.0`:
+Cherry pick PRs follow the same review process as normal PRs. Code owners review (`/lgtm`) and approve (`/approve`) as they see fit.
 
-  ```shell
-  hack/cherry_pick_pull.sh upstream/release-1.0 1206
-  ```
+Release notes auto-populate from the original master PR.
 
-  - Be aware the cherry pick script assumes you have a git remote called
-    `upstream` that points at the HAMi github org.
+## Troubleshooting
 
-  - You will need to run the cherry pick script separately for each patch
-    release you want to cherry pick to. Cherry picks should be applied to all
-    active release branches where the fix is applicable.
+**The cherry pick does not apply cleanly.**
+The patch conflicts with changes already in the release branch. Fetch the auto-generated branch from your fork, resolve the conflicts manually, and force-push.
 
-  - If `GITHUB_TOKEN` is not set you will be asked for your github password:
-    provide the github [personal access token](https://github.com/settings/tokens) rather than your actual github
-    password. If you can securely set the environment variable `GITHUB_TOKEN`
-    to your personal access token then you can avoid an interactive prompt.
-    Refer [https://github.com/github/hub/issues/2655#issuecomment-735836048](https://github.com/github/hub/issues/2655#issuecomment-735836048)
+**CI fails on the cherry pick branch.**
+Fetch the auto-generated branch, amend the failing commit, and force-push. Alternatively, open a new PR manually - it is noisier but sometimes cleaner.
 
-## Cherry Pick Review
+## Unsupported releases
 
-As with any other PR, code OWNERS review (`/lgtm`) and approve (`/approve`) on
-cherry pick PRs as they deem appropriate.
-
-The same release note requirements apply as normal pull requests, except the
-release note stanza will auto-populate from the master branch pull request from
-which the cherry pick originated.
-
-## Troubleshooting Cherry Picks
-
-Contributors may encounter some of the following difficulties when initiating a
-cherry pick.
-
-- A cherry pick PR does not apply cleanly against an old release branch. In
-  that case, you will need to manually fix conflicts.
-
-- The cherry pick PR includes code that does not pass CI tests. In such a case
-  you will have to fetch the auto-generated branch from your fork, amend the
-  problematic commit and force push to the auto-generated branch.
-  Alternatively, you can create a new PR, which is noisier.
-
-## Cherry Picks for Unsupported Releases
-
-Community support and patches for these releases need to be discussed.
+Fixes for end-of-life release branches are not accepted without prior discussion. Open an issue to start that conversation before submitting a cherry pick against an unsupported branch.
 
 [cherry-pick-script]: https://github.com/Project-HAMi/HAMi/blob/master/hack/cherry_pick_pull.sh


### PR DESCRIPTION
The existing `cherry-picks.md` was lifted verbatim from the Kubernetes community docs and carried the original attribution header.

Changes:
- Remove Kubernetes attribution
- Rewrite prerequisites in plain list form, remove GITHUB_USER reference
- Rewrite qualification criteria with direct language (no "please reconsider", no filler)
- Collapse scattered bullet sub-items in the initiate section into clean prose + notes
- Rewrite troubleshooting as named problem/solution pairs
- Apply writing style rules: no `*` bullets, no first-person, no em-dashes, no filler