### PR TITLE
fix: replace NOTICE blockquotes with admonitions in versioned docs

### DIFF
--- a/versioned_docs/version-v1.3.0/installation/uninstall.md
+++ b/versioned_docs/version-v1.3.0/installation/uninstall.md
@@ -8,4 +8,8 @@ The step to uninstall hami is simple:
 helm uninstall hami -n kube-system
 ```
 
-> **NOTICE:** *Uninstallation won't kill running tasks.*
+:::note
+
+Uninstallation won't kill running tasks.
+
+:::

--- a/versioned_docs/version-v1.3.0/userguide/ascend-device/examples/allocate-310p.md
+++ b/versioned_docs/version-v1.3.0/userguide/ascend-device/examples/allocate-310p.md
@@ -26,4 +26,8 @@ spec:
           huawei.com/Ascend310P-memory: 1024
 ```
 
-> **NOTICE:** * compute resource of Ascend910B is also limited with `huawei.com/Ascend310P-memory`, equals to the percentage of device memory allocated. *
+:::note
+
+compute resource of Ascend910B is also limited with `huawei.com/Ascend310P-memory`, equals to the percentage of device memory allocated.
+
+:::

--- a/versioned_docs/version-v1.3.0/userguide/ascend-device/examples/allocate-910b.md
+++ b/versioned_docs/version-v1.3.0/userguide/ascend-device/examples/allocate-910b.md
@@ -22,4 +22,8 @@ spec:
           huawei.com/Ascend910-memory: 2000 # requesting 2000m device memory
 ```
 
-> **NOTICE:** * compute resource of Ascend910B is also limited with `huawei.com/Ascend910-memory`, equals to the percentage of device memory allocated. *
+:::note
+
+compute resource of Ascend910B is also limited with `huawei.com/Ascend910-memory`, equals to the percentage of device memory allocated.
+
+:::

--- a/versioned_docs/version-v1.3.0/userguide/cambricon-device/enable-cambricon-mlu-sharing.md
+++ b/versioned_docs/version-v1.3.0/userguide/cambricon-device/enable-cambricon-mlu-sharing.md
@@ -63,4 +63,8 @@ spec:
           cambricon.com/mlu.smlu.vcore: 10 # each MLU requesting 10% MLU device core
 ```
 
-> **NOTICE:** *`vmemory` and `vcore` can only work when `cambricon.com/mlunum=1`* 
+:::note
+
+`vmemory` and `vcore` can only work when `cambricon.com/mlunum=1`*
+
+:::

--- a/versioned_docs/version-v1.3.0/userguide/cambricon-device/specify-device-core-usage.md
+++ b/versioned_docs/version-v1.3.0/userguide/cambricon-device/specify-device-core-usage.md
@@ -14,4 +14,8 @@ Optional, each unit of `cambricon.com/mlu.smlu.vcore` equals to 1% device cores.
           cambricon.com/mlu.smlu.vcore: "10" # Each MLU contains 10% device cores
 ```
 
-> **NOTICE:** *Depending on the parameters of cambricon-device-plugin, resource name can be `cambricon.com/mlu370.smlu.vcore` or other types*
+:::note
+
+Depending on the parameters of cambricon-device-plugin, resource name can be `cambricon.com/mlu370.smlu.vcore` or other types
+
+:::

--- a/versioned_docs/version-v1.3.0/userguide/cambricon-device/specify-device-memory-usage.md
+++ b/versioned_docs/version-v1.3.0/userguide/cambricon-device/specify-device-memory-usage.md
@@ -14,4 +14,8 @@ Optional, Each unit of `cambricon.com/mlu.smlu.vmemory` equals to 1% of device m
           cambricon.com/mlu.smlu.vmemory: "20" # Each GPU contains 20% device memory
 ```
 
-> **NOTICE:** *Depending on the parameters of cambricon-device-plugin, resource name can be `cambricon.com/mlu370.smlu.vmemory` or other types*
+:::note
+
+Depending on the parameters of cambricon-device-plugin, resource name can be `cambricon.com/mlu370.smlu.vmemory` or other types
+
+:::

--- a/versioned_docs/version-v1.3.0/userguide/hygon-device/specify-device-core-usage.md
+++ b/versioned_docs/version-v1.3.0/userguide/hygon-device/specify-device-core-usage.md
@@ -14,4 +14,8 @@ Optional, each unit of `cambricon.com/mlu.smlu.vcore` equals to 1% device cores.
           cambricon.com/mlu.smlu.vcore: "10" # Each MLU contains 10% device cores
 ```
 
-> **NOTICE:** *Depending on the parameters of cambricon-device-plugin, resource name can be `cambricon.com/mlu370.smlu.vcore` or other types*
+:::note
+
+Depending on the parameters of cambricon-device-plugin, resource name can be `cambricon.com/mlu370.smlu.vcore` or other types
+
+:::

--- a/versioned_docs/version-v1.3.0/userguide/metax-device/enable-metax-gpu-schedule.md
+++ b/versioned_docs/version-v1.3.0/userguide/metax-device/enable-metax-gpu-schedule.md
@@ -63,4 +63,8 @@ spec:
           metax-tech.com/gpu: 1 # requesting 1 vGPUs
 ```
 
-> **NOTICE2:** *You can find more examples in examples folder
+:::note
+
+You can find more examples in examples folder
+
+:::

--- a/versioned_docs/version-v1.3.0/userguide/mthreads-device/enable-mthreads-gpu-sharing.md
+++ b/versioned_docs/version-v1.3.0/userguide/mthreads-device/enable-mthreads-gpu-sharing.md
@@ -31,7 +31,11 @@ title: Enable Mthreads GPU sharing
 
 * Deploy MT-CloudNative Toolkit on mthreads nodes (Please consult your device provider to acquire its package and document)
 
-> **NOTICE:** *You can remove mt-mutating-webhook and mt-gpu-scheduler after installation(optional).*
+:::note
+
+You can remove mt-mutating-webhook and mt-gpu-scheduler after installation(optional).
+
+:::
 
 * set the 'devices.mthreads.enabled = true' when installing hami
 
@@ -64,8 +68,16 @@ spec:
           mthreads.com/sgpu-core: 8
 ```
 
-> **NOTICE1:** *Each unit of sgpu-memory indicates 512M device memory*
+:::note
 
-> **NOTICE2:** *You can find more examples in examples folder*
+Each unit of sgpu-memory indicates 512M device memory
+
+:::
+
+:::note
+
+You can find more examples in examples folder
+
+:::
 
     

--- a/versioned_docs/version-v1.3.0/userguide/nvidia-device/examples/allocate-device-core.md
+++ b/versioned_docs/version-v1.3.0/userguide/nvidia-device/examples/allocate-device-core.md
@@ -22,4 +22,8 @@ spec:
           nvidia.com/gpucores: 50 # requesting 50% of each vGPU's core resources
 ```
 
-> **NOTICE:** *HAMi implements `nvidia.com/gpucores` using time-slice, Therefore, when the core utilization is queried through the nvidia-smi command, there will be fluctuations*
+:::note
+
+HAMi implements `nvidia.com/gpucores` using time-slice, Therefore, when the core utilization is queried through the nvidia-smi command, there will be fluctuations
+
+:::

--- a/versioned_docs/version-v1.3.0/userguide/nvidia-device/examples/allocate-device-memory.md
+++ b/versioned_docs/version-v1.3.0/userguide/nvidia-device/examples/allocate-device-memory.md
@@ -22,4 +22,8 @@ spec:
           nvidia.com/gpumem: 3000 # each vGPU requests 3G device memory
 ```
 
-> **NOTICE:** *`nvidia.com/gpumem` can't be used together with `nvidia.com/gpumem-percentage`*
+:::note
+
+`nvidia.com/gpumem` can't be used together with `nvidia.com/gpumem-percentage`
+
+:::

--- a/versioned_docs/version-v1.3.0/userguide/nvidia-device/examples/allocate-device-memory2.md
+++ b/versioned_docs/version-v1.3.0/userguide/nvidia-device/examples/allocate-device-memory2.md
@@ -22,4 +22,8 @@ spec:
           nvidia.com/gpumem-percentage: 50 # each vGPU requests 50% of device memory
 ```
 
-> **NOTICE:** *`nvidia.com/gpumem` can't be used together with `nvidia.com/gpumem-percentage`*
+:::note
+
+`nvidia.com/gpumem` can't be used together with `nvidia.com/gpumem-percentage`
+
+:::

--- a/versioned_docs/version-v1.3.0/userguide/nvidia-device/examples/specify-card-type-to-use.md
+++ b/versioned_docs/version-v1.3.0/userguide/nvidia-device/examples/specify-card-type-to-use.md
@@ -24,4 +24,8 @@ spec:
           nvidia.com/gpu: 2 # requesting 2 vGPUs
 ```
 
-> **NOTICE:** * You can assign this task to multiple GPU types, use comma to separate,In this example, the job targets A100 or V100*
+:::note
+
+You can assign this task to multiple GPU types, use comma to separate,In this example, the job targets A100 or V100
+
+:::

--- a/versioned_docs/version-v1.3.0/userguide/nvidia-device/specify-device-core-usage.md
+++ b/versioned_docs/version-v1.3.0/userguide/nvidia-device/specify-device-core-usage.md
@@ -14,4 +14,8 @@ Optional, each unit of `nvidia.com/gpucores` equals to 1% device cores.
           nvidia.com/gpucores: 50 # Each GPU allocates 50% device cores.
 ```
 
-> **NOTICE:** * HAMi-core uses time-slice to limit device core usage. Therefore, there will be fluctuations when looking at GPU utilization through nvidia-smi*
+:::note
+
+HAMi-core uses time-slice to limit device core usage. Therefore, there will be fluctuations when looking at GPU utilization through nvidia-smi
+
+:::

