### PR TITLE
fix: replace NOTICE blockquotes with Docusaurus admonitions in 24 docs

### DIFF
--- a/docs/installation/how-to-use-hami-dra.md
+++ b/docs/installation/how-to-use-hami-dra.md
@@ -28,7 +28,11 @@ Then install with the following command:
 helm install hami hami-charts/hami --set dra.enable=true -n hami-system
 ```
 
-> **NOTICE:** *DRA mode is not compatible with traditional mode. Do not enable both at the same time.*
+:::note
+
+DRA mode is not compatible with traditional mode. Do not enable both at the same time.
+
+:::
 
 ## Supported Devices
 

--- a/docs/userguide/ascend-device/examples/allocate-310p.md
+++ b/docs/userguide/ascend-device/examples/allocate-310p.md
@@ -21,7 +21,11 @@ spec:
           huawei.com/Ascend310P-memory: 2000 # requesting 2000m device memory
 ```
 
-> **NOTICE:** *Compute resource of Ascend310P is also limited with `huawei.com/Ascend310P-memory`, equal to the percentage of device memory allocated.*
+:::note
+
+Compute resource of Ascend310P is also limited with `huawei.com/Ascend310P-memory`, equal to the percentage of device memory allocated.
+
+:::
 
 ## Select Device by UUID
 

--- a/docs/userguide/ascend-device/examples/allocate-910b.md
+++ b/docs/userguide/ascend-device/examples/allocate-910b.md
@@ -21,7 +21,11 @@ spec:
           huawei.com/Ascend910B-memory: 2000 # requesting 2000m device memory
 ```
 
-> **NOTICE:** *Compute resource of Ascend910B is also limited with `huawei.com/Ascend910B-memory`, equal to the percentage of device memory allocated.*
+:::note
+
+Compute resource of Ascend910B is also limited with `huawei.com/Ascend910B-memory`, equal to the percentage of device memory allocated.
+
+:::
 
 ## Select Device by UUID
 

--- a/docs/userguide/awsneuron-device/enable-awsneuron-managing.md
+++ b/docs/userguide/awsneuron-device/enable-awsneuron-managing.md
@@ -109,7 +109,11 @@ spec:
   # ... rest of pod spec
 ```
 
-> **NOTICE:** The device ID format is `{node-name}-AWSNeuron-{index}`. You can find the available device IDs in the node annotations.
+:::note
+
+The device ID format is `{node-name}-AWSNeuron-{index}`. You can find the available device IDs in the node annotations.
+
+:::
 
 ### Finding Device UUIDs
 

--- a/docs/userguide/enflame-device/enable-enflame-gcu-sharing.md
+++ b/docs/userguide/enflame-device/enable-enflame-gcu-sharing.md
@@ -26,13 +26,18 @@ title: Enable Enflame GPU Sharing
 
 * Deploy gcushare-device-plugin on enflame nodes (Please consult your device provider to acquire its package and document)
 
-> **NOTICE:** *Install only gpushare-device-plugin, don't install gpu-scheduler-plugin package.*
-> **NOTICE:** The default resource names are:
->
-> * `enflame.com/vgcu` for GCU count, only support 1 now.
-> * `enflame.com/vgcu-percentage` for the percentage of memory and cores in a gcu slice.
->
-> You can customize these names by modifying `hami-scheduler-device` configMap above.
+:::caution
+Install only `gcushare-device-plugin`. Do not install the `gcushare-scheduler-plugin` package.
+:::
+
+:::note
+The default resource names are:
+
+- `enflame.com/vgcu` for GCU count (only 1 is supported currently)
+- `enflame.com/vgcu-percentage` for the percentage of memory and cores in a GCU slice
+
+You can customize these names by modifying the `hami-scheduler-device` ConfigMap.
+:::
 
 * Set 'devices.enflame.enabled=true' when deploy HAMi
 
