### PR TITLE
fix: correct YAML frontmatter error and NVIDIA capitalization

### DIFF
--- a/blog/2024-12-31-post/index.md
+++ b/blog/2024-12-31-post/index.md
@@ -774,7 +774,7 @@ In this case, the registered device is NVIDIA, and the `GetNodeDevices` implemen
 `pkg/device/nvidia/device.go:209`
 
 ```golang
-ffunc (dev *NvidiaGPUDevices) GetNodeDevices(n corev1.Node) ([]*util.DeviceInfo, error) {
+func (dev *NvidiaGPUDevices) GetNodeDevices(n corev1.Node) ([]*util.DeviceInfo, error) {
  devEncoded, ok := n.Annotations[RegisterAnnos]
  if !ok {
   return []*util.DeviceInfo{}, errors.New("annos not found " + RegisterAnnos)

--- a/blog/hami-at-kubecon-eu-2026/index.md
+++ b/blog/hami-at-kubecon-eu-2026/index.md
@@ -133,7 +133,7 @@ During the conference, the HAMi community will continue to curate and publish re
 
 Stay connected:
 
-- [HAMi GitHub Repository](https://github.com/project-hami/hami)
+- [HAMi GitHub Repository](https://github.com/Project-HAMi/HAMi)
 - [HAMi Community Website](https://project-hami.io)
 
 If you'll be in Amsterdam, come find us at Project Pavilion.

--- a/docs/installation/how-to-use-volcano-vgpu.md
+++ b/docs/installation/how-to-use-volcano-vgpu.md
@@ -8,7 +8,7 @@ linktitle: Use Volcano vGPU
 You *DON'T* need to install HAMi when using volcano-vgpu, only use
 [Volcano vGPU device-plugin](https://github.com/Project-HAMi/volcano-vgpu-device-plugin) is good enough. It can provide device-sharing mechanism for NVIDIA devices managed by Volcano.
 
-This is based on [Nvidia Device Plugin](https://github.com/NVIDIA/k8s-device-plugin), it uses [HAMi-core](https://github.com/Project-HAMi/HAMi-core) to support hard isolation of GPU cards.
+This is based on [NVIDIA Device Plugin](https://github.com/NVIDIA/k8s-device-plugin), it uses [HAMi-core](https://github.com/Project-HAMi/HAMi-core) to support hard isolation of GPU cards.
 
 Volcano vGPU is only available in Volcano > v1.9.
 

--- a/docs/userguide/cambricon-device/specify-device-memory-usage.md
+++ b/docs/userguide/cambricon-device/specify-device-memory-usage.md
@@ -10,7 +10,7 @@ This field is optional. Each unit of `cambricon.com/mlu.smlu.vmemory` represents
       resources:
         limits:
           cambricon.com/vmlu: 1 # requesting 1 MLU
-          cambricon.com/mlu.smlu.vmemory: "20" # Each GPU contains 20% device memory
+          cambricon.com/mlu.smlu.vmemory: "20" # Each MLU contains 20% device memory
 ```
 
 :::note

--- a/docs/userguide/cambricon-device/specify-device-type-to-use.md
+++ b/docs/userguide/cambricon-device/specify-device-type-to-use.md
@@ -16,6 +16,6 @@ You can specify these resources in your container specification like this:
       resources:
         limits:
           cambricon.com/vmlu: 1 # requesting 1 MLU
-          cambricon.com/mlu370.smlu.vmemory: "20" # Each GPU contains 20% device memory
-          cambricon.com/mlu370.smlu.vcore: "10" # Each GPU contains 10% compute cores
+          cambricon.com/mlu370.smlu.vmemory: "20" # Each MLU contains 20% device memory
+          cambricon.com/mlu370.smlu.vcore: "10" # Each MLU contains 10% compute cores
 ```

--- a/docs/userguide/configure.md
+++ b/docs/userguide/configure.md
@@ -12,7 +12,7 @@ All the configurations listed below are managed within the hami-scheduler-device
 You can update these configurations using one of the following methods:
 
 1. Directly edit the ConfigMap: If HAMi has already been successfully installed, you can manually update
-   the hami-scheduler-device ConfigMap using the kubectl edit command to manually update the hami-scheduler-device ConfigMap.
+   the hami-scheduler-device ConfigMap using the kubectl edit command.
 
    ```bash
    kubectl edit configmap hami-scheduler-device -n <namespace>