--- a/versioned_docs/version-v1.3.0/userguide/nvidia-device/specify-device-memory-usage.md
+++ b/versioned_docs/version-v1.3.0/userguide/nvidia-device/specify-device-memory-usage.md
@@ -24,4 +24,8 @@ Optional, each unit of `nvidia.com/gpumem-percentage` equals to 1% percentage of
           nvidia.com/gpumem-percentage: 50 # Each GPU contains 50% device memory
 ```
 
-> **NOTICE:** *`nvidia.com/gpumem` and `nvidia.com/gpumem-percentage` can't be assigned together*
+:::note
+
+`nvidia.com/gpumem` and `nvidia.com/gpumem-percentage` can't be assigned together
+
+:::

--- a/versioned_docs/version-v1.3.0/userguide/nvidia-device/specify-device-uuid-to-use.md
+++ b/versioned_docs/version-v1.3.0/userguide/nvidia-device/specify-device-uuid-to-use.md
@@ -14,4 +14,8 @@ metadata:
     nvidia.com/use-gpuuuid: "GPU-123456"
 ```
 
-> **NOTICE:** *Each GPU UUID is unique in a cluster, so assign a certain UUID means assigning this task to certain node with that GPU*
+:::note
+
+Each GPU UUID is unique in a cluster, so assign a certain UUID means assigning this task to certain node with that GPU
+
+:::

--- a/versioned_docs/version-v2.4.1/installation/uninstall.md
+++ b/versioned_docs/version-v2.4.1/installation/uninstall.md
@@ -8,4 +8,8 @@ The step to uninstall hami is simple:
 helm uninstall hami -n kube-system
 ```
 
-> **NOTICE:** *Uninstallation won't kill running tasks.*
+:::note
+
+Uninstallation won't kill running tasks.
+
+:::

--- a/versioned_docs/version-v2.4.1/userguide/ascend-device/examples/allocate-310p.md
+++ b/versioned_docs/version-v2.4.1/userguide/ascend-device/examples/allocate-310p.md
@@ -26,4 +26,8 @@ spec:
           huawei.com/Ascend310P-memory: 1024
 ```
 
-> **NOTICE:** * compute resource of Ascend910B is also limited with `huawei.com/Ascend310P-memory`, equals to the percentage of device memory allocated. *
+:::note
+
+compute resource of Ascend910B is also limited with `huawei.com/Ascend310P-memory`, equals to the percentage of device memory allocated.
+
+:::

--- a/versioned_docs/version-v2.4.1/userguide/ascend-device/examples/allocate-910b.md
+++ b/versioned_docs/version-v2.4.1/userguide/ascend-device/examples/allocate-910b.md
@@ -22,4 +22,8 @@ spec:
           huawei.com/Ascend910-memory: 2000 # requesting 2000m device memory
 ```
 
-> **NOTICE:** * compute resource of Ascend910B is also limited with `huawei.com/Ascend910-memory`, equals to the percentage of device memory allocated. *
+:::note
+
+compute resource of Ascend910B is also limited with `huawei.com/Ascend910-memory`, equals to the percentage of device memory allocated.
+
+:::

--- a/versioned_docs/version-v2.4.1/userguide/cambricon-device/enable-cambricon-mlu-sharing.md
+++ b/versioned_docs/version-v2.4.1/userguide/cambricon-device/enable-cambricon-mlu-sharing.md
@@ -63,4 +63,8 @@ spec:
           cambricon.com/mlu.smlu.vcore: 10 # each MLU requesting 10% MLU device core
 ```
 
-> **NOTICE:** *`vmemory` and `vcore` can only work when `cambricon.com/mlunum=1`* 
+:::note
+
+`vmemory` and `vcore` can only work when `cambricon.com/mlunum=1`*
+
+:::

--- a/versioned_docs/version-v2.4.1/userguide/cambricon-device/specify-device-core-usage.md
+++ b/versioned_docs/version-v2.4.1/userguide/cambricon-device/specify-device-core-usage.md
@@ -14,4 +14,8 @@ Optional, each unit of `cambricon.com/mlu.smlu.vcore` equals to 1% device cores.
           cambricon.com/mlu.smlu.vcore: "10" # Each MLU contains 10% device cores
 ```
 
-> **NOTICE:** *Depending on the parameters of cambricon-device-plugin, resource name can be `cambricon.com/mlu370.smlu.vcore` or other types*
+:::note
+
+Depending on the parameters of cambricon-device-plugin, resource name can be `cambricon.com/mlu370.smlu.vcore` or other types
+
+:::

--- a/versioned_docs/version-v2.4.1/userguide/cambricon-device/specify-device-memory-usage.md
+++ b/versioned_docs/version-v2.4.1/userguide/cambricon-device/specify-device-memory-usage.md
@@ -14,4 +14,8 @@ Optional, Each unit of `cambricon.com/mlu.smlu.vmemory` equals to 1% of device m
           cambricon.com/mlu.smlu.vmemory: "20" # Each GPU contains 20% device memory
 ```
 
-> **NOTICE:** *Depending on the parameters of cambricon-device-plugin, resource name can be `cambricon.com/mlu370.smlu.vmemory` or other types*
+:::note
+
+Depending on the parameters of cambricon-device-plugin, resource name can be `cambricon.com/mlu370.smlu.vmemory` or other types
+
+:::

--- a/versioned_docs/version-v2.4.1/userguide/hygon-device/specify-device-core-usage.md
+++ b/versioned_docs/version-v2.4.1/userguide/hygon-device/specify-device-core-usage.md
@@ -14,4 +14,8 @@ Optional, each unit of `cambricon.com/mlu.smlu.vcore` equals to 1% device cores.
           cambricon.com/mlu.smlu.vcore: "10" # Each MLU contains 10% device cores
 ```
 
-> **NOTICE:** *Depending on the parameters of cambricon-device-plugin, resource name can be `cambricon.com/mlu370.smlu.vcore` or other types*
+:::note
+
+Depending on the parameters of cambricon-device-plugin, resource name can be `cambricon.com/mlu370.smlu.vcore` or other types
+
+:::

--- a/versioned_docs/version-v2.4.1/userguide/metax-device/enable-metax-gpu-schedule.md
+++ b/versioned_docs/version-v2.4.1/userguide/metax-device/enable-metax-gpu-schedule.md
@@ -62,6 +62,10 @@ spec:
           metax-tech.com/gpu: 1 # requesting 1 vGPUs
 ```
 
-> **NOTICE2:** *You can find more examples in examples folder
+:::note
+
+You can find more examples in examples folder
+
+:::
 
    

--- a/versioned_docs/version-v2.4.1/userguide/mthreads-device/enable-mthreads-gpu-sharing.md
+++ b/versioned_docs/version-v2.4.1/userguide/mthreads-device/enable-mthreads-gpu-sharing.md
@@ -31,7 +31,11 @@ title: Enable Mthreads GPU sharing
 
 * Deploy MT-CloudNative Toolkit on mthreads nodes (Please consult your device provider to acquire its package and document)
 
-> **NOTICE:** *You can remove mt-mutating-webhook and mt-gpu-scheduler after installation(optional).*
+:::note
+
+You can remove mt-mutating-webhook and mt-gpu-scheduler after installation(optional).
+
+:::
 
 * set the 'devices.mthreads.enabled = true' when installing hami
 
@@ -64,8 +68,16 @@ spec:
           mthreads.com/sgpu-core: 8
 ```
 
-> **NOTICE1:** *Each unit of sgpu-memory indicates 512M device memory*
+:::note
 
-> **NOTICE2:** *You can find more examples in examples folder*
+Each unit of sgpu-memory indicates 512M device memory
+
+:::
+
+:::note
+
+You can find more examples in examples folder
+
+:::
 
     

--- a/versioned_docs/version-v2.4.1/userguide/nvidia-device/examples/allocate-device-core.md
+++ b/versioned_docs/version-v2.4.1/userguide/nvidia-device/examples/allocate-device-core.md
@@ -22,4 +22,8 @@ spec:
           nvidia.com/gpucores: 50 # requesting 50% of each vGPU's core resources
 ```
 
-> **NOTICE:** *HAMi implements `nvidia.com/gpucores` using time-slice, Therefore, when the core utilization is queried through the nvidia-smi command, there will be fluctuations*
+:::note
+
+HAMi implements `nvidia.com/gpucores` using time-slice, Therefore, when the core utilization is queried through the nvidia-smi command, there will be fluctuations
+
+:::

--- a/versioned_docs/version-v2.4.1/userguide/nvidia-device/examples/allocate-device-memory.md
+++ b/versioned_docs/version-v2.4.1/userguide/nvidia-device/examples/allocate-device-memory.md
@@ -22,4 +22,8 @@ spec:
           nvidia.com/gpumem: 3000 # each vGPU requests 3G device memory
 ```
 
-> **NOTICE:** *`nvidia.com/gpumem` can't be used together with `nvidia.com/gpumem-percentage`*
+:::note
+
+`nvidia.com/gpumem` can't be used together with `nvidia.com/gpumem-percentage`
+
+:::

--- a/versioned_docs/version-v2.4.1/userguide/nvidia-device/examples/allocate-device-memory2.md
+++ b/versioned_docs/version-v2.4.1/userguide/nvidia-device/examples/allocate-device-memory2.md
@@ -22,4 +22,8 @@ spec:
           nvidia.com/gpumem-percentage: 50 # each vGPU requests 50% of device memory
 ```
 
-> **NOTICE:** *`nvidia.com/gpumem` can't be used together with `nvidia.com/gpumem-percentage`*
+:::note
+
+`nvidia.com/gpumem` can't be used together with `nvidia.com/gpumem-percentage`
+
+:::

