### PR TITLE
fix: convert informal Note markers to admonitions in versioned docs

### DIFF
--- a/docs/userguide/iluvatar-device/enable-iluvatar-gpu-sharing.md
+++ b/docs/userguide/iluvatar-device/enable-iluvatar-gpu-sharing.md
@@ -33,7 +33,7 @@ title: Enable Iluvatar GPU Sharing
 helm install hami hami-charts/hami --set scheduler.kubeScheduler.imageTag={your kubernetes version} --set devices.iluvatar.enabled=true -n kube-system
 ```
 
-**Note:** The currently supported GPU models and resource names are defined in ([https://github.com/Project-HAMi/HAMi/blob/master/charts/hami/templates/scheduler/device-configmap.yaml](https://github.com/Project-HAMi/HAMi/blob/master/charts/hami/templates/scheduler/device-configmap.yaml)):
+The currently supported GPU models and resource names are defined in [device-configmap.yaml](https://github.com/Project-HAMi/HAMi/blob/master/charts/hami/templates/scheduler/device-configmap.yaml):
 
 ```yaml
     iluvatars:

--- a/versioned_docs/version-v1.3.0/userguide/configure.md
+++ b/versioned_docs/version-v1.3.0/userguide/configure.md
@@ -6,8 +6,12 @@ title: Configuration
 
 ## Device Configs: ConfigMap
 
-**Note:**
+:::note
+
 All the configurations listed below are managed within the hami-scheduler-device ConfigMap.
+
+:::
+
 You can update these configurations using one of the following methods:
 
 1. Directly edit the ConfigMap: If HAMi has already been successfully installed, you can manually update the hami-scheduler-device ConfigMap using the kubectl edit command to manually update the hami-scheduler-device ConfigMap.

--- a/versioned_docs/version-v2.4.1/userguide/configure.md
+++ b/versioned_docs/version-v2.4.1/userguide/configure.md
@@ -6,8 +6,12 @@ title: Configuration
 
 ## Device Configs: ConfigMap
 
-**Note:**
+:::note
+
 All the configurations listed below are managed within the hami-scheduler-device ConfigMap.
+
+:::
+
 You can update these configurations using one of the following methods:
 
 1. Directly edit the ConfigMap: If HAMi has already been successfully installed, you can manually update the hami-scheduler-device ConfigMap using the kubectl edit command to manually update the hami-scheduler-device ConfigMap.

--- a/versioned_docs/version-v2.5.0/userguide/configure.md
+++ b/versioned_docs/version-v2.5.0/userguide/configure.md
@@ -6,8 +6,12 @@ title: Configuration
 
 ## Device Configs: ConfigMap
 
-**Note:**
+:::note
+
 All the configurations listed below are managed within the hami-scheduler-device ConfigMap.
+
+:::
+
 You can update these configurations using one of the following methods:
 
 1. Directly edit the ConfigMap: If HAMi has already been successfully installed, you can manually update the hami-scheduler-device ConfigMap using the kubectl edit command to manually update the hami-scheduler-device ConfigMap.

--- a/versioned_docs/version-v2.8.0/userguide/iluvatar-device/enable-illuvatar-gpu-sharing.md
+++ b/versioned_docs/version-v2.8.0/userguide/iluvatar-device/enable-illuvatar-gpu-sharing.md
@@ -33,7 +33,7 @@ title: Enable Illuvatar GPU Sharing
 helm install hami hami-charts/hami --set scheduler.kubeScheduler.imageTag={your kubernetes version} --set devices.iluvatar.enabled=true
 ```
 
-**Note:** The currently supported GPU models and resource names are defined in (https://github.com/Project-HAMi/HAMi/blob/master/charts/hami/templates/scheduler/device-configmap.yaml):
+The currently supported GPU models and resource names are defined in [device-configmap.yaml](https://github.com/Project-HAMi/HAMi/blob/master/charts/hami/templates/scheduler/device-configmap.yaml):
 
 ```yaml
     iluvatars:


### PR DESCRIPTION
Replace four informal bold **Note:** markers in versioned documentation with proper Docusaurus admonitions or plain prose.

- versioned_docs v1.3.0, v2.4.1, v2.5.0 configure.md: wrap single-sentence note in :::note ... ::: block
- versioned_docs v2.8.0 enable-illuvatar-gpu-sharing.md: remove **Note:** prefix and fix raw URL to proper link text