--- a/docs/userguide/nvidia-device/dynamic-resource-allocation.md
+++ b/docs/userguide/nvidia-device/dynamic-resource-allocation.md
@@ -6,7 +6,7 @@ translated: true
 ## Introduction
 
 HAMi has supported K8s [DRA](https://kubernetes.io/docs/concepts/scheduling-eviction/dynamic-resource-allocation/) (Dynamic Resource Allocation) on NVIDIA devices.
-By installing hami-k8s-dra-driver, your cluster scheduler can discover Nvidia GPU devices on nodes.
+By installing hami-k8s-dra-driver, your cluster scheduler can discover NVIDIA GPU devices on nodes.
 
 ## Prerequisites
 
@@ -14,7 +14,7 @@ By installing hami-k8s-dra-driver, your cluster scheduler can discover Nvidia GP
 
 ## Installation
 
-The Nvidia DRA driver is built into HAMi and does not need to be installed separately. You only need to specify the `--set hami-dra-webhook.drivers.nvidia.enabled=true` parameter when [installing HAMi DRA](../../installation/how-to-use-hami-dra). For more information, please refer to [Installing Nvidia DRA driver](https://github.com/Project-HAMi/HAMi-DRA?tab=readme-ov-file#installation)
+The NVIDIA DRA driver is built into HAMi and does not need to be installed separately. You only need to specify the `--set hami-dra-webhook.drivers.nvidia.enabled=true` parameter when [installing HAMi DRA](../../installation/how-to-use-hami-dra). For more information, please refer to [Installing NVIDIA DRA driver](https://github.com/Project-HAMi/HAMi-DRA?tab=readme-ov-file#installation)
 
 ## Verify Installation
 

--- a/docs/userguide/nvidia-device/examples/dynamic-mig-example.md
+++ b/docs/userguide/nvidia-device/examples/dynamic-mig-example.md
@@ -2,7 +2,7 @@
 title: Assign task to mig instance
 ---
 
-This example will allocate `2g.10gb * 2` for A100-40GB-PCIE device or `1g.10gb * 2` for A100-80GB-XSM device.
+This example will allocate `2g.10gb * 2` for A100-40GB-PCIE device or `1g.10gb * 2` for A100-80GB-SXM device.
 
 ```yaml
 apiVersion: v1

--- a/docs/userguide/volcano-vgpu/nvidia-gpu/how-to-use-volcano-vgpu.md
+++ b/docs/userguide/volcano-vgpu/nvidia-gpu/how-to-use-volcano-vgpu.md
@@ -8,7 +8,7 @@ linktitle: Use Volcano vGPU
 You *DON'T* need to install HAMi when using volcano-vgpu, only use
 [Volcano vGPU device-plugin](https://github.com/Project-HAMi/volcano-vgpu-device-plugin) is good enough. It can provide device-sharing mechanism for NVIDIA devices managed by Volcano.
 
-This is based on [Nvidia Device Plugin](https://github.com/NVIDIA/k8s-device-plugin), it uses [HAMi-core](https://github.com/Project-HAMi/HAMi-core) to support hard isolation of GPU cards.
+This is based on [NVIDIA Device Plugin](https://github.com/NVIDIA/k8s-device-plugin), it uses [HAMi-core](https://github.com/Project-HAMi/HAMi-core) to support hard isolation of GPU cards.
 
 Volcano vGPU is only available in Volcano > v1.9.
 

--- a/i18n/zh/docusaurus-plugin-content-docs/current/core-concepts/gpu-virtualization.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/current/core-concepts/gpu-virtualization.md
@@ -1,5 +1,5 @@
 ---
-title: GPU 虚拟化原理]
+title: GPU 虚拟化原理
 linktitle: GPU 虚拟化
 translated: true
 ---


### PR DESCRIPTION
`docs/developers/protocol.md` (`Nvidia-V100` + `Cambircon`) is excluded as it is covered by PR #334.