--- a/versioned_docs/version-v2.4.1/userguide/nvidia-device/examples/specify-card-type-to-use.md
+++ b/versioned_docs/version-v2.4.1/userguide/nvidia-device/examples/specify-card-type-to-use.md
@@ -24,4 +24,8 @@ spec:
           nvidia.com/gpu: 2 # requesting 2 vGPUs
 ```
 
-> **NOTICE:** * You can assign this task to multiple GPU types, use comma to separate,In this example, the job targets A100 or V100*
+:::note
+
+You can assign this task to multiple GPU types, use comma to separate,In this example, the job targets A100 or V100
+
+:::

--- a/versioned_docs/version-v2.4.1/userguide/nvidia-device/specify-device-core-usage.md
+++ b/versioned_docs/version-v2.4.1/userguide/nvidia-device/specify-device-core-usage.md
@@ -14,4 +14,8 @@ Optional, each unit of `nvidia.com/gpucores` equals to 1% device cores.
           nvidia.com/gpucores: 50 # Each GPU allocates 50% device cores.
 ```
 
-> **NOTICE:** * HAMi-core uses time-slice to limit device core usage. Therefore, there will be fluctuations when looking at GPU utilization through nvidia-smi*
+:::note
+
+HAMi-core uses time-slice to limit device core usage. Therefore, there will be fluctuations when looking at GPU utilization through nvidia-smi
+
+:::

--- a/versioned_docs/version-v2.4.1/userguide/nvidia-device/specify-device-memory-usage.md
+++ b/versioned_docs/version-v2.4.1/userguide/nvidia-device/specify-device-memory-usage.md
@@ -24,4 +24,8 @@ Optional, each unit of `nvidia.com/gpumem-percentage` equals to 1% percentage of
           nvidia.com/gpumem-percentage: 50 # Each GPU contains 50% device memory
 ```
 
-> **NOTICE:** *`nvidia.com/gpumem` and `nvidia.com/gpumem-percentage` can't be assigned together*
+:::note
+
+`nvidia.com/gpumem` and `nvidia.com/gpumem-percentage` can't be assigned together
+
+:::

--- a/versioned_docs/version-v2.4.1/userguide/nvidia-device/specify-device-uuid-to-use.md
+++ b/versioned_docs/version-v2.4.1/userguide/nvidia-device/specify-device-uuid-to-use.md
@@ -14,4 +14,8 @@ metadata:
     nvidia.com/use-gpuuuid: "GPU-123456"
 ```
 
-> **NOTICE:** *Each GPU UUID is unique in a cluster, so assign a certain UUID means assigning this task to certain node with that GPU*
+:::note
+
+Each GPU UUID is unique in a cluster, so assign a certain UUID means assigning this task to certain node with that GPU
+
+:::

--- a/versioned_docs/version-v2.5.0/installation/uninstall.md
+++ b/versioned_docs/version-v2.5.0/installation/uninstall.md
@@ -8,4 +8,8 @@ The step to uninstall hami is simple:
 helm uninstall hami -n kube-system
 ```
 
-> **NOTICE:** *Uninstallation won't kill running tasks.*
+:::note
+
+Uninstallation won't kill running tasks.
+
+:::

--- a/versioned_docs/version-v2.5.0/userguide/ascend-device/examples/allocate-310p.md
+++ b/versioned_docs/version-v2.5.0/userguide/ascend-device/examples/allocate-310p.md
@@ -26,4 +26,8 @@ spec:
           huawei.com/Ascend310P-memory: 1024
 ```
 
-> **NOTICE:** * compute resource of Ascend910B is also limited with `huawei.com/Ascend310P-memory`, equals to the percentage of device memory allocated. *
+:::note
+
+compute resource of Ascend910B is also limited with `huawei.com/Ascend310P-memory`, equals to the percentage of device memory allocated.
+
+:::

--- a/versioned_docs/version-v2.5.0/userguide/ascend-device/examples/allocate-910b.md
+++ b/versioned_docs/version-v2.5.0/userguide/ascend-device/examples/allocate-910b.md
@@ -22,4 +22,8 @@ spec:
           huawei.com/Ascend910-memory: 2000 # requesting 2000m device memory
 ```
 
-> **NOTICE:** * compute resource of Ascend910B is also limited with `huawei.com/Ascend910-memory`, equals to the percentage of device memory allocated. *
+:::note
+
+compute resource of Ascend910B is also limited with `huawei.com/Ascend910-memory`, equals to the percentage of device memory allocated.
+
+:::

--- a/versioned_docs/version-v2.5.0/userguide/cambricon-device/enable-cambricon-mlu-sharing.md
+++ b/versioned_docs/version-v2.5.0/userguide/cambricon-device/enable-cambricon-mlu-sharing.md
@@ -63,4 +63,8 @@ spec:
           cambricon.com/mlu.smlu.vcore: 10 # each MLU requesting 10% MLU device core
 ```
 
-> **NOTICE:** *`vmemory` and `vcore` can only work when `cambricon.com/mlunum=1`* 
+:::note
+
+`vmemory` and `vcore` can only work when `cambricon.com/mlunum=1`*
+
+:::

--- a/versioned_docs/version-v2.5.0/userguide/cambricon-device/specify-device-core-usage.md
+++ b/versioned_docs/version-v2.5.0/userguide/cambricon-device/specify-device-core-usage.md
@@ -14,4 +14,8 @@ Optional, each unit of `cambricon.com/mlu.smlu.vcore` equals to 1% device cores.
           cambricon.com/mlu.smlu.vcore: "10" # Each MLU contains 10% device cores
 ```
 
-> **NOTICE:** *Depending on the parameters of cambricon-device-plugin, resource name can be `cambricon.com/mlu370.smlu.vcore` or other types*
+:::note
+
+Depending on the parameters of cambricon-device-plugin, resource name can be `cambricon.com/mlu370.smlu.vcore` or other types
+
+:::

--- a/versioned_docs/version-v2.5.0/userguide/cambricon-device/specify-device-memory-usage.md
+++ b/versioned_docs/version-v2.5.0/userguide/cambricon-device/specify-device-memory-usage.md
@@ -14,4 +14,8 @@ Optional, Each unit of `cambricon.com/mlu.smlu.vmemory` equals to 1% of device m
           cambricon.com/mlu.smlu.vmemory: "20" # Each GPU contains 20% device memory
 ```
 
-> **NOTICE:** *Depending on the parameters of cambricon-device-plugin, resource name can be `cambricon.com/mlu370.smlu.vmemory` or other types*
+:::note
+
+Depending on the parameters of cambricon-device-plugin, resource name can be `cambricon.com/mlu370.smlu.vmemory` or other types
+
+:::

--- a/versioned_docs/version-v2.5.0/userguide/enflame-device/enable-enflame-gpu-sharing.md
+++ b/versioned_docs/version-v2.5.0/userguide/enflame-device/enable-enflame-gpu-sharing.md
@@ -25,7 +25,11 @@ title: Enable Enflame GCU sharing
 
 * Deploy gcushare-device-plugin on enflame nodes (Please consult your device provider to acquire its package and document)
 
-> **NOTICE:** *Install only gpushare-device-plugin, don't install gpu-scheduler-plugin package.*
+:::note
+
+Install only gpushare-device-plugin, don't install gpu-scheduler-plugin package.
+
+:::
 
 > **NOTE:** The default resource names are:
 > - `enflame.com/vgcu` for GCU count, only support 1 now.
@@ -77,7 +81,11 @@ spec:
           enflame.com/vgcu-percentage: 22
 ```
 
-> **NOTICE:** *You can find more examples in examples folder*
+:::note
+
+You can find more examples in examples folder
+
+:::
 
 ## Device UUID Selection
 

--- a/versioned_docs/version-v2.5.0/userguide/hygon-device/specify-device-core-usage.md
+++ b/versioned_docs/version-v2.5.0/userguide/hygon-device/specify-device-core-usage.md
@@ -14,4 +14,8 @@ Optional, each unit of `cambricon.com/mlu.smlu.vcore` equals to 1% device cores.
           cambricon.com/mlu.smlu.vcore: "10" # Each MLU contains 10% device cores
 ```
 
-> **NOTICE:** *Depending on the parameters of cambricon-device-plugin, resource name can be `cambricon.com/mlu370.smlu.vcore` or other types*
+:::note
+
+Depending on the parameters of cambricon-device-plugin, resource name can be `cambricon.com/mlu370.smlu.vcore` or other types
+
+:::

--- a/versioned_docs/version-v2.5.0/userguide/iluvatar-device/enable-iluvatar-gpu-sharing.md
+++ b/versioned_docs/version-v2.5.0/userguide/iluvatar-device/enable-iluvatar-gpu-sharing.md
@@ -25,7 +25,11 @@ title: Enable Iluvatar GCU sharing
 
 * Deploy gpu-manager on iluvatar nodes (Please consult your device provider to acquire its package and document)
 
-> **NOTICE:** *Install only gpu-manager, don't install gpu-admission package.*
+:::note
+
+Install only gpu-manager, don't install gpu-admission package.
+
+:::
 
 * Identify the resource name about core and memory usage(i.e 'iluvatar.ai/vcuda-core', 'iluvatar.ai/vcuda-memory')
 
@@ -95,9 +99,17 @@ spec:
         iluvatar.ai/vcuda-memory: 64
 ```
 
-> **NOTICE1:** *Each unit of vcuda-memory indicates 256M device memory*
+:::note
 
-> **NOTICE2:** *You can find more examples in examples folder*
+Each unit of vcuda-memory indicates 256M device memory
+
+:::
+
+:::note
+
+You can find more examples in examples folder
+
+:::
 
 ## Notes
 

--- a/versioned_docs/version-v2.5.0/userguide/metax-device/enable-metax-gpu-schedule.md
+++ b/versioned_docs/version-v2.5.0/userguide/metax-device/enable-metax-gpu-schedule.md
@@ -62,6 +62,10 @@ spec:
           metax-tech.com/gpu: 1 # requesting 1 vGPUs
 ```
 