@@ -78,7 +83,9 @@ spec:
           enflame.com/vgcu-percentage: 22
 ```
 
-> **NOTICE:** *You can find more examples in [examples/enflame folder](https://github.com/Project-HAMi/HAMi/tree/master/examples/enflame/)*
+:::tip
+More examples are available in the [examples/enflame folder](https://github.com/Project-HAMi/HAMi/tree/master/examples/enflame/).
+:::
 
 ## Device UUID Selection
 
@@ -98,7 +105,9 @@ spec:
   # ... rest of pod spec
 ```
 
-> **NOTICE:** The device ID format is `{node-name}-enflame-{index}`. You can find the available device IDs in the node status.
+:::note
+The device ID format is `{node-name}-enflame-{index}`. You can find the available device IDs in the node status.
+:::
 
 ### Finding Device UUIDs
 

--- a/docs/userguide/hygon-device/specify-device-uuid-to-use.md
+++ b/docs/userguide/hygon-device/specify-device-uuid-to-use.md
@@ -12,4 +12,8 @@ metadata:
     hygon.com/use-gpuuuid: "DCU-123456"
 ```
 
-> **NOTICE:** *Each DCU UUID is unique in a cluster, so assign a certain UUID means assigning this task to certain node with that DCU*
+:::note
+
+Each DCU UUID is unique in a cluster, so assign a certain UUID means assigning this task to certain node with that DCU
+
+:::

--- a/docs/userguide/iluvatar-device/enable-iluvatar-gpu-sharing.md
+++ b/docs/userguide/iluvatar-device/enable-iluvatar-gpu-sharing.md
@@ -23,11 +23,13 @@ title: Enable Iluvatar GPU Sharing
 
 ## Enabling GPU-sharing Support
 
-* Deploy gpu-manager on iluvatar nodes (Please consult your device provider to acquire its package and document)
+- Deploy gpu-manager on iluvatar nodes (please consult your device provider to acquire its package and document)
 
-  > **NOTICE:** *Install only gpu-manager, don't install gpu-admission package.*
+:::caution
+Install only gpu-manager. Do not install the gpu-admission package.
+:::
 
-* set the devices.iluvatar.enabled=true when installing HAMi
+- Set `devices.iluvatar.enabled=true` when installing HAMi
 
 ```bash
 helm install hami hami-charts/hami --set scheduler.kubeScheduler.imageTag={your kubernetes version} --set devices.iluvatar.enabled=true -n kube-system
@@ -112,7 +114,11 @@ spec:
         iluvatar.ai/BI-V150.vMem: 64
 ```
 
-> **NOTICE:** *Each unit of `iluvatar.ai/<card-type>.vMem` represents 256 MB of device memory*
+:::note
+
+Each unit of `iluvatar.ai/<card-type>.vMem` represents 256 MB of device memory.
+
+:::
 
 ## Device UUID Selection
 

--- a/docs/userguide/iluvatar-device/examples/allocate-bi-v150.md
+++ b/docs/userguide/iluvatar-device/examples/allocate-bi-v150.md
@@ -36,4 +36,8 @@ spec:
         iluvatar.ai/BI-V150.vMem: 64
 ```
 
-> **NOTICE:** *Each `iluvatar.ai/<card-type>.vCore` unit represents 1% of an available compute core, and each `iluvatar.ai/<card-type>.vMem` unit represents 256MB of device memory*
+:::note
+
+Each `iluvatar.ai/<card-type>.vCore` unit represents 1% of an available compute core, and each `iluvatar.ai/<card-type>.vMem` unit represents 256MB of device memory
+
+:::

