### PR TITLE
fix: clean up informal note markers in active English docs

### DIFF
--- a/docs/faq/faq.md
+++ b/docs/faq/faq.md
@@ -159,7 +159,7 @@ Device Plugins can only report a single resource type. GPU memory and compute in
 **Why does the Node Capacity show `volcano.sh/vgpu-number` and `volcano.sh/vgpu-memory` when using `volcano-vgpu-device-plugin`?**
 
 - volcano-vgpu-device-plugin creates **[three independent Device Plugin instances](https://github.com/Project-HAMi/volcano-vgpu-device-plugin/blob/2bf6dfe37f7b716f05d0d3210f89898087c06d99/pkg/plugin/vgpu/mig-strategy.go#L65-L85)**, each registering with kubelet for volcano.sh/vgpu-number, volcano.sh/vgpu-memory, and volcano.sh/vgpu-cores resources respectively. After kubelet receives the registration, it automatically writes the resources into Capacity and Allocatable.
-- **Note:** volcano.sh/vgpu-memory resource is subject to Kubernetes extended resources quantity limit (**maximum 32,767**). For GPUs with large memory (e.g., A100 80GB), configure the `--gpu-memory-factor` parameter to avoid exceeding the limit.
+- The `volcano.sh/vgpu-memory` resource is subject to a Kubernetes extended resources quantity limit of **32,767 maximum**. For GPUs with large memory (e.g., A100 80GB), configure the `--gpu-memory-factor` parameter to avoid exceeding the limit.
 
 ## Why don’t some domestic vendors require a runtime for installation?
 

--- a/docs/installation/uninstall.md
+++ b/docs/installation/uninstall.md
@@ -26,9 +26,9 @@ This command will remove all HAMi resources, including:
 - ConfigMaps and Secrets
 - RBAC roles and bindings
 
-:::note
+:::warning
 
-**Important:** Uninstalling HAMi won't automatically stop or kill running GPU tasks. Container processes will continue to use GPU resources even after HAMi components are removed.
+Uninstalling HAMi won't automatically stop or kill running GPU tasks. Container processes will continue to use GPU resources even after HAMi components are removed.
 
 :::
 

--- a/docs/userguide/iluvatar-device/enable-iluvatar-gpu-sharing.md
+++ b/docs/userguide/iluvatar-device/enable-iluvatar-gpu-sharing.md
@@ -33,7 +33,7 @@ title: Enable Iluvatar GPU Sharing
 helm install hami hami-charts/hami --set scheduler.kubeScheduler.imageTag={your kubernetes version} --set devices.iluvatar.enabled=true -n kube-system
 ```
 
-**Note:** The currently supported GPU models and resource names are defined in ([https://github.com/Project-HAMi/HAMi/blob/master/charts/hami/templates/scheduler/device-configmap.yaml](https://github.com/Project-HAMi/HAMi/blob/master/charts/hami/templates/scheduler/device-configmap.yaml)):
+The currently supported GPU models and resource names are defined in [device-configmap.yaml](https://github.com/Project-HAMi/HAMi/blob/master/charts/hami/templates/scheduler/device-configmap.yaml):
 
 ```yaml
     iluvatars:


### PR DESCRIPTION
Replace informal bold note markers with proper Docusaurus admonitions and clean up a redundant double-link in three active English documentation files.