-> **NOTICE2:** *You can find more examples in examples folder
+:::note
+
+You can find more examples in examples folder
+
+:::
 
    

--- a/versioned_docs/version-v2.5.0/userguide/metax-device/enable-metax-gpu-sharing.md
+++ b/versioned_docs/version-v2.5.0/userguide/metax-device/enable-metax-gpu-sharing.md
@@ -54,4 +54,8 @@ spec:
           metax-tech.com/vmemory: 4 # each GPU require 4 GiB device memory
 ```
 
-> **NOTICE1:** *You can find more examples in examples/sgpu folder*
+:::note
+
+You can find more examples in examples/sgpu folder
+
+:::

--- a/versioned_docs/version-v2.5.0/userguide/mthreads-device/enable-mthreads-gpu-sharing.md
+++ b/versioned_docs/version-v2.5.0/userguide/mthreads-device/enable-mthreads-gpu-sharing.md
@@ -31,7 +31,11 @@ title: Enable Mthreads GPU sharing
 
 * Deploy MT-CloudNative Toolkit on mthreads nodes (Please consult your device provider to acquire its package and document)
 
-> **NOTICE:** *You can remove mt-mutating-webhook and mt-gpu-scheduler after installation(optional).*
+:::note
+
+You can remove mt-mutating-webhook and mt-gpu-scheduler after installation(optional).
+
+:::
 
 * set the 'devices.mthreads.enabled = true' when installing hami
 
@@ -64,8 +68,16 @@ spec:
           mthreads.com/sgpu-core: 8
 ```
 
-> **NOTICE1:** *Each unit of sgpu-memory indicates 512M device memory*
+:::note
 
-> **NOTICE2:** *You can find more examples in examples folder*
+Each unit of sgpu-memory indicates 512M device memory
+
+:::
+
+:::note
+
+You can find more examples in examples folder
+
+:::
 
     

--- a/versioned_docs/version-v2.5.0/userguide/nvidia-device/examples/allocate-device-core.md
+++ b/versioned_docs/version-v2.5.0/userguide/nvidia-device/examples/allocate-device-core.md
@@ -22,4 +22,8 @@ spec:
           nvidia.com/gpucores: 50 # requesting 50% of each vGPU's core resources
 ```
 
-> **NOTICE:** *HAMi implements `nvidia.com/gpucores` using time-slice, Therefore, when the core utilization is queried through the nvidia-smi command, there will be fluctuations*
+:::note
+
+HAMi implements `nvidia.com/gpucores` using time-slice, Therefore, when the core utilization is queried through the nvidia-smi command, there will be fluctuations
+
+:::

--- a/versioned_docs/version-v2.5.0/userguide/nvidia-device/examples/allocate-device-memory.md
+++ b/versioned_docs/version-v2.5.0/userguide/nvidia-device/examples/allocate-device-memory.md
@@ -22,4 +22,8 @@ spec:
           nvidia.com/gpumem: 3000 # each vGPU requests 3G device memory
 ```
 
-> **NOTICE:** *`nvidia.com/gpumem` can't be used together with `nvidia.com/gpumem-percentage`*
+:::note
+
+`nvidia.com/gpumem` can't be used together with `nvidia.com/gpumem-percentage`
+
+:::

--- a/versioned_docs/version-v2.5.0/userguide/nvidia-device/examples/allocate-device-memory2.md
+++ b/versioned_docs/version-v2.5.0/userguide/nvidia-device/examples/allocate-device-memory2.md
@@ -22,4 +22,8 @@ spec:
           nvidia.com/gpumem-percentage: 50 # each vGPU requests 50% of device memory
 ```
 
-> **NOTICE:** *`nvidia.com/gpumem` can't be used together with `nvidia.com/gpumem-percentage`*
+:::note
+
+`nvidia.com/gpumem` can't be used together with `nvidia.com/gpumem-percentage`
+
+:::

--- a/versioned_docs/version-v2.5.0/userguide/nvidia-device/examples/specify-card-type-to-use.md
+++ b/versioned_docs/version-v2.5.0/userguide/nvidia-device/examples/specify-card-type-to-use.md
@@ -24,4 +24,8 @@ spec:
           nvidia.com/gpu: 2 # requesting 2 vGPUs
 ```
 
-> **NOTICE:** * You can assign this task to multiple GPU types, use comma to separate,In this example, the job targets A100 or V100*
+:::note
+
+You can assign this task to multiple GPU types, use comma to separate,In this example, the job targets A100 or V100
+
+:::

--- a/versioned_docs/version-v2.5.0/userguide/nvidia-device/specify-device-core-usage.md
+++ b/versioned_docs/version-v2.5.0/userguide/nvidia-device/specify-device-core-usage.md
@@ -14,4 +14,8 @@ Optional, each unit of `nvidia.com/gpucores` equals to 1% device cores.
           nvidia.com/gpucores: 50 # Each GPU allocates 50% device cores.
 ```
 
-> **NOTICE:** * HAMi-core uses time-slice to limit device core usage. Therefore, there will be fluctuations when looking at GPU utilization through nvidia-smi*
+:::note
+
+HAMi-core uses time-slice to limit device core usage. Therefore, there will be fluctuations when looking at GPU utilization through nvidia-smi
+
+:::

--- a/versioned_docs/version-v2.5.0/userguide/nvidia-device/specify-device-memory-usage.md
+++ b/versioned_docs/version-v2.5.0/userguide/nvidia-device/specify-device-memory-usage.md
@@ -24,4 +24,8 @@ Optional, each unit of `nvidia.com/gpumem-percentage` equals to 1% percentage of
           nvidia.com/gpumem-percentage: 50 # Each GPU contains 50% device memory
 ```
 
-> **NOTICE:** *`nvidia.com/gpumem` and `nvidia.com/gpumem-percentage` can't be assigned together*
+:::note
+
+`nvidia.com/gpumem` and `nvidia.com/gpumem-percentage` can't be assigned together
+
+:::

--- a/versioned_docs/version-v2.5.0/userguide/nvidia-device/specify-device-uuid-to-use.md
+++ b/versioned_docs/version-v2.5.0/userguide/nvidia-device/specify-device-uuid-to-use.md
@@ -14,4 +14,8 @@ metadata:
     nvidia.com/use-gpuuuid: "GPU-123456"
 ```
 
-> **NOTICE:** *Each GPU UUID is unique in a cluster, so assign a certain UUID means assigning this task to certain node with that GPU*
+:::note
+
+Each GPU UUID is unique in a cluster, so assign a certain UUID means assigning this task to certain node with that GPU
+
+:::

--- a/versioned_docs/version-v2.5.1/installation/uninstall.md
+++ b/versioned_docs/version-v2.5.1/installation/uninstall.md
@@ -8,4 +8,8 @@ The step to uninstall hami is simple:
 helm uninstall hami -n kube-system
 ```
 
-> **NOTICE:** *Uninstallation won't kill running tasks.*
+:::note
+
+Uninstallation won't kill running tasks.
+
+:::

--- a/versioned_docs/version-v2.5.1/userguide/ascend-device/examples/allocate-310p.md
+++ b/versioned_docs/version-v2.5.1/userguide/ascend-device/examples/allocate-310p.md
@@ -24,4 +24,8 @@ spec:
           huawei.com/Ascend310P-memory: 1024
 ```
 
-> **NOTICE:** *compute resource of Ascend910B is also limited with `huawei.com/Ascend310P-memory`, equals to the percentage of device memory allocated.*
+:::note
+
+compute resource of Ascend910B is also limited with `huawei.com/Ascend310P-memory`, equals to the percentage of device memory allocated.
+
+:::

--- a/versioned_docs/version-v2.5.1/userguide/ascend-device/examples/allocate-910b.md
+++ b/versioned_docs/version-v2.5.1/userguide/ascend-device/examples/allocate-910b.md
@@ -20,4 +20,8 @@ spec:
           huawei.com/Ascend910-memory: 2000 # requesting 2000m device memory
 ```
 
-> **NOTICE:** *compute resource of Ascend910B is also limited with `huawei.com/Ascend910-memory`, equals to the percentage of device memory allocated.*
+:::note
+
+compute resource of Ascend910B is also limited with `huawei.com/Ascend910-memory`, equals to the percentage of device memory allocated.
+
+:::

--- a/versioned_docs/version-v2.5.1/userguide/cambricon-device/enable-cambricon-mlu-sharing.md
+++ b/versioned_docs/version-v2.5.1/userguide/cambricon-device/enable-cambricon-mlu-sharing.md
@@ -63,4 +63,8 @@ spec:
           cambricon.com/mlu.smlu.vcore: 10 # each MLU requesting 10% MLU device core
 ```
 
-> **NOTICE:** *`vmemory` and `vcore` can only work when `cambricon.com/mlunum=1`* 
+:::note
+
+`vmemory` and `vcore` can only work when `cambricon.com/mlunum=1`*
+
+:::

--- a/versioned_docs/version-v2.5.1/userguide/cambricon-device/specify-device-core-usage.md
+++ b/versioned_docs/version-v2.5.1/userguide/cambricon-device/specify-device-core-usage.md
@@ -14,4 +14,8 @@ Optional, each unit of `cambricon.com/mlu.smlu.vcore` equals to 1% device cores.
           cambricon.com/mlu.smlu.vcore: "10" # Each MLU contains 10% device cores
 ```
 
