### PR TITLE
fix: add missing space before (i.e., in iluvatar and enflame docs

### DIFF
--- a/docs/userguide/enflame-device/enable-enflame-gcu-sharing.md
+++ b/docs/userguide/enflame-device/enable-enflame-gcu-sharing.md
@@ -5,7 +5,7 @@ title: Enable Enflame GPU Sharing
 
 ## Introduction
 
-**HAMi now supports sharing on enflame.com/gcu(i.e., S60) by implementing most device-sharing features as nvidia-GPU**, including:
+**HAMi now supports sharing on enflame.com/gcu (i.e., S60) by implementing most device-sharing features as nvidia-GPU**, including:
 
 **GCU sharing**: Each task can allocate a portion of GCU instead of a whole GCU card, thus GCU can be shared among multiple tasks.
 

--- a/docs/userguide/iluvatar-device/enable-iluvatar-gpu-sharing.md
+++ b/docs/userguide/iluvatar-device/enable-iluvatar-gpu-sharing.md
@@ -4,7 +4,7 @@ title: Enable Iluvatar GPU Sharing
 
 ## Introduction
 
-**HAMi now supports iluvatar.ai/gpu(i.e., MR-V100, BI-V150, BI-V100) by implementing most device-sharing features as nvidia-GPU**, including:
+**HAMi now supports iluvatar.ai/gpu (i.e., MR-V100, BI-V150, BI-V100) by implementing most device-sharing features as nvidia-GPU**, including:
 
 **GPU sharing**: Each task can allocate a portion of GPU instead of a whole GPU card, thus GPU can be shared among multiple tasks.
 


### PR DESCRIPTION
## Summary

- `userguide/iluvatar-device/enable-iluvatar-gpu-sharing.md`: `gpu(i.e.,` corrected to `gpu (i.e.,`
- `userguide/enflame-device/enable-enflame-gcu-sharing.md`: `gcu(i.e.,` corrected to `gcu (i.e.,`

Missing space between the resource identifier and the parenthetical explanation.

## Test plan

- [x] Verified surrounding context unchanged