### PR TITLE
fix: replace stale README.md references with proper doc links

### DIFF
--- a/docs/installation/prerequisites.md
+++ b/docs/installation/prerequisites.md
@@ -16,7 +16,7 @@ Before installing HAMi, make sure the following tools and dependencies are prope
 
 Execute the following steps on all your GPU nodes.
 
-This README assumes pre-installation of NVIDIA drivers and the `nvidia-container-toolkit`. Additionally, it assumes configuration of the `nvidia-container-runtime` as the default low-level runtime.
+This guide assumes pre-installation of NVIDIA drivers and the `nvidia-container-toolkit`. Additionally, it assumes configuration of the `nvidia-container-runtime` as the default low-level runtime.
 
 For details see [Installing the NVIDIA Container Toolkit](https://docs.nvidia.com/datacenter/cloud-native/container-toolkit/install-guide.html).
 

--- a/docs/userguide/metax-device/metax-gpu/enable-metax-gpu-schedule.md
+++ b/docs/userguide/metax-device/metax-gpu/enable-metax-gpu-schedule.md
@@ -42,7 +42,7 @@ the GPU device plugin (gpu-device) handles fine-grained allocation based on the 
 
 - Deploy Metax GPU Extensions on metax nodes (Please consult your device provider to acquire its package and document)
 
-- Deploy HAMi according to README.md
+- Deploy HAMi using the [online installation guide](../../installation/online-installation.md)
 
 ## Running Metax jobs
 

--- a/docs/userguide/metax-device/metax-gpu/enable-metax-gpu-schedule.md
+++ b/docs/userguide/metax-device/metax-gpu/enable-metax-gpu-schedule.md
@@ -42,7 +42,7 @@ the GPU device plugin (gpu-device) handles fine-grained allocation based on the 
 
 - Deploy Metax GPU Extensions on metax nodes (Please consult your device provider to acquire its package and document)
 
-- Deploy HAMi using the [online installation guide](../../installation/online-installation.md)
+- Deploy HAMi using the [online installation guide](../../../installation/online-installation.md)
 
 ## Running Metax jobs
 

--- a/docs/userguide/metax-device/metax-sgpu/enable-metax-gpu-sharing.md
+++ b/docs/userguide/metax-device/metax-sgpu/enable-metax-gpu-sharing.md
@@ -21,7 +21,7 @@ translated: true
 
 - Deploy Metax GPU Operator on metax nodes (Please consult your device provider to obtain the installation package and documentation)
 
-- Deploy HAMi according to README.md
+- Deploy HAMi using the [online installation guide](../../installation/online-installation.md)
 
 ## Running Metax jobs
 

--- a/docs/userguide/metax-device/metax-sgpu/enable-metax-gpu-sharing.md
+++ b/docs/userguide/metax-device/metax-sgpu/enable-metax-gpu-sharing.md
@@ -21,7 +21,7 @@ translated: true
 
 - Deploy Metax GPU Operator on metax nodes (Please consult your device provider to obtain the installation package and documentation)
 
-- Deploy HAMi using the [online installation guide](../../installation/online-installation.md)
+- Deploy HAMi using the [online installation guide](../../../installation/online-installation.md)
 
 ## Running Metax jobs
 


### PR DESCRIPTION
Replace three stale \"README.md\" references that were carried over from when content lived in the repo README rather than the docs site.

- `docs/installation/prerequisites.md`: change \"This README assumes\" to \"This guide assumes\"
- `docs/userguide/metax-device/metax-gpu/enable-metax-gpu-schedule.md`: link to online installation guide instead of \"README.md\"
- `docs/userguide/metax-device/metax-sgpu/enable-metax-gpu-sharing.md`: same fix as above