-> **NOTICE:** *Depending on the parameters of cambricon-device-plugin, resource name can be `cambricon.com/mlu370.smlu.vcore` or other types*
+:::note
+
+Depending on the parameters of cambricon-device-plugin, resource name can be `cambricon.com/mlu370.smlu.vcore` or other types
+
+:::

--- a/versioned_docs/version-v2.5.1/userguide/cambricon-device/specify-device-memory-usage.md
+++ b/versioned_docs/version-v2.5.1/userguide/cambricon-device/specify-device-memory-usage.md
@@ -14,4 +14,8 @@ Optional, Each unit of `cambricon.com/mlu.smlu.vmemory` equals to 1% of device m
           cambricon.com/mlu.smlu.vmemory: "20" # Each GPU contains 20% device memory
 ```
 
-> **NOTICE:** *Depending on the parameters of cambricon-device-plugin, resource name can be `cambricon.com/mlu370.smlu.vmemory` or other types*
+:::note
+
+Depending on the parameters of cambricon-device-plugin, resource name can be `cambricon.com/mlu370.smlu.vmemory` or other types
+
+:::

--- a/versioned_docs/version-v2.5.1/userguide/hygon-device/specify-device-core-usage.md
+++ b/versioned_docs/version-v2.5.1/userguide/hygon-device/specify-device-core-usage.md
@@ -14,4 +14,8 @@ Optional, each unit of `cambricon.com/mlu.smlu.vcore` equals to 1% device cores.
           cambricon.com/mlu.smlu.vcore: "10" # Each MLU contains 10% device cores
 ```
 
-> **NOTICE:** *Depending on the parameters of cambricon-device-plugin, resource name can be `cambricon.com/mlu370.smlu.vcore` or other types*
+:::note
+
+Depending on the parameters of cambricon-device-plugin, resource name can be `cambricon.com/mlu370.smlu.vcore` or other types
+
+:::

--- a/versioned_docs/version-v2.5.1/userguide/metax-device/enable-metax-gpu-schedule.md
+++ b/versioned_docs/version-v2.5.1/userguide/metax-device/enable-metax-gpu-schedule.md
@@ -62,6 +62,10 @@ spec:
           metax-tech.com/gpu: 1 # requesting 1 vGPUs
 ```
 
-> **NOTICE2:** *You can find more examples in examples folder
+:::note
+
+You can find more examples in examples folder
+
+:::
 
    

--- a/versioned_docs/version-v2.5.1/userguide/metax-device/enable-metax-gpu-sharing.md
+++ b/versioned_docs/version-v2.5.1/userguide/metax-device/enable-metax-gpu-sharing.md
@@ -45,4 +45,8 @@ spec:
           metax-tech.com/vmemory: 4 # each GPU require 4 GiB device memory
 ```
 
-> **NOTICE1:** *You can find more examples in examples/sgpu folder.*
+:::note
+
+You can find more examples in examples/sgpu folder.
+
+:::

--- a/versioned_docs/version-v2.5.1/userguide/mthreads-device/enable-mthreads-gpu-sharing.md
+++ b/versioned_docs/version-v2.5.1/userguide/mthreads-device/enable-mthreads-gpu-sharing.md
@@ -31,7 +31,11 @@ title: Enable Mthreads GPU sharing
 
 * Deploy MT-CloudNative Toolkit on mthreads nodes (Please consult your device provider to acquire its package and document)
 
-> **NOTICE:** *You can remove mt-mutating-webhook and mt-gpu-scheduler after installation(optional).*
+:::note
+
+You can remove mt-mutating-webhook and mt-gpu-scheduler after installation(optional).
+
+:::
 
 * set the 'devices.mthreads.enabled = true' when installing hami
 
@@ -64,8 +68,16 @@ spec:
           mthreads.com/sgpu-core: 8
 ```
 
-> **NOTICE1:** *Each unit of sgpu-memory indicates 512M device memory*
+:::note
 
-> **NOTICE2:** *You can find more examples in examples folder*
+Each unit of sgpu-memory indicates 512M device memory
+
+:::
+
+:::note
+
+You can find more examples in examples folder
+
+:::
 
     

--- a/versioned_docs/version-v2.5.1/userguide/nvidia-device/examples/allocate-device-core.md
+++ b/versioned_docs/version-v2.5.1/userguide/nvidia-device/examples/allocate-device-core.md
@@ -22,4 +22,8 @@ spec:
           nvidia.com/gpucores: 50 # requesting 50% of each vGPU's core resources
 ```
 
-> **NOTICE:** *HAMi implements `nvidia.com/gpucores` using time-slice, Therefore, when the core utilization is queried through the nvidia-smi command, there will be fluctuations*
+:::note
+
+HAMi implements `nvidia.com/gpucores` using time-slice, Therefore, when the core utilization is queried through the nvidia-smi command, there will be fluctuations
+
+:::

--- a/versioned_docs/version-v2.5.1/userguide/nvidia-device/examples/allocate-device-memory.md
+++ b/versioned_docs/version-v2.5.1/userguide/nvidia-device/examples/allocate-device-memory.md
@@ -22,4 +22,8 @@ spec:
           nvidia.com/gpumem: 3000 # each vGPU requests 3G device memory
 ```
 
-> **NOTICE:** *`nvidia.com/gpumem` can't be used together with `nvidia.com/gpumem-percentage`*
+:::note
+
+`nvidia.com/gpumem` can't be used together with `nvidia.com/gpumem-percentage`
+
+:::

--- a/versioned_docs/version-v2.5.1/userguide/nvidia-device/examples/allocate-device-memory2.md
+++ b/versioned_docs/version-v2.5.1/userguide/nvidia-device/examples/allocate-device-memory2.md
@@ -22,4 +22,8 @@ spec:
           nvidia.com/gpumem-percentage: 50 # each vGPU requests 50% of device memory
 ```
 
-> **NOTICE:** *`nvidia.com/gpumem` can't be used together with `nvidia.com/gpumem-percentage`*
+:::note
+
+`nvidia.com/gpumem` can't be used together with `nvidia.com/gpumem-percentage`
+
+:::

--- a/versioned_docs/version-v2.5.1/userguide/nvidia-device/examples/specify-card-type-to-use.md
+++ b/versioned_docs/version-v2.5.1/userguide/nvidia-device/examples/specify-card-type-to-use.md
@@ -24,4 +24,8 @@ spec:
           nvidia.com/gpu: 2 # requesting 2 vGPUs
 ```
 
-> **NOTICE:** * You can assign this task to multiple GPU types, use comma to separate,In this example, the job targets A100 or V100*
+:::note
+
+You can assign this task to multiple GPU types, use comma to separate,In this example, the job targets A100 or V100
+
+:::

--- a/versioned_docs/version-v2.5.1/userguide/nvidia-device/specify-device-core-usage.md
+++ b/versioned_docs/version-v2.5.1/userguide/nvidia-device/specify-device-core-usage.md
@@ -14,4 +14,8 @@ Optional, each unit of `nvidia.com/gpucores` equals to 1% device cores.
           nvidia.com/gpucores: 50 # Each GPU allocates 50% device cores.
 ```
 
-> **NOTICE:** * HAMi-core uses time-slice to limit device core usage. Therefore, there will be fluctuations when looking at GPU utilization through nvidia-smi*
+:::note
+
+HAMi-core uses time-slice to limit device core usage. Therefore, there will be fluctuations when looking at GPU utilization through nvidia-smi
+
+:::

--- a/versioned_docs/version-v2.5.1/userguide/nvidia-device/specify-device-memory-usage.md
+++ b/versioned_docs/version-v2.5.1/userguide/nvidia-device/specify-device-memory-usage.md
@@ -24,4 +24,8 @@ Optional, each unit of `nvidia.com/gpumem-percentage` equals to 1% percentage of
           nvidia.com/gpumem-percentage: 50 # Each GPU contains 50% device memory
 ```
 
-> **NOTICE:** *`nvidia.com/gpumem` and `nvidia.com/gpumem-percentage` can't be assigned together*
+:::note
+
+`nvidia.com/gpumem` and `nvidia.com/gpumem-percentage` can't be assigned together
+
+:::

--- a/versioned_docs/version-v2.5.1/userguide/nvidia-device/specify-device-uuid-to-use.md
+++ b/versioned_docs/version-v2.5.1/userguide/nvidia-device/specify-device-uuid-to-use.md
@@ -14,4 +14,8 @@ metadata:
     nvidia.com/use-gpuuuid: "GPU-123456"
 ```
 
-> **NOTICE:** *Each GPU UUID is unique in a cluster, so assign a certain UUID means assigning this task to certain node with that GPU*
+:::note
+
+Each GPU UUID is unique in a cluster, so assign a certain UUID means assigning this task to certain node with that GPU
+
+:::

--- a/versioned_docs/version-v2.6.0/installation/uninstall.md
+++ b/versioned_docs/version-v2.6.0/installation/uninstall.md
@@ -8,4 +8,8 @@ The step to uninstall hami is simple:
 helm uninstall hami -n kube-system
 ```
 
-> **NOTICE:** *Uninstallation won't kill running tasks.*
+:::note
+
+Uninstallation won't kill running tasks.
+
+:::

--- a/versioned_docs/version-v2.6.0/userguide/ascend-device/examples/allocate-310p.md
+++ b/versioned_docs/version-v2.6.0/userguide/ascend-device/examples/allocate-310p.md
@@ -24,4 +24,8 @@ spec:
           huawei.com/Ascend310P-memory: 1024
 ```
 
-> **NOTICE:** *compute resource of Ascend910B is also limited with `huawei.com/Ascend310P-memory`, equals to the percentage of device memory allocated.*
+:::note
+
+compute resource of Ascend910B is also limited with `huawei.com/Ascend310P-memory`, equals to the percentage of device memory allocated.
+
+:::

