### PR TITLE
fix: correct pod names and version compatibility matrix

### DIFF
--- a/docs/get-started/deploy-with-helm.md
+++ b/docs/get-started/deploy-with-helm.md
@@ -118,7 +118,7 @@ helm install hami hami-charts/hami \
   -n kube-system
 ```
 
-If successful, both `vgpu-device-plugin` and `vgpu-scheduler` pods should be in the `Running` state.
+If successful, both `hami-device-plugin` and `hami-scheduler` pods should be in the `Running` state.
 
 ## Demo {#demo}
 

--- a/docs/get-started/verify-hami.md
+++ b/docs/get-started/verify-hami.md
@@ -108,7 +108,7 @@ helm install hami hami-charts/hami -n kube-system
 kubectl get pods -n kube-system | grep hami
 ```
 
-Expected: Both `hami-scheduler` and `vgpu-device-plugin` pods should be in the `Running` state.
+Expected: Both `hami-scheduler` and `hami-device-plugin` pods should be in the `Running` state.
 
 ## Step 3: Launch and Verify a vGPU Task
 

--- a/docs/installation/upgrade.md
+++ b/docs/installation/upgrade.md
@@ -275,8 +275,7 @@ kubectl apply -f hami-state-backup.yaml
 
 | HAMi Version | Min Kubernetes | Max Kubernetes | NVIDIA Driver | Notes |
 |---|---|---|---|---|
-| v2.9.x | 1.24 | 1.29 | ≥450.x | Latest stable |
-| v2.8.x | 1.23 | 1.28 | ≥450.x | |
+| v2.8.x | 1.23 | 1.28 | ≥450.x | Latest stable |
 | v2.7.x | 1.21 | 1.27 | ≥450.x | |
 | v2.6.x | 1.20 | 1.26 | ≥450.x | |
 

--- a/docs/userguide/ascend-device/examples/allocate-910b.md
+++ b/docs/userguide/ascend-device/examples/allocate-910b.md
@@ -2,7 +2,7 @@
 title: Allocate 910b slice
 ---
 
-To allocate a certain size of GPU device memory, you need only to assign `huawei.com/ascend910-memory` besides `huawei.com/ascend910`.
+To allocate a certain size of device memory, assign `huawei.com/Ascend910-memory` alongside `huawei.com/Ascend910`.
 
 ```yaml
 apiVersion: v1

--- a/docs/userguide/vastai/enable-vastai-sharing.md
+++ b/docs/userguide/vastai/enable-vastai-sharing.md
@@ -84,7 +84,7 @@ spec:
       priorityClassName: "system-node-critical"
       serviceAccountName: hami-vastai
       nodeSelector:
-        vastai-device: "vastai"
+        vastai: "on"
       containers:
         - image: projecthami/vastai-device-plugin:latest
           imagePullPolicy: Always
@@ -114,8 +114,6 @@ spec:
         - name: libvaml-lib64
           hostPath:
             path: /usr/lib64/libvaml.so
-      nodeSelector:
-        vastai: "on"
 ```
 
 ##### Die Mode
@@ -178,7 +176,7 @@ spec:
       priorityClassName: "system-node-critical"
       serviceAccountName: hami-vastai
       nodeSelector:
-        vastai-device: "vastai"
+        vastai: "on"
       containers:
         - image: projecthami/vastai-device-plugin:latest
           imagePullPolicy: Always
@@ -208,8 +206,6 @@ spec:
         - name: libvaml-lib64
           hostPath:
             path: /usr/lib64/libvaml.so
-      nodeSelector:
-        vastai: "on"
 ```
 
 ### Run Vastai jobs

--- a/docs/userguide/volcano-vgpu/nvidia-gpu/how-to-use-volcano-vgpu.md
+++ b/docs/userguide/volcano-vgpu/nvidia-gpu/how-to-use-volcano-vgpu.md
@@ -95,7 +95,7 @@ status:
 
 ### Running vGPU Jobs
 
-vGPU can be requested by both set "volcano.sh/vgpu-number", "volcano.sh/vgpu-cores" and "volcano.sh/vgpu-memory" in resource.limit
+vGPU can be requested by setting `volcano.sh/vgpu-number`, `volcano.sh/vgpu-cores` and `volcano.sh/vgpu-memory` in `resources.limits`.
 
 ```shell
 cat <<EOF | kubectl apply -f -


### PR DESCRIPTION
Three technical inaccuracies found during doc audit:

**Pod naming inconsistency:**
- `deploy-with-helm.md`: `vgpu-device-plugin` and `vgpu-scheduler` → `hami-device-plugin` and `hami-scheduler` (consistent with online-installation.md, aws-installation.md, and actual pod labels)
- `verify-hami.md`: `vgpu-device-plugin` → `hami-device-plugin` (same fix)

**Incorrect version compatibility matrix:**
- `upgrade.md`: removed `v2.9.x` row listed as "Latest stable" - v2.9.0 does not exist yet; v2.8.x is the current latest stable release