--- a/docs/userguide/iluvatar-device/examples/allocate-exclusive-bi-v150.md
+++ b/docs/userguide/iluvatar-device/examples/allocate-exclusive-bi-v150.md
@@ -32,4 +32,8 @@ spec:
         iluvatar.ai/BI-V150-vgpu: 2
 ```
 
-> **NOTICE:** *When applying for exclusive use of a GPU, `iluvatar.ai/<card-type>-vgpu=1`, you need to set the values of `iluvatar.ai/<card-type>.vCore` and `iluvatar.ai/<card-type>.vMem` to the maximum number of GPU resources. `iluvatar.ai/<card-type>-vgpu>1` no longer supports the vGPU function, so you don't need to fill in the core and memory values*
+:::note
+
+When applying for exclusive use of a GPU, `iluvatar.ai/<card-type>-vgpu=1`, you need to set the values of `iluvatar.ai/<card-type>.vCore` and `iluvatar.ai/<card-type>.vMem` to the maximum number of GPU resources. `iluvatar.ai/<card-type>-vgpu>1` no longer supports the vGPU function, so you don't need to fill in the core and memory values
+
+:::

--- a/docs/userguide/iluvatar-device/examples/allocate-exclusive-mr-v100.md
+++ b/docs/userguide/iluvatar-device/examples/allocate-exclusive-mr-v100.md
@@ -32,4 +32,8 @@ spec:
         iluvatar.ai/MR-V100-vgpu: 2
 ```
 
-> **NOTICE:** *When applying for exclusive use of a GPU, `iluvatar.ai/<card-type>-vgpu=1`, you need to set the values of `iluvatar.ai/<card-type>.vCore` and `iluvatar.ai/<card-type>.vMem` to the maximum number of GPU resources. `iluvatar.ai/<card-type>-vgpu>1` no longer supports the vGPU function, so you don't need to fill in the core and memory values*
+:::note
+
+When applying for exclusive use of a GPU, `iluvatar.ai/<card-type>-vgpu=1`, you need to set the values of `iluvatar.ai/<card-type>.vCore` and `iluvatar.ai/<card-type>.vMem` to the maximum number of GPU resources. `iluvatar.ai/<card-type>-vgpu>1` no longer supports the vGPU function, so you don't need to fill in the core and memory values
+
+:::

--- a/docs/userguide/iluvatar-device/examples/allocate-mr-v100.md
+++ b/docs/userguide/iluvatar-device/examples/allocate-mr-v100.md
@@ -37,4 +37,8 @@ spec:
         iluvatar.ai/MR-V100.vMem: 64
 ```
 
-> **NOTICE:** *Each `iluvatar.ai/<card-type>.vCore` unit represents 1% of an available compute core, and each `iluvatar.ai/<card-type>.vMem` unit represents 256MB of device memory*
+:::note
+
+Each `iluvatar.ai/<card-type>.vCore` unit represents 1% of an available compute core, and each `iluvatar.ai/<card-type>.vMem` unit represents 256MB of device memory
+
+:::

--- a/docs/userguide/kunlunxin-device/enable-kunlunxin-vxpu.md
+++ b/docs/userguide/kunlunxin-device/enable-kunlunxin-vxpu.md
@@ -176,7 +176,11 @@ spec:
   # ... rest of Pod configuration
 ```
 
-> **NOTICE:** Device ID format is `{BusID}`. You can find available device IDs in the node status.
+:::note
+
+Device ID format is `{BusID}`. You can find available device IDs in the node status.
+
+:::
 
 ### Finding Device UUIDs
 

--- a/docs/userguide/metax-device/metax-gpu/enable-metax-gpu-schedule.md
+++ b/docs/userguide/metax-device/metax-gpu/enable-metax-gpu-schedule.md
@@ -67,4 +67,8 @@ spec:
           metax-tech.com/gpu: 1 # requesting 1 GPU
 ```
 
-> **NOTICE:** *You can find more examples in [examples/metax folder](https://github.com/Project-HAMi/HAMi/tree/master/examples/metax/gpu)*
+:::note
+
+You can find more examples in [examples/metax folder](https://github.com/Project-HAMi/HAMi/tree/master/examples/metax/gpu)
+
+:::

--- a/docs/userguide/metax-device/metax-sgpu/enable-metax-gpu-sharing.md
+++ b/docs/userguide/metax-device/metax-sgpu/enable-metax-gpu-sharing.md
@@ -46,4 +46,8 @@ spec:
           metax-tech.com/vmemory: 4 # each GPU require 4 GiB device memory
 ```
 