--- a/versioned_docs/version-v2.6.0/userguide/ascend-device/examples/allocate-910b.md
+++ b/versioned_docs/version-v2.6.0/userguide/ascend-device/examples/allocate-910b.md
@@ -20,4 +20,8 @@ spec:
           huawei.com/Ascend910-memory: 2000 # requesting 2000m device memory
 ```
 
-> **NOTICE:** *compute resource of Ascend910B is also limited with `huawei.com/Ascend910-memory`, equals to the percentage of device memory allocated.*
+:::note
+
+compute resource of Ascend910B is also limited with `huawei.com/Ascend910-memory`, equals to the percentage of device memory allocated.
+
+:::

--- a/versioned_docs/version-v2.6.0/userguide/cambricon-device/specify-device-core-usage.md
+++ b/versioned_docs/version-v2.6.0/userguide/cambricon-device/specify-device-core-usage.md
@@ -14,4 +14,8 @@ Optional, each unit of `cambricon.com/mlu.smlu.vcore` equals to 1% device cores.
           cambricon.com/mlu.smlu.vcore: "10" # Each MLU contains 10% device cores
 ```
 
-> **NOTICE:** *Depending on the parameters of cambricon-device-plugin, resource name can be `cambricon.com/mlu370.smlu.vcore` or other types*
+:::note
+
+Depending on the parameters of cambricon-device-plugin, resource name can be `cambricon.com/mlu370.smlu.vcore` or other types
+
+:::

--- a/versioned_docs/version-v2.6.0/userguide/cambricon-device/specify-device-memory-usage.md
+++ b/versioned_docs/version-v2.6.0/userguide/cambricon-device/specify-device-memory-usage.md
@@ -14,4 +14,8 @@ Optional, Each unit of `cambricon.com/mlu.smlu.vmemory` equals to 1% of device m
           cambricon.com/mlu.smlu.vmemory: "20" # Each GPU contains 20% device memory
 ```
 
-> **NOTICE:** *Depending on the parameters of cambricon-device-plugin, resource name can be `cambricon.com/mlu370.smlu.vmemory` or other types*
+:::note
+
+Depending on the parameters of cambricon-device-plugin, resource name can be `cambricon.com/mlu370.smlu.vmemory` or other types
+
+:::

--- a/versioned_docs/version-v2.6.0/userguide/enflame-device/enable-enflame-gcu-sharing.md
+++ b/versioned_docs/version-v2.6.0/userguide/enflame-device/enable-enflame-gcu-sharing.md
@@ -26,7 +26,11 @@ title: Enable Enflame GPU Sharing
 
 * Deploy gcushare-device-plugin on enflame nodes (Please consult your device provider to acquire its package and document)
 
-> **NOTICE:** *Install only gpushare-device-plugin, don't install gpu-scheduler-plugin package.*
+:::note
+
+Install only gpushare-device-plugin, don't install gpu-scheduler-plugin package.
+
+:::
 
 > **NOTE:** The default resource names are:
 > - `enflame.com/vgcu` for GCU count, only support 1 now.
@@ -78,7 +82,11 @@ spec:
           enflame.com/vgcu-percentage: 22
 ```
 
-> **NOTICE:** *You can find more examples in [examples/enflame folder](https://github.com/Project-HAMi/HAMi/tree/release-v2.6/examples/enflame/)*
+:::note
+
+You can find more examples in [examples/enflame folder](https://github.com/Project-HAMi/HAMi/tree/release-v2.6/examples/enflame/)
+
+:::
 
 ## Device UUID Selection
 

--- a/versioned_docs/version-v2.6.0/userguide/hygon-device/specify-device-core-usage.md
+++ b/versioned_docs/version-v2.6.0/userguide/hygon-device/specify-device-core-usage.md
@@ -14,4 +14,8 @@ Optional, each unit of `cambricon.com/mlu.smlu.vcore` equals to 1% device cores.
           cambricon.com/mlu.smlu.vcore: "10" # Each MLU contains 10% device cores
 ```
 
-> **NOTICE:** *Depending on the parameters of cambricon-device-plugin, resource name can be `cambricon.com/mlu370.smlu.vcore` or other types*
+:::note
+
+Depending on the parameters of cambricon-device-plugin, resource name can be `cambricon.com/mlu370.smlu.vcore` or other types
+
+:::

--- a/versioned_docs/version-v2.6.0/userguide/iluvatar-device/enable-illuvatar-gpu-sharing.md
+++ b/versioned_docs/version-v2.6.0/userguide/iluvatar-device/enable-illuvatar-gpu-sharing.md
@@ -26,7 +26,11 @@ title: Enable Illuvatar GPU Sharing
 
 * Deploy gpu-manager on iluvatar nodes (Please consult your device provider to acquire its package and document)
 
-> **NOTICE:** *Install only gpu-manager, don't install gpu-admission package.*
+:::note
+
+Install only gpu-manager, don't install gpu-admission package.
+
+:::
 
 * Identify the resource name about core and memory usage(i.e 'iluvatar.ai/vcuda-core', 'iluvatar.ai/vcuda-memory')
 
@@ -96,9 +100,17 @@ spec:
         iluvatar.ai/vcuda-memory: 64
 ```
 
-> **NOTICE1:** *Each unit of vcuda-memory indicates 256M device memory*
+:::note
 
-> **NOTICE2:** *You can find more examples in [examples/iluvatar folder](https://github.com/Project-HAMi/HAMi/tree/release-v2.6/examples/iluvatar/)*
+Each unit of vcuda-memory indicates 256M device memory
+
+:::
+
+:::note
+
+You can find more examples in [examples/iluvatar folder](https://github.com/Project-HAMi/HAMi/tree/release-v2.6/examples/iluvatar/)
+
+:::
 
 ## Device UUID Selection
 

--- a/versioned_docs/version-v2.6.0/userguide/metax-device/metax-gpu/enable-metax-gpu-schedule.md
+++ b/versioned_docs/version-v2.6.0/userguide/metax-device/metax-gpu/enable-metax-gpu-schedule.md
@@ -64,4 +64,8 @@ spec:
           metax-tech.com/gpu: 1 # requesting 1 GPU
 ```
 
-> **NOTICE:** *You can find more examples in [examples/metax folder](https://github.com/Project-HAMi/HAMi/tree/release-v2.6/examples/metax/gpu)*
+:::note
+
+You can find more examples in [examples/metax folder](https://github.com/Project-HAMi/HAMi/tree/release-v2.6/examples/metax/gpu)
+
+:::

--- a/versioned_docs/version-v2.6.0/userguide/metax-device/metax-sgpu/enable-metax-gpu-sharing.md
+++ b/versioned_docs/version-v2.6.0/userguide/metax-device/metax-sgpu/enable-metax-gpu-sharing.md
@@ -48,4 +48,8 @@ spec:
           metax-tech.com/vmemory: 4 # each GPU require 4 GiB device memory
 ```
 
-> **NOTICE:** *You can find more examples in [examples/metax folder](https://github.com/Project-HAMi/HAMi/tree/release-v2.6/examples/metax/sgpu)*
+:::note
+
+You can find more examples in [examples/metax folder](https://github.com/Project-HAMi/HAMi/tree/release-v2.6/examples/metax/sgpu)
+
+:::

--- a/versioned_docs/version-v2.6.0/userguide/metax-device/metax-sgpu/examples/default-use.md
+++ b/versioned_docs/version-v2.6.0/userguide/metax-device/metax-sgpu/examples/default-use.md
@@ -25,4 +25,8 @@ spec:
           metax-tech.com/vmemory: 4 # each GPU require 4 GiB device memory
 ```
 
-> **NOTICE:** *When a `metax-tech.com/vcore` or `metax-tech.com/vmemory` resource is not applied for, it indicates that the quota for the corresponding resource is full*
+:::note
+
+When a `metax-tech.com/vcore` or `metax-tech.com/vmemory` resource is not applied for, it indicates that the quota for the corresponding resource is full
+
+:::

--- a/versioned_docs/version-v2.6.0/userguide/mthreads-device/enable-mthreads-gpu-sharing.md
+++ b/versioned_docs/version-v2.6.0/userguide/mthreads-device/enable-mthreads-gpu-sharing.md
@@ -31,7 +31,11 @@ title: Enable Mthreads GPU sharing
 
 * Deploy MT-CloudNative Toolkit on mthreads nodes (Please consult your device provider to acquire its package and document)
 
-> **NOTICE:** *You can remove mt-mutating-webhook and mt-gpu-scheduler after installation(optional).*
+:::note
+
+You can remove mt-mutating-webhook and mt-gpu-scheduler after installation(optional).
+
+:::
 
 * set the 'devices.mthreads.enabled = true' when installing hami
 
@@ -64,6 +68,14 @@ spec:
           mthreads.com/sgpu-core: 8
 ```
 
-> **NOTICE1:** *Each unit of sgpu-memory indicates 512M device memory*
+:::note
 
-> **NOTICE2:** *You can find more examples in [examples/mthreads folder](https://github.com/Project-HAMi/HAMi/tree/release-v2.6/examples/mthreads/)*
+Each unit of sgpu-memory indicates 512M device memory
+
+:::
+
+:::note
+
+You can find more examples in [examples/mthreads folder](https://github.com/Project-HAMi/HAMi/tree/release-v2.6/examples/mthreads/)
+
+:::

--- a/versioned_docs/version-v2.6.0/userguide/nvidia-device/examples/allocate-device-core.md
+++ b/versioned_docs/version-v2.6.0/userguide/nvidia-device/examples/allocate-device-core.md
@@ -22,4 +22,8 @@ spec:
           nvidia.com/gpucores: 50 # requesting 50% of each vGPU's core resources
 ```
 
-> **NOTICE:** *HAMi implements `nvidia.com/gpucores` using time-slice, Therefore, when the core utilization is queried through the nvidia-smi command, there will be fluctuations*
+:::note
+
+HAMi implements `nvidia.com/gpucores` using time-slice, Therefore, when the core utilization is queried through the nvidia-smi command, there will be fluctuations
+
+:::

--- a/versioned_docs/version-v2.6.0/userguide/nvidia-device/examples/allocate-device-memory.md
+++ b/versioned_docs/version-v2.6.0/userguide/nvidia-device/examples/allocate-device-memory.md
@@ -22,4 +22,8 @@ spec:
           nvidia.com/gpumem: 3000 # each vGPU requests 3G device memory
 ```
 
-> **NOTICE:** *`nvidia.com/gpumem` can't be used together with `nvidia.com/gpumem-percentage`*
+:::note
+
+`nvidia.com/gpumem` can't be used together with `nvidia.com/gpumem-percentage`
+
+:::

--- a/versioned_docs/version-v2.6.0/userguide/nvidia-device/examples/allocate-device-memory2.md
+++ b/versioned_docs/version-v2.6.0/userguide/nvidia-device/examples/allocate-device-memory2.md
@@ -22,4 +22,8 @@ spec:
           nvidia.com/gpumem-percentage: 50 # each vGPU requests 50% of device memory
 ```
 
-> **NOTICE:** *`nvidia.com/gpumem` can't be used together with `nvidia.com/gpumem-percentage`*
+:::note
+
+`nvidia.com/gpumem` can't be used together with `nvidia.com/gpumem-percentage`
+
+:::

--- a/versioned_docs/version-v2.6.0/userguide/nvidia-device/examples/specify-card-type-to-use.md
+++ b/versioned_docs/version-v2.6.0/userguide/nvidia-device/examples/specify-card-type-to-use.md
@@ -24,4 +24,8 @@ spec:
           nvidia.com/gpu: 2 # requesting 2 vGPUs
 ```
 
-> **NOTICE:** * You can assign this task to multiple GPU types, use comma to separate,In this example, the job targets A100 or V100*
+:::note
+
+You can assign this task to multiple GPU types, use comma to separate,In this example, the job targets A100 or V100
+
+:::

--- a/versioned_docs/version-v2.6.0/userguide/nvidia-device/specify-device-core-usage.md
+++ b/versioned_docs/version-v2.6.0/userguide/nvidia-device/specify-device-core-usage.md
@@ -14,4 +14,8 @@ Optional, each unit of `nvidia.com/gpucores` equals to 1% device cores.
           nvidia.com/gpucores: 50 # Each GPU allocates 50% device cores.
 ```
 
-> **NOTICE:** * HAMi-core uses time-slice to limit device core usage. Therefore, there will be fluctuations when looking at GPU utilization through nvidia-smi*
+:::note
+
+HAMi-core uses time-slice to limit device core usage. Therefore, there will be fluctuations when looking at GPU utilization through nvidia-smi
+
+:::

--- a/versioned_docs/version-v2.6.0/userguide/nvidia-device/specify-device-memory-usage.md
+++ b/versioned_docs/version-v2.6.0/userguide/nvidia-device/specify-device-memory-usage.md
@@ -24,4 +24,8 @@ Optional, each unit of `nvidia.com/gpumem-percentage` equals to 1% percentage of
           nvidia.com/gpumem-percentage: 50 # Each GPU contains 50% device memory
 ```
 
-> **NOTICE:** *`nvidia.com/gpumem` and `nvidia.com/gpumem-percentage` can't be assigned together*
+:::note
+
+`nvidia.com/gpumem` and `nvidia.com/gpumem-percentage` can't be assigned together
+
+:::

--- a/versioned_docs/version-v2.6.0/userguide/nvidia-device/specify-device-uuid-to-use.md
+++ b/versioned_docs/version-v2.6.0/userguide/nvidia-device/specify-device-uuid-to-use.md
@@ -14,4 +14,8 @@ metadata:
     nvidia.com/use-gpuuuid: "GPU-123456"
 ```
 
-> **NOTICE:** *Each GPU UUID is unique in a cluster, so assign a certain UUID means assigning this task to certain node with that GPU*
+:::note
+
+Each GPU UUID is unique in a cluster, so assign a certain UUID means assigning this task to certain node with that GPU
+
+:::

--- a/versioned_docs/version-v2.7.0/userguide/ascend-device/examples/allocate-310p.md
+++ b/versioned_docs/version-v2.7.0/userguide/ascend-device/examples/allocate-310p.md
@@ -24,7 +24,11 @@ spec:
           huawei.com/Ascend310P-memory: 1024
 ```
 
-> **NOTICE:** *compute resource of Ascend310P is also limited with `huawei.com/Ascend310P-memory`, equals to the percentage of device memory allocated.*
+:::note
+
+compute resource of Ascend310P is also limited with `huawei.com/Ascend310P-memory`, equals to the percentage of device memory allocated.
+
+:::
 
 ## Select Device by UUID
 

--- a/versioned_docs/version-v2.7.0/userguide/ascend-device/examples/allocate-910b.md
+++ b/versioned_docs/version-v2.7.0/userguide/ascend-device/examples/allocate-910b.md
@@ -20,7 +20,11 @@ spec:
           huawei.com/Ascend910-memory: 2000 # requesting 2000m device memory
 ```
 
-> **NOTICE:** *compute resource of Ascend910B is also limited with `huawei.com/Ascend910-memory`, equals to the percentage of device memory allocated.*
+:::note
+
+compute resource of Ascend910B is also limited with `huawei.com/Ascend910-memory`, equals to the percentage of device memory allocated.
+
+:::
 
 ## Select Device by UUID
 

--- a/versioned_docs/version-v2.7.0/userguide/enflame-device/enable-enflame-gcu-sharing.md
+++ b/versioned_docs/version-v2.7.0/userguide/enflame-device/enable-enflame-gcu-sharing.md
@@ -26,7 +26,11 @@ title: Enable Enflame GPU Sharing
 
 * Deploy gcushare-device-plugin on enflame nodes (Please consult your device provider to acquire its package and document)
 
-> **NOTICE:** *Install only gpushare-device-plugin, don't install gpu-scheduler-plugin package.*
+:::note
+
+Install only gpushare-device-plugin, don't install gpu-scheduler-plugin package.
+
+:::
 
 > **NOTE:** The default resource names are:
 > - `enflame.com/vgcu` for GCU count, only support 1 now.
@@ -78,7 +82,11 @@ spec:
           enflame.com/vgcu-percentage: 22
 ```
 
-> **NOTICE:** *You can find more examples in [examples/enflame folder](https://github.com/Project-HAMi/HAMi/tree/release-v2.6/examples/enflame/)*
+:::note
+
+You can find more examples in [examples/enflame folder](https://github.com/Project-HAMi/HAMi/tree/release-v2.6/examples/enflame/)
+
+:::
 
 ## Device UUID Selection
 

--- a/versioned_docs/version-v2.7.0/userguide/hygon-device/specify-device-uuid-to-use.md
+++ b/versioned_docs/version-v2.7.0/userguide/hygon-device/specify-device-uuid-to-use.md
@@ -14,4 +14,8 @@ metadata:
     hygon.com/use-gpuuuid: "DCU-123456"
 ```
 
-> **NOTICE:** *Each DCU UUID is unique in a cluster, so assign a certain UUID means assigning this task to certain node with that DCU*
+:::note
+
+Each DCU UUID is unique in a cluster, so assign a certain UUID means assigning this task to certain node with that DCU
+
+:::

--- a/versioned_docs/version-v2.7.0/userguide/iluvatar-device/enable-illuvatar-gpu-sharing.md
+++ b/versioned_docs/version-v2.7.0/userguide/iluvatar-device/enable-illuvatar-gpu-sharing.md
@@ -26,7 +26,11 @@ title: Enable Illuvatar GPU Sharing
 
 * Deploy gpu-manager on iluvatar nodes (Please consult your device provider to acquire its package and document)
 
-> **NOTICE:** *Install only gpu-manager, don't install gpu-admission package.*
+:::note
+
+Install only gpu-manager, don't install gpu-admission package.
+
+:::
 
 * Identify the resource name about core and memory usage(i.e 'iluvatar.ai/vcuda-core', 'iluvatar.ai/vcuda-memory')
 
@@ -96,9 +100,17 @@ spec:
         iluvatar.ai/vcuda-memory: 64
 ```
 
-> **NOTICE1:** *Each unit of vcuda-memory indicates 256M device memory*
+:::note
 
-> **NOTICE2:** *You can find more examples in [examples/iluvatar folder](https://github.com/Project-HAMi/HAMi/tree/release-v2.6/examples/iluvatar/)*
+Each unit of vcuda-memory indicates 256M device memory
+
+:::
+
+:::note
+
+You can find more examples in [examples/iluvatar folder](https://github.com/Project-HAMi/HAMi/tree/release-v2.6/examples/iluvatar/)
+
+:::
 
 ## Device UUID Selection
 

--- a/versioned_docs/version-v2.7.0/userguide/metax-device/metax-gpu/enable-metax-gpu-schedule.md
+++ b/versioned_docs/version-v2.7.0/userguide/metax-device/metax-gpu/enable-metax-gpu-schedule.md
@@ -66,4 +66,8 @@ spec:
           metax-tech.com/gpu: 1 # requesting 1 GPU
 ```
 
-> **NOTICE:** *You can find more examples in [examples/metax folder](https://github.com/Project-HAMi/HAMi/tree/release-v2.6/examples/metax/gpu)*
+:::note
+
+You can find more examples in [examples/metax folder](https://github.com/Project-HAMi/HAMi/tree/release-v2.6/examples/metax/gpu)
+
+:::

--- a/versioned_docs/version-v2.7.0/userguide/metax-device/metax-sgpu/enable-metax-gpu-sharing.md
+++ b/versioned_docs/version-v2.7.0/userguide/metax-device/metax-sgpu/enable-metax-gpu-sharing.md
@@ -46,4 +46,8 @@ spec:
           metax-tech.com/vmemory: 4 # each GPU require 4 GiB device memory
 ```
 
-> **NOTICE:** *You can find more examples in [examples/metax folder](https://github.com/Project-HAMi/HAMi/tree/release-v2.6/examples/metax/sgpu)*
+:::note
+
+You can find more examples in [examples/metax folder](https://github.com/Project-HAMi/HAMi/tree/release-v2.6/examples/metax/sgpu)
+
+:::

--- a/versioned_docs/version-v2.7.0/userguide/metax-device/metax-sgpu/examples/default-use.md
+++ b/versioned_docs/version-v2.7.0/userguide/metax-device/metax-sgpu/examples/default-use.md
@@ -23,4 +23,8 @@ spec:
           metax-tech.com/vmemory: 4 # each GPU require 4 GiB device memory
 ```
 
-> **NOTICE:** *When a `metax-tech.com/vcore` or `metax-tech.com/vmemory` resource is not applied for, it indicates that the quota for the corresponding resource is full*
+:::note
+
+When a `metax-tech.com/vcore` or `metax-tech.com/vmemory` resource is not applied for, it indicates that the quota for the corresponding resource is full
+
+:::

--- a/versioned_docs/version-v2.7.0/userguide/mthreads-device/enable-mthreads-gpu-sharing.md
+++ b/versioned_docs/version-v2.7.0/userguide/mthreads-device/enable-mthreads-gpu-sharing.md
@@ -31,7 +31,11 @@ title: Enable Mthreads GPU sharing
 
 * Deploy MT-CloudNative Toolkit on mthreads nodes (Please consult your device provider to acquire its package and document)
 
-> **NOTICE:** *You can remove mt-mutating-webhook and mt-gpu-scheduler after installation(optional).*
+:::note
+
+You can remove mt-mutating-webhook and mt-gpu-scheduler after installation(optional).
+
+:::
 
 * set the 'devices.mthreads.enabled = true' when installing hami
 
@@ -64,6 +68,14 @@ spec:
           mthreads.com/sgpu-core: 8
 ```
 
-> **NOTICE1:** *Each unit of sgpu-memory indicates 512M device memory*
+:::note
 
-> **NOTICE2:** *You can find more examples in [examples/mthreads folder](https://github.com/Project-HAMi/HAMi/tree/release-v2.6/examples/mthreads/)*
+Each unit of sgpu-memory indicates 512M device memory
+
+:::
+
+:::note
+
+You can find more examples in [examples/mthreads folder](https://github.com/Project-HAMi/HAMi/tree/release-v2.6/examples/mthreads/)
+
+:::

--- a/versioned_docs/version-v2.7.0/userguide/nvidia-device/examples/allocate-device-core.md
+++ b/versioned_docs/version-v2.7.0/userguide/nvidia-device/examples/allocate-device-core.md
@@ -22,4 +22,8 @@ spec:
           nvidia.com/gpucores: 50 # requesting 50% of each vGPU's core resources
 ```
 
-> **NOTICE:** *HAMi implements `nvidia.com/gpucores` using time-slice, Therefore, when the core utilization is queried through the nvidia-smi command, there will be fluctuations*
+:::note
+
+HAMi implements `nvidia.com/gpucores` using time-slice, Therefore, when the core utilization is queried through the nvidia-smi command, there will be fluctuations
+
+:::

--- a/versioned_docs/version-v2.7.0/userguide/nvidia-device/examples/allocate-device-memory.md
+++ b/versioned_docs/version-v2.7.0/userguide/nvidia-device/examples/allocate-device-memory.md
@@ -22,4 +22,8 @@ spec:
           nvidia.com/gpumem: 3000 # each vGPU requests 3G device memory
 ```
 
-> **NOTICE:** *`nvidia.com/gpumem` can't be used together with `nvidia.com/gpumem-percentage`*
+:::note
+
+`nvidia.com/gpumem` can't be used together with `nvidia.com/gpumem-percentage`
+
+:::

--- a/versioned_docs/version-v2.7.0/userguide/nvidia-device/examples/allocate-device-memory2.md
+++ b/versioned_docs/version-v2.7.0/userguide/nvidia-device/examples/allocate-device-memory2.md
@@ -22,4 +22,8 @@ spec:
           nvidia.com/gpumem-percentage: 50 # each vGPU requests 50% of device memory
 ```
 
-> **NOTICE:** *`nvidia.com/gpumem` can't be used together with `nvidia.com/gpumem-percentage`*
+:::note
+
+`nvidia.com/gpumem` can't be used together with `nvidia.com/gpumem-percentage`
+
+:::

--- a/versioned_docs/version-v2.7.0/userguide/nvidia-device/examples/specify-card-type-to-use.md
+++ b/versioned_docs/version-v2.7.0/userguide/nvidia-device/examples/specify-card-type-to-use.md
@@ -24,4 +24,8 @@ spec:
           nvidia.com/gpu: 2 # requesting 2 vGPUs
 ```
 
-> **NOTICE:** * You can assign this task to multiple GPU types, use comma to separate,In this example, the job targets A100 or V100*
+:::note
+
+You can assign this task to multiple GPU types, use comma to separate,In this example, the job targets A100 or V100
+
+:::

--- a/versioned_docs/version-v2.7.0/userguide/nvidia-device/specify-device-core-usage.md
+++ b/versioned_docs/version-v2.7.0/userguide/nvidia-device/specify-device-core-usage.md
@@ -14,4 +14,8 @@ Optional, each unit of `nvidia.com/gpucores` equals to 1% device cores.
           nvidia.com/gpucores: 50 # Each GPU allocates 50% device cores.
 ```
 
-> **NOTICE:** * HAMi-core uses time-slice to limit device core usage. Therefore, there will be fluctuations when looking at GPU utilization through nvidia-smi*
+:::note
+
+HAMi-core uses time-slice to limit device core usage. Therefore, there will be fluctuations when looking at GPU utilization through nvidia-smi
+
+:::

--- a/versioned_docs/version-v2.7.0/userguide/nvidia-device/specify-device-memory-usage.md
+++ b/versioned_docs/version-v2.7.0/userguide/nvidia-device/specify-device-memory-usage.md
@@ -24,4 +24,8 @@ Optional, each unit of `nvidia.com/gpumem-percentage` equals to 1% percentage of
           nvidia.com/gpumem-percentage: 50 # Each GPU contains 50% device memory
 ```
 
-> **NOTICE:** *`nvidia.com/gpumem` and `nvidia.com/gpumem-percentage` can't be assigned together*
+:::note
+
+`nvidia.com/gpumem` and `nvidia.com/gpumem-percentage` can't be assigned together
+
+:::

--- a/versioned_docs/version-v2.7.0/userguide/nvidia-device/specify-device-uuid-to-use.md
+++ b/versioned_docs/version-v2.7.0/userguide/nvidia-device/specify-device-uuid-to-use.md
@@ -14,4 +14,8 @@ metadata:
     nvidia.com/use-gpuuuid: "GPU-123456"
 ```
 
-> **NOTICE:** *Each GPU UUID is unique in a cluster, so assign a certain UUID means assigning this task to certain node with that GPU*
+:::note
+
+Each GPU UUID is unique in a cluster, so assign a certain UUID means assigning this task to certain node with that GPU
+
+:::

--- a/versioned_docs/version-v2.8.0/userguide/hygon-device/specify-device-uuid-to-use.md
+++ b/versioned_docs/version-v2.8.0/userguide/hygon-device/specify-device-uuid-to-use.md
@@ -12,4 +12,8 @@ metadata:
     hygon.com/use-gpuuuid: "DCU-123456"
 ```
 
-> **NOTICE:** *Each DCU UUID is unique in a cluster, so assign a certain UUID means assigning this task to certain node with that DCU*
+:::note
+
+Each DCU UUID is unique in a cluster, so assign a certain UUID means assigning this task to certain node with that DCU
+
+:::

--- a/versioned_docs/version-v2.8.0/userguide/iluvatar-device/enable-illuvatar-gpu-sharing.md
+++ b/versioned_docs/version-v2.8.0/userguide/iluvatar-device/enable-illuvatar-gpu-sharing.md
@@ -25,7 +25,11 @@ title: Enable Illuvatar GPU Sharing
 
 * Deploy gpu-manager on iluvatar nodes (Please consult your device provider to acquire its package and document)
 
-> **NOTICE:** *Install only gpu-manager, don't install gpu-admission package.*
+:::note
+
+Install only gpu-manager, don't install gpu-admission package.
+
+:::
 
 * set the devices.iluvatar.enabled=true when install hami
 
@@ -112,7 +116,11 @@ spec:
         iluvatar.ai/BI-V150.vMem: 64
 ```
 
-> **NOTICE1:** *Each unit of vcuda-memory indicates 256M device memory*
+:::note
+
+Each unit of vcuda-memory indicates 256M device memory
+
+:::
 
 ## Device UUID Selection
 


### PR DESCRIPTION
Convert all 144 informal `> **NOTICE:**` blockquotes to Docusaurus `:::note` admonitions across all versioned documentation (v1.3.0, v2.4.1, v2.5.0, v2.5.1, v2.6.0, v2.7.0, v2.8.0). Mirrors the same change already applied to active docs in PR #347.