-> **NOTICE:** *You can find more examples in [examples/metax folder](https://github.com/Project-HAMi/HAMi/tree/master/examples/metax/sgpu)*
+:::note
+
+You can find more examples in [examples/metax folder](https://github.com/Project-HAMi/HAMi/tree/master/examples/metax/sgpu)
+
+:::

--- a/docs/userguide/metax-device/metax-sgpu/examples/default-use.md
+++ b/docs/userguide/metax-device/metax-sgpu/examples/default-use.md
@@ -23,4 +23,8 @@ spec:
           metax-tech.com/vmemory: 4 # each GPU require 4 GiB device memory
 ```
 
-> **NOTICE:** *When a `metax-tech.com/vcore` or `metax-tech.com/vmemory` resource is not applied for, it indicates that the quota for the corresponding resource is full*
+:::note
+
+When a `metax-tech.com/vcore` or `metax-tech.com/vmemory` resource is not applied for, it indicates that the quota for the corresponding resource is full
+
+:::

--- a/docs/userguide/monitoring/device-allocation.md
+++ b/docs/userguide/monitoring/device-allocation.md
@@ -33,4 +33,8 @@ If you are using [HAMi DRA](../../installation/how-to-use-hami-dra), the metrics
 | vGPUDeviceCoreAllocated | vGPU core allocated from a container | `{devicebrand="Tesla",deviceidx="0",devicename="hami-gpu-0",deviceproductname="Tesla P4",deviceuuid="GPU-82be-83fe-3068",nodeid="k8s-node01",podname="pod-0",podnamespace="default"}` 100 |
 | vGPUDeviceMemoryAllocated | vGPU memory allocated from a container | `{devicebrand="Tesla",deviceidx="0",devicename="hami-gpu-0",deviceproductname="Tesla P4",deviceuuid="GPU-82be-83fe-3068",nodeid="k8s-node01",podname="pod-0",podnamespace="default"}` 4000 |
 
-> **NOTICE:** This is the overview of device allocation, it is NOT device real-time usage metrics. For that part, see real-time device usage.
+:::note
+
+This is the overview of device allocation, it is NOT device real-time usage metrics. For that part, see real-time device usage.
+
+:::

--- a/docs/userguide/mthreads-device/enable-mthreads-gpu-sharing.md
+++ b/docs/userguide/mthreads-device/enable-mthreads-gpu-sharing.md
@@ -31,7 +31,11 @@ title: Enable Mthreads GPU sharing
 
 * Deploy MT-CloudNative Toolkit on Mthreads nodes (Please consult your device provider to acquire its package and document)
 
-> **NOTICE:** *You can remove mt-mutating-webhook and mt-gpu-scheduler after installation(optional).*
+:::note
+
+You can remove `mt-mutating-webhook` and `mt-gpu-scheduler` after installation (optional).
+
+:::
 
 * set the 'devices.mthreads.enabled = true' when installing hami
 
@@ -64,5 +68,8 @@ spec:
           mthreads.com/sgpu-core: 8
 ```
 
-> **NOTICE:** *Each unit of sgpu-memory indicates 512M device memory*
-> **NOTICE:** *You can find more examples in [examples/mthreads folder](https://github.com/Project-HAMi/HAMi/tree/master/examples/mthreads/)*
+:::note
+
+Each unit of `sgpu-memory` represents 512 MB of device memory. More examples are available in the [examples/mthreads folder](https://github.com/Project-HAMi/HAMi/tree/master/examples/mthreads/).
+
+:::

--- a/docs/userguide/nvidia-device/examples/allocate-device-core.md
+++ b/docs/userguide/nvidia-device/examples/allocate-device-core.md
@@ -21,4 +21,8 @@ spec:
           nvidia.com/gpucores: 50 # requesting 50% of each vGPU's core resources
 ```
 
-> **NOTICE:** *HAMi implements `nvidia.com/gpucores` using time-slice, Therefore, when the core utilization is queried through the nvidia-smi command, there will be fluctuations*
+:::note
+
+HAMi implements `nvidia.com/gpucores` using time-slice, Therefore, when the core utilization is queried through the nvidia-smi command, there will be fluctuations
+
+:::

--- a/docs/userguide/nvidia-device/examples/allocate-device-memory.md
+++ b/docs/userguide/nvidia-device/examples/allocate-device-memory.md
@@ -21,4 +21,8 @@ spec:
           nvidia.com/gpumem: 3000 # each vGPU requests 3G device memory
 ```
 
-> **NOTICE:** *`nvidia.com/gpumem` can't be used together with `nvidia.com/gpumem-percentage`*
+:::note
+
+`nvidia.com/gpumem` can't be used together with `nvidia.com/gpumem-percentage`
+
+:::

--- a/docs/userguide/nvidia-device/examples/allocate-device-memory2.md
+++ b/docs/userguide/nvidia-device/examples/allocate-device-memory2.md
@@ -21,4 +21,8 @@ spec:
           nvidia.com/gpumem-percentage: 50 # each vGPU requests 50% of device memory
 ```
 
-> **NOTICE:** *`nvidia.com/gpumem` can't be used together with `nvidia.com/gpumem-percentage`*
+:::note
+
+`nvidia.com/gpumem` can't be used together with `nvidia.com/gpumem-percentage`
+
+:::

--- a/docs/userguide/nvidia-device/examples/specify-card-type-to-use.md
+++ b/docs/userguide/nvidia-device/examples/specify-card-type-to-use.md
@@ -22,4 +22,8 @@ spec:
           nvidia.com/gpu: 2 # requesting 2 vGPUs
 ```
 
-> **NOTICE:** *You can assign this task to multiple GPU types, use comma to separate. In this example, the job runs on A100 or V100.*
+:::note
+
+You can assign this task to multiple GPU types, use comma to separate. In this example, the job runs on A100 or V100.
+
+:::

--- a/docs/userguide/nvidia-device/specify-device-core-usage.md
+++ b/docs/userguide/nvidia-device/specify-device-core-usage.md
@@ -13,4 +13,8 @@ Optional, each unit of `nvidia.com/gpucores` equals 1% of device cores.
           nvidia.com/gpucores: 50 # Each GPU allocates 50% device cores.
 ```
 
-> **NOTICE:** *HAMi-core uses time-slice to limit device core usage. Therefore, there will be fluctuations when looking at GPU utilization through nvidia-smi*
+:::note
+
+HAMi-core uses time-slice to limit device core usage. Therefore, there will be fluctuations when looking at GPU utilization through nvidia-smi
+
+:::

--- a/docs/userguide/nvidia-device/specify-device-memory-usage.md
+++ b/docs/userguide/nvidia-device/specify-device-memory-usage.md
@@ -23,4 +23,8 @@ Optional, each unit of `nvidia.com/gpumem-percentage` equals 1% of device memory
           nvidia.com/gpumem-percentage: 50 # Each GPU contains 50% device memory
 ```
 
-> **NOTICE:** *`nvidia.com/gpumem` and `nvidia.com/gpumem-percentage` can't be assigned together*
+:::note
+
+`nvidia.com/gpumem` and `nvidia.com/gpumem-percentage` can't be assigned together
+
+:::

--- a/docs/userguide/nvidia-device/specify-device-uuid-to-use.md
+++ b/docs/userguide/nvidia-device/specify-device-uuid-to-use.md
@@ -13,4 +13,8 @@ metadata:
     nvidia.com/use-gpuuuid: "GPU-123456"
 ```
 
-> **NOTICE:** *Each GPU UUID is unique in a cluster, so assign a certain UUID means assigning this task to certain node with that GPU*
+:::note
+
+Each GPU UUID is unique in a cluster, so assign a certain UUID means assigning this task to certain node with that GPU
+
+:::


### PR DESCRIPTION
Replace all informal blockquote NOTICE markers with proper Docusaurus note, caution, and tip admonitions for consistent professional styling across device userguide and installation docs.

Files changed: nvidia-device, metax-device, iluvatar-device, ascend-device, enflame-device, hygon-device, mthreads-device, kunlunxin-device, awsneuron-device, monitoring, and installation docs (24 files total).