### PR TITLE
fix: normalize asterisk list bullets to hyphens in versioned docs

### DIFF
--- a/versioned_docs/version-v1.3.0/contributor/governance.md
+++ b/versioned_docs/version-v1.3.0/contributor/governance.md
@@ -8,21 +8,21 @@ Heterogeneous AI Computing Virtualization Middleware (HAMi), formerly known as k
 
 The HAMi and its leadership embrace the following values:
 
-* Openness: Communication and decision-making happens in the open and is discoverable for future
+- Openness: Communication and decision-making happens in the open and is discoverable for future
   reference. As much as possible, all discussions and work take place in public
   forums and open repositories.
 
-* Fairness: All stakeholders have the opportunity to provide feedback and submit
+- Fairness: All stakeholders have the opportunity to provide feedback and submit
   contributions, which will be considered on their merits.
 
-* Community over Product or Company: Sustaining and growing the community takes
+- Community over Product or Company: Sustaining and growing the community takes
   priority over shipping code or sponsors' organizational goals. Each
   contributor participates in the project as an individual.
 
-* Inclusivity: Innovation comes from different perspectives and skill sets, and this
+- Inclusivity: Innovation comes from different perspectives and skill sets, and this
   can only be accomplished in a welcoming and respectful environment.
 
-* Participation: Responsibilities within the project are earned through
+- Participation: Responsibilities within the project are earned through
   participation, and there is a clear path up the contributor ladder into leadership
   positions.
 

--- a/versioned_docs/version-v1.3.0/contributor/ladder.md
+++ b/versioned_docs/version-v1.3.0/contributor/ladder.md
@@ -12,38 +12,38 @@ Each of the contributor roles below is organized into lists of three types of th
 
 Description: A Community Participant engages with the project and its community, contributing their time, thoughts, etc. Community participants are usually users who have stopped being anonymous and started being active in project discussions.
 
-* Responsibilities:
-  * Must follow the [CNCF CoC](https://github.com/cncf/foundation/blob/main/code-of-conduct.md)
-* How users can get involved with the community:
-  * Participating in community discussions
-  * Helping other users
-  * Submitting bug reports
-  * Commenting on issues
-  * Trying out new releases
-  * Attending community events
+- Responsibilities:
+  - Must follow the [CNCF CoC](https://github.com/cncf/foundation/blob/main/code-of-conduct.md)
+- How users can get involved with the community:
+  - Participating in community discussions
+  - Helping other users
+  - Submitting bug reports
+  - Commenting on issues
+  - Trying out new releases
+  - Attending community events
 
 ## Contributor
 
 Description: A Contributor contributes directly to the project and adds value to it. Contributions need not be code. People at the Contributor level may be new contributors, or they may only contribute occasionally.
 
-* Responsibilities include:
-  * Follow the CNCF CoC
-  * Follow the project contributing guide
-* Requirements (one or several of the below):
-  * Report and sometimes resolve issues
-  * Occasionally submit PRs
-  * Contribute to the documentation
-  * Show up at meetings, takes notes
-  * Answer questions from other community members
-  * Submit feedback on issues and PRs
-  * Test releases and patches and submit reviews
-  * Run or helps run events
-  * Promote the project in public
-  * Help run the project infrastructure
-  * [TODO: other small contributions]
-* Privileges:
-  * Invitations to contributor events
-  * Eligible to become an Organization Member
+- Responsibilities include:
+  - Follow the CNCF CoC
+  - Follow the project contributing guide
+- Requirements (one or several of the below):
+  - Report and sometimes resolve issues
+  - Occasionally submit PRs
+  - Contribute to the documentation
+  - Show up at meetings, takes notes
+  - Answer questions from other community members
+  - Submit feedback on issues and PRs
+  - Test releases and patches and submit reviews
+  - Run or helps run events
+  - Promote the project in public
+  - Help run the project infrastructure
+  - [TODO: other small contributions]
+- Privileges:
+  - Invitations to contributor events
+  - Eligible to become an Organization Member
 
 A very special thanks to the [long list of people](https://github.com/Project-HAMi/HAMi/blob/master/AUTHORS.md) who have contributed to and helped maintain the project. Thanks to everyone who contributed and helped maintain the project.
 
@@ -55,31 +55,31 @@ Description: An Organization Member is an established contributor who regularly 
 
 An Organization Member must meet the responsibilities and has the requirements of a Contributor, plus:
 
-* Responsibilities include:
-  * Continues to contribute regularly, as demonstrated by having at least 50 GitHub contributions per year
-* Requirements:
-  * Enabled [two-factor authentication] on their GitHub account
-  * Must have successful contributions to the project or community, including at least one of the following:
-    * 5 accepted PRs,
-    * Reviewed 5 PRs,
-    * Resolved and closed 3 Issues,
-    * Become responsible for a key project management area,
-    * Or some equivalent combination or contribution
-  * Must have been contributing for at least 1 months
-  * Must be actively contributing to at least one project area
-  * Must have two sponsors who are also Organization Members, at least one of whom does not work for the same employer
-  * **[Open an issue][membership request] against the Project-HAMi/HAMi repo**
-    * Ensure your sponsors are @mentioned on the issue
-    * Complete every item on the issue checklist
-    * Make sure that the list of contributions included is representative of your work on the project.
-  * Have your sponsoring reviewers reply confirmation of sponsorship: `+1`
-  * Once your sponsors have responded, your request will be handled by the `HAMi GitHub Admin team`.
+- Responsibilities include:
+  - Continues to contribute regularly, as demonstrated by having at least 50 GitHub contributions per year
+- Requirements:
+  - Enabled [two-factor authentication] on their GitHub account
+  - Must have successful contributions to the project or community, including at least one of the following:
+    - 5 accepted PRs,
+    - Reviewed 5 PRs,
+    - Resolved and closed 3 Issues,
+    - Become responsible for a key project management area,
+    - Or some equivalent combination or contribution
+  - Must have been contributing for at least 1 months
+  - Must be actively contributing to at least one project area
+  - Must have two sponsors who are also Organization Members, at least one of whom does not work for the same employer
+  - **[Open an issue][membership request] against the Project-HAMi/HAMi repo**
+    - Ensure your sponsors are @mentioned on the issue
+    - Complete every item on the issue checklist
+    - Make sure that the list of contributions included is representative of your work on the project.
+  - Have your sponsoring reviewers reply confirmation of sponsorship: `+1`
+  - Once your sponsors have responded, your request will be handled by the `HAMi GitHub Admin team`.
 
-* Privileges:
-  * May be assigned Issues and Reviews
-  * May give commands to CI/CD automation
-  * Can be added to [TODO: Repo Host] teams
-  * Can recommend other contributors to become Org Members
+- Privileges:
+  - May be assigned Issues and Reviews
+  - May give commands to CI/CD automation
+  - Can be added to [TODO: Repo Host] teams
+  - Can recommend other contributors to become Org Members
 
 The process for a Contributor to become an Organization Member is as follows:
 
@@ -94,22 +94,22 @@ Reviewers are responsible for a "specific area." This can be a specific code dir
 
 Reviewers have all the rights and responsibilities of an Organization Member, plus:
 
-* Responsibilities include:
-  * Following the reviewing guide
-  * Reviewing most Pull Requests against their specific areas of responsibility
-  * Reviewing at least 20 PRs per year
-  * Helping other contributors become reviewers
-* Requirements:
-  * Experience as a Contributor for at least 3 months
-  * Is an Organization Member
-  * Has reviewed, or helped review, at least 10 Pull Requests
-  * Has analyzed and resolved test failures in their specific area
-  * Has demonstrated an in-depth knowledge of the specific area
-  * Commits to being responsible for that specific area
-  * Is supportive of new and occasional contributors and helps get useful PRs in shape to commit
-* Additional privileges:
-  * Has GitHub or CI/CD rights to approve pull requests in specific directories
-  * Can recommend and review other contributors to become Reviewers
+- Responsibilities include:
+  - Following the reviewing guide
+  - Reviewing most Pull Requests against their specific areas of responsibility
+  - Reviewing at least 20 PRs per year
+  - Helping other contributors become reviewers
+- Requirements:
+  - Experience as a Contributor for at least 3 months
+  - Is an Organization Member
+  - Has reviewed, or helped review, at least 10 Pull Requests
+  - Has analyzed and resolved test failures in their specific area
+  - Has demonstrated an in-depth knowledge of the specific area
+  - Commits to being responsible for that specific area
+  - Is supportive of new and occasional contributors and helps get useful PRs in shape to commit
+- Additional privileges:
+  - Has GitHub or CI/CD rights to approve pull requests in specific directories
+  - Can recommend and review other contributors to become Reviewers
 
 The process of becoming a Reviewer is:
 
@@ -126,15 +126,15 @@ The current list of maintainers can be found in the [MAINTAINERS](https://github
 
 ## An active maintainer should
 
-* Actively participate in reviewing pull requests and incoming issues. There are no hard rules on what is “active enough” and this is left up to the judgement of the current group of maintainers.
+- Actively participate in reviewing pull requests and incoming issues. There are no hard rules on what is “active enough” and this is left up to the judgement of the current group of maintainers.
 
-* Actively participate in discussions about design and the future of the project.
+- Actively participate in discussions about design and the future of the project.
 
-* Take responsibility for backports to appropriate branches for PRs they approve and merge.
+- Take responsibility for backports to appropriate branches for PRs they approve and merge.
 
-* Do their best to follow all code, testing, and design conventions as determined by consensus among active maintainers.
+- Do their best to follow all code, testing, and design conventions as determined by consensus among active maintainers.
 
-* Gracefully step down from their maintainership role when they are no longer planning to actively participate in the project.
+- Gracefully step down from their maintainership role when they are no longer planning to actively participate in the project.
 
 ## How to be a maintainer
 
@@ -150,12 +150,12 @@ It is normal for maintainers to come and go based on their other responsibilitie
 
 It is important for contributors to be and stay active to set an example and show commitment to the project. Inactivity is harmful to the project as it may lead to unexpected delays, contributor attrition, and a lost of trust in the project.
 
-* Inactivity is measured by:
-  * Periods of no contributions for longer than 3 months
-  * Periods of no communication for longer than 3 months
-* Consequences of being inactive include:
-  * Involuntary removal or demotion
-  * Being asked to move to Emeritus status
+- Inactivity is measured by:
+  - Periods of no contributions for longer than 3 months
+  - Periods of no communication for longer than 3 months
+- Consequences of being inactive include:
+  - Involuntary removal or demotion
+  - Being asked to move to Emeritus status
 
 ## Involuntary Removal or Demotion
 

--- a/versioned_docs/version-v1.3.0/roadmap.md
+++ b/versioned_docs/version-v1.3.0/roadmap.md
@@ -11,9 +11,9 @@ The items below are intended to inspire further community engagement to keep HAM
 
 ## 2022 H1
 - Multi-cluster HA scheduling policy
-    * spread by region
-    * spread by zone
-    * spread by provider
+    - spread by region
+    - spread by zone
+    - spread by provider
 - Multi-cluster Ingress
 - Multi-cluster HPA (Horizontal Pod Autoscaling)
 - Federated resource quota

--- a/versioned_docs/version-v1.3.0/userguide/ascend-device/enable-ascend-sharing.md
+++ b/versioned_docs/version-v1.3.0/userguide/ascend-device/enable-ascend-sharing.md
@@ -8,13 +8,13 @@ Memory slicing is supported based on virtualization template, lease available te
 
 ## Prerequisites
 
-* Ascend device type: 910B,910A,310P
-* driver version >= 24.1.rc1
-* Ascend docker runtime
+- Ascend device type: 910B,910A,310P
+- driver version >= 24.1.rc1
+- Ascend docker runtime
 
 ## Enabling Ascend-sharing Support
 
-* Due to dependencies with HAMi, you need to set 
+- Due to dependencies with HAMi, you need to set 
 
 ```
 devices.ascend.enabled=true
@@ -41,14 +41,14 @@ devices:
       - huawei.com/Ascend310P-memory
 ```
 
-* Tag Ascend node with the following command
+- Tag Ascend node with the following command
 ```
 kubectl label node {ascend-node} ascend=on
 ```
 
-* Install [Ascend docker runtime](https://gitee.com/ascend/ascend-docker-runtime)
+- Install [Ascend docker runtime](https://gitee.com/ascend/ascend-docker-runtime)
 
-* Download yaml for Ascend-vgpu-device-plugin from HAMi Project [here](https://github.com/Project-HAMi/ascend-device-plugin/blob/master/build/ascendplugin-hami.yaml), and deploy
+- Download yaml for Ascend-vgpu-device-plugin from HAMi Project [here](https://github.com/Project-HAMi/ascend-device-plugin/blob/master/build/ascendplugin-hami.yaml), and deploy
 
 ```
 wge https://raw.githubusercontent.com/Project-HAMi/ascend-device-plugin/refs/heads/main/ascend-device-plugin.yaml

--- a/versioned_docs/version-v1.3.0/userguide/cambricon-device/enable-cambricon-mlu-sharing.md
+++ b/versioned_docs/version-v1.3.0/userguide/cambricon-device/enable-cambricon-mlu-sharing.md
@@ -16,13 +16,13 @@ title: Enable cambricon MLU sharing
 
 ## Prerequisites
 
-* neuware-mlu370-driver > 5.0.0
-* cambricon-device-plugin > 2.0.9
-* cntoolkit > 2.5.3
+- neuware-mlu370-driver > 5.0.0
+- cambricon-device-plugin > 2.0.9
+- cntoolkit > 2.5.3
 
 ## Enabling MLU-sharing Support
 
-* Contact your device provider to acquire cambricon-device-plugin>2.0.9, edit parameter `mode` to 'dynamic-smlu` in containers.args field.
+- Contact your device provider to acquire cambricon-device-plugin>2.0.9, edit parameter `mode` to 'dynamic-smlu` in containers.args field.
 
 ```
         args:
@@ -30,11 +30,11 @@ title: Enable cambricon MLU sharing
 	...
 ```
 
-* Deploy modified cambricon-device-plugin
+- Deploy modified cambricon-device-plugin
 
-* Install the chart using helm, See 'enabling vGPU support in kubernetes' section [here](https://github.com/Project-HAMi/HAMi#enabling-vgpu-support-in-kubernetes)
+- Install the chart using helm, See 'enabling vGPU support in kubernetes' section [here](https://github.com/Project-HAMi/HAMi#enabling-vgpu-support-in-kubernetes)
 
-* Activate the smlu mode for each MLUs on that node
+- Activate the smlu mode for each MLUs on that node
 ```
 cnmon set -c 0 -smlu on
 cnmon set -c 1 -smlu on

--- a/versioned_docs/version-v1.3.0/userguide/configure.md
+++ b/versioned_docs/version-v1.3.0/userguide/configure.md
@@ -21,29 +21,29 @@ You can update these configurations using one of the following methods:
     After making changes, restart the related HAMi components to apply the updated configurations.
 2. Modify Helm Chart: Update the corresponding values in the [ConfigMap](https://raw.githubusercontent.com/archlitchi/HAMi/refs/heads/master/charts/hami/templates/scheduler/device-configmap.yaml), then reapply the Helm Chart to regenerate the ConfigMap.
 
-* `nvidia.deviceMemoryScaling:` 
+- `nvidia.deviceMemoryScaling:` 
   Float type, by default: 1. The ratio for NVIDIA device memory scaling, can be greater than 1 (enable virtual device memory, experimental feature). For NVIDIA GPU with *M* memory, if `nvidia.deviceMemoryScaling` is set argument to *S*, vGPUs split by this GPU will totally get `S * M` memory in Kubernetes with the HAMi device plugin.
-* `nvidia.deviceSplitCount:` 
+- `nvidia.deviceSplitCount:` 
   Integer type, by default: equals 10. Maximum tasks assigned to a simple GPU device.
-* `nvidia.migstrategy:`
+- `nvidia.migstrategy:`
   String type, "none" for ignoring MIG features or "mixed" for allocating MIG device by separate resources. Default "none"
-* `nvidia.disablecorelimit:`
+- `nvidia.disablecorelimit:`
   String type, "true" for disable core limit, "false" for enable core limit, default: false
-* `nvidia.defaultMem:` 
+- `nvidia.defaultMem:` 
   Integer type, by default: 0. The default device memory of the current task, in MB.'0' means use 100% device memory
-* `nvidia.defaultCores:` 
+- `nvidia.defaultCores:` 
   Integer type, by default: equals 0. Percentage of GPU cores reserved for the current task. If assigned to 0, it may fit in any GPU with enough device memory. If assigned to 100, it will use an entire GPU card exclusively.
-* `nvidia.defaultGPUNum:`
+- `nvidia.defaultGPUNum:`
   Integer type, by default: equals 1, if configuration value is 0, then the configuration value will not take effect and will be filtered. when a user does not set nvidia.com/gpu this key in pod resource, webhook should check nvidia.com/gpumem、resource-mem-percentage、nvidia.com/gpucores this three key, anyone a key having value, webhook should add nvidia.com/gpu key and this default value to resources limits map.
-* `nvidia.resourceCountName:`
+- `nvidia.resourceCountName:`
   String type, vgpu number resource name, default: "nvidia.com/gpu"
-* `nvidia.resourceMemoryName:`
+- `nvidia.resourceMemoryName:`
   String type, vgpu memory size resource name, default: "nvidia.com/gpumem"
-* `nvidia.resourceMemoryPercentageName:`
+- `nvidia.resourceMemoryPercentageName:`
   String type, vgpu memory fraction resource name, default: "nvidia.com/gpumem-percentage" 
-* `nvidia.resourceCoreName:`
+- `nvidia.resourceCoreName:`
   String type, vgpu cores resource name, default: "nvidia.com/cores"
-* `nvidia.resourcePriorityName:`
+- `nvidia.resourcePriorityName:`
   String type, vgpu task priority name, default: "nvidia.com/priority"
 
 ## Chart Configs: parameters
@@ -54,47 +54,47 @@ you can customize your vGPU support by setting the following parameters using `-
 helm install hami hami-charts/hami --set devicePlugin.deviceMemoryScaling=5 ...
 ```
 
-* `devicePlugin.service.schedulerPort:`
+- `devicePlugin.service.schedulerPort:`
   Integer type, by default: 31998, scheduler webhook service nodePort.
-* `scheduler.defaultSchedulerPolicy.nodeSchedulerPolicy:` String type, default value is "binpack", representing the GPU node scheduling policy. "binpack" means trying to allocate tasks to the same GPU node as much as possible, while "spread" means trying to allocate tasks to different GPU nodes as much as possible.
-* `scheduler.defaultSchedulerPolicy.gpuSchedulerPolicy:` String type, default value is "spread", representing the GPU scheduling policy. "binpack" means trying to allocate tasks to the same GPU as much as possible, while "spread" means trying to allocate tasks to different GPUs as much as possible.
+- `scheduler.defaultSchedulerPolicy.nodeSchedulerPolicy:` String type, default value is "binpack", representing the GPU node scheduling policy. "binpack" means trying to allocate tasks to the same GPU node as much as possible, while "spread" means trying to allocate tasks to different GPU nodes as much as possible.
+- `scheduler.defaultSchedulerPolicy.gpuSchedulerPolicy:` String type, default value is "spread", representing the GPU scheduling policy. "binpack" means trying to allocate tasks to the same GPU as much as possible, while "spread" means trying to allocate tasks to different GPUs as much as possible.
 
 ## Pod configs: annotations
 
-* `nvidia.com/use-gpuuuid:` 
+- `nvidia.com/use-gpuuuid:` 
   String type, ie: "GPU-AAA,GPU-BBB"
   If set, devices allocated by this pod must be one of UUIDs defined in this string.
-* `nvidia.com/nouse-gpuuuid`
+- `nvidia.com/nouse-gpuuuid`
   String type, ie: "GPU-AAA,GPU-BBB"
   If set, devices allocated by this pod will NOT in UUIDs defined in this string.
-* `nvidia.com/nouse-gputype:`
+- `nvidia.com/nouse-gputype:`
   String type, ie: "Tesla V100-PCIE-32GB, NVIDIA A10"
   If set, devices allocated by this pod will NOT in types defined in this string.
-* `nvidia.com/use-gputype`
+- `nvidia.com/use-gputype`
   String type, ie: "Tesla V100-PCIE-32GB, NVIDIA A10"
   If set, devices allocated by this pod MUST be one of types defined in this string.
-* `hami.io/node-scheduler-policy`
+- `hami.io/node-scheduler-policy`
   String type, "binpack" or "spread"
   binpack: the scheduler will try to allocate the pod to used GPU nodes for execution. 
   spread: the scheduler will try to allocate the pod to different GPU nodes for execution.
-* `hami.io/gpu-scheduler-policy`
+- `hami.io/gpu-scheduler-policy`
   String type, "binpack" or "spread"
   binpack: the scheduler will try to allocate the pod to the same GPU card for execution.
   spread:the scheduler will try to allocate the pod to different GPU card for execution. 
-* `nvidia.com/vgpu-mode`
+- `nvidia.com/vgpu-mode`
   String type, "hami-core" or "mig"
   Which type of vgpu instance this pod wish to use
 
 
 ## Container configs: env
 
-* `GPU_CORE_UTILIZATION_POLICY:`
+- `GPU_CORE_UTILIZATION_POLICY:`
   String type, "default", "force", "disable"
   default: "default"
   "default" means the default utilization policy
   "force" means the container will always limit the core utilization below "nvidia.com/gpucores"
   "disable" means the container will ignore the utilization limitation set by "nvidia.com/gpucores" during task execution
-* `CUDA_DISABLE_CONTROL`
+- `CUDA_DISABLE_CONTROL`
   Bool type, "true","false"
   default: false
   "true" means the HAMi-core will not be used inside container, as a result, there will be no resource isolation and limitation in that container, only for debug. 

--- a/versioned_docs/version-v1.3.0/userguide/hygon-device/enable-hygon-dcu-sharing.md
+++ b/versioned_docs/version-v1.3.0/userguide/hygon-device/enable-hygon-dcu-sharing.md
@@ -16,11 +16,11 @@ title: Enable Hygon DCU sharing
 
 ## Prerequisites
 
-* dtk driver >= 24.04
+- dtk driver >= 24.04
 
 ## Enabling DCU-sharing Support
 
-* Deploy the dcu-vgpu-device-plugin [here](https://github.com/Project-HAMi/dcu-vgpu-device-plugin)
+- Deploy the dcu-vgpu-device-plugin [here](https://github.com/Project-HAMi/dcu-vgpu-device-plugin)
 
 ## Running DCU jobs
 

--- a/versioned_docs/version-v1.3.0/userguide/metax-device/enable-metax-gpu-schedule.md
+++ b/versioned_docs/version-v1.3.0/userguide/metax-device/enable-metax-gpu-schedule.md
@@ -32,14 +32,14 @@ Equipped with MetaXLink interconnected resources.
 
 ## Prerequisites
 
-* Metax GPU extensions >= 0.8.0
-* Kubernetes >= 1.23
+- Metax GPU extensions >= 0.8.0
+- Kubernetes >= 1.23
 
 ## Enabling topo-awareness scheduling
 
-* Deploy Metax GPU Extensions on metax nodes (Please consult your device provider to acquire its package and document)
+- Deploy Metax GPU Extensions on metax nodes (Please consult your device provider to acquire its package and document)
 
-* Deploy HAMi according to README.md
+- Deploy HAMi according to README.md
 
 ## Running Metax jobs
 

--- a/versioned_docs/version-v1.3.0/userguide/mthreads-device/enable-mthreads-gpu-sharing.md
+++ b/versioned_docs/version-v1.3.0/userguide/mthreads-device/enable-mthreads-gpu-sharing.md
@@ -24,16 +24,16 @@ title: Enable Mthreads GPU sharing
 
 ## Prerequisites
 
-* [MT CloudNative Toolkits > 1.9.0](https://docs.mthreads.com/cloud-native/cloud-native-doc-online/)
-* driver version >= 1.2.0
+- [MT CloudNative Toolkits > 1.9.0](https://docs.mthreads.com/cloud-native/cloud-native-doc-online/)
+- driver version >= 1.2.0
 
 ## Enabling GPU-sharing Support
 
-* Deploy MT-CloudNative Toolkit on mthreads nodes (Please consult your device provider to acquire its package and document)
+- Deploy MT-CloudNative Toolkit on mthreads nodes (Please consult your device provider to acquire its package and document)
 
 > **NOTICE:** *You can remove mt-mutating-webhook and mt-gpu-scheduler after installation(optional).*
 
-* set the 'devices.mthreads.enabled = true' when installing hami
+- set the 'devices.mthreads.enabled = true' when installing hami
 
 ```
 helm install hami hami-charts/hami --set scheduler.kubeScheduler.imageTag={your kubernetes version} --set device.mthreads.enabled=true -n kube-system

--- a/versioned_docs/version-v1.3.0/userguide/nvidia-device/dynamic-mig-support.md
+++ b/versioned_docs/version-v1.3.0/userguide/nvidia-device/dynamic-mig-support.md
@@ -18,15 +18,15 @@ title: Enable dynamic-mig feature
 
 ## Prerequisites
 
-* NVIDIA Blackwell and Hopper™ and Ampere Devices
-* HAMi > v2.5.0
-* NVIDIA Container Toolkit
+- NVIDIA Blackwell and Hopper™ and Ampere Devices
+- HAMi > v2.5.0
+- NVIDIA Container Toolkit
 
 ## Enabling Dynamic-mig Support
 
-* Install the chart using helm, See 'enabling vGPU support in kubernetes' section [here](https://github.com/Project-HAMi/HAMi#enabling-vgpu-support-in-kubernetes)
+- Install the chart using helm, See 'enabling vGPU support in kubernetes' section [here](https://github.com/Project-HAMi/HAMi#enabling-vgpu-support-in-kubernetes)
 
-* Configure `mode` in device-plugin configMap to `mig` for MIG nodes
+- Configure `mode` in device-plugin configMap to `mig` for MIG nodes
 ```
 kubectl describe cm  hami-device-plugin -n kube-system
 ```
@@ -46,9 +46,9 @@ kubectl describe cm  hami-device-plugin -n kube-system
 }
 ```
 
-* Restart the following pods for the change to take effect:
-  * hami-scheduler 
-  * hami-device-plugin on 'MIG-NODE-A'
+- Restart the following pods for the change to take effect:
+  - hami-scheduler 
+  - hami-device-plugin on 'MIG-NODE-A'
 
 ## Custom mig configuration (Optional)
 HAMi currently has a [built-in mig configuration](https://github.com/Project-HAMi/HAMi/blob/master/charts/hami/templates/scheduler/device-configmap.yaml) for MIG.

--- a/versioned_docs/version-v2.4.1/contributor/governance.md
+++ b/versioned_docs/version-v2.4.1/contributor/governance.md
@@ -8,21 +8,21 @@ Heterogeneous AI Computing Virtualization Middleware (HAMi), formerly known as k
 
 The HAMi and its leadership embrace the following values:
 
-* Openness: Communication and decision-making happens in the open and is discoverable for future
+- Openness: Communication and decision-making happens in the open and is discoverable for future
   reference. As much as possible, all discussions and work take place in public
   forums and open repositories.
 
-* Fairness: All stakeholders have the opportunity to provide feedback and submit
+- Fairness: All stakeholders have the opportunity to provide feedback and submit
   contributions, which will be considered on their merits.
 
-* Community over Product or Company: Sustaining and growing the community takes
+- Community over Product or Company: Sustaining and growing the community takes
   priority over shipping code or sponsors' organizational goals. Each
   contributor participates in the project as an individual.
 
-* Inclusivity: Innovation comes from different perspectives and skill sets, and this
+- Inclusivity: Innovation comes from different perspectives and skill sets, and this
   can only be accomplished in a welcoming and respectful environment.
 
-* Participation: Responsibilities within the project are earned through
+- Participation: Responsibilities within the project are earned through
   participation, and there is a clear path up the contributor ladder into leadership
   positions.
 

--- a/versioned_docs/version-v2.4.1/contributor/ladder.md
+++ b/versioned_docs/version-v2.4.1/contributor/ladder.md
@@ -12,38 +12,38 @@ Each of the contributor roles below is organized into lists of three types of th
 
 Description: A Community Participant engages with the project and its community, contributing their time, thoughts, etc. Community participants are usually users who have stopped being anonymous and started being active in project discussions.
 
-* Responsibilities:
-  * Must follow the [CNCF CoC](https://github.com/cncf/foundation/blob/main/code-of-conduct.md)
-* How users can get involved with the community:
-  * Participating in community discussions
-  * Helping other users
-  * Submitting bug reports
-  * Commenting on issues
-  * Trying out new releases
-  * Attending community events
+- Responsibilities:
+  - Must follow the [CNCF CoC](https://github.com/cncf/foundation/blob/main/code-of-conduct.md)
+- How users can get involved with the community:
+  - Participating in community discussions
+  - Helping other users
+  - Submitting bug reports
+  - Commenting on issues
+  - Trying out new releases
+  - Attending community events
 
 ## Contributor
 
 Description: A Contributor contributes directly to the project and adds value to it. Contributions need not be code. People at the Contributor level may be new contributors, or they may only contribute occasionally.
 
-* Responsibilities include:
-  * Follow the CNCF CoC
-  * Follow the project contributing guide
-* Requirements (one or several of the below):
-  * Report and sometimes resolve issues
-  * Occasionally submit PRs
-  * Contribute to the documentation
-  * Show up at meetings, takes notes
-  * Answer questions from other community members
-  * Submit feedback on issues and PRs
-  * Test releases and patches and submit reviews
-  * Run or helps run events
-  * Promote the project in public
-  * Help run the project infrastructure
-  * [TODO: other small contributions]
-* Privileges:
-  * Invitations to contributor events
-  * Eligible to become an Organization Member
+- Responsibilities include:
+  - Follow the CNCF CoC
+  - Follow the project contributing guide
+- Requirements (one or several of the below):
+  - Report and sometimes resolve issues
+  - Occasionally submit PRs
+  - Contribute to the documentation
+  - Show up at meetings, takes notes
+  - Answer questions from other community members
+  - Submit feedback on issues and PRs
+  - Test releases and patches and submit reviews
+  - Run or helps run events
+  - Promote the project in public
+  - Help run the project infrastructure
+  - [TODO: other small contributions]
+- Privileges:
+  - Invitations to contributor events
+  - Eligible to become an Organization Member
 
 A very special thanks to the [long list of people](https://github.com/Project-HAMi/HAMi/blob/master/AUTHORS.md) who have contributed to and helped maintain the project. Thanks to everyone who contributed and helped maintain the project.
 
@@ -55,31 +55,31 @@ Description: An Organization Member is an established contributor who regularly 
 
 An Organization Member must meet the responsibilities and has the requirements of a Contributor, plus:
 
-* Responsibilities include:
-  * Continues to contribute regularly, as demonstrated by having at least 50 GitHub contributions per year
-* Requirements:
-  * Enabled [two-factor authentication] on their GitHub account
-  * Must have successful contributions to the project or community, including at least one of the following:
-    * 5 accepted PRs,
-    * Reviewed 5 PRs,
-    * Resolved and closed 3 Issues,
-    * Become responsible for a key project management area,
-    * Or some equivalent combination or contribution
-  * Must have been contributing for at least 1 months
-  * Must be actively contributing to at least one project area
-  * Must have two sponsors who are also Organization Members, at least one of whom does not work for the same employer
-  * **Open an issue against the Project-HAMi/HAMi repo**
-    * Ensure your sponsors are @mentioned on the issue
-    * Complete every item on the issue checklist
-    * Make sure that the list of contributions included is representative of your work on the project.
-  * Have your sponsoring reviewers reply confirmation of sponsorship: `+1`
-  * Once your sponsors have responded, your request will be handled by the `HAMi GitHub Admin team`.
+- Responsibilities include:
+  - Continues to contribute regularly, as demonstrated by having at least 50 GitHub contributions per year
+- Requirements:
+  - Enabled [two-factor authentication] on their GitHub account
+  - Must have successful contributions to the project or community, including at least one of the following:
+    - 5 accepted PRs,
+    - Reviewed 5 PRs,
+    - Resolved and closed 3 Issues,
+    - Become responsible for a key project management area,
+    - Or some equivalent combination or contribution
+  - Must have been contributing for at least 1 months
+  - Must be actively contributing to at least one project area
+  - Must have two sponsors who are also Organization Members, at least one of whom does not work for the same employer
+  - **Open an issue against the Project-HAMi/HAMi repo**
+    - Ensure your sponsors are @mentioned on the issue
+    - Complete every item on the issue checklist
+    - Make sure that the list of contributions included is representative of your work on the project.
+  - Have your sponsoring reviewers reply confirmation of sponsorship: `+1`
+  - Once your sponsors have responded, your request will be handled by the `HAMi GitHub Admin team`.
 
-* Privileges:
-  * May be assigned Issues and Reviews
-  * May give commands to CI/CD automation
-  * Can be added to [TODO: Repo Host] teams
-  * Can recommend other contributors to become Org Members
+- Privileges:
+  - May be assigned Issues and Reviews
+  - May give commands to CI/CD automation
+  - Can be added to [TODO: Repo Host] teams
+  - Can recommend other contributors to become Org Members
 
 The process for a Contributor to become an Organization Member is as follows:
 
@@ -94,22 +94,22 @@ Reviewers are responsible for a "specific area." This can be a specific code dir
 
 Reviewers have all the rights and responsibilities of an Organization Member, plus:
 
-* Responsibilities include:
-  * Following the reviewing guide
-  * Reviewing most Pull Requests against their specific areas of responsibility
-  * Reviewing at least 20 PRs per year
-  * Helping other contributors become reviewers
-* Requirements:
-  * Experience as a Contributor for at least 3 months
-  * Is an Organization Member
-  * Has reviewed, or helped review, at least 10 Pull Requests
-  * Has analyzed and resolved test failures in their specific area
-  * Has demonstrated an in-depth knowledge of the specific area
-  * Commits to being responsible for that specific area
-  * Is supportive of new and occasional contributors and helps get useful PRs in shape to commit
-* Additional privileges:
-  * Has GitHub or CI/CD rights to approve pull requests in specific directories
-  * Can recommend and review other contributors to become Reviewers
+- Responsibilities include:
+  - Following the reviewing guide
+  - Reviewing most Pull Requests against their specific areas of responsibility
+  - Reviewing at least 20 PRs per year
+  - Helping other contributors become reviewers
+- Requirements:
+  - Experience as a Contributor for at least 3 months
+  - Is an Organization Member
+  - Has reviewed, or helped review, at least 10 Pull Requests
+  - Has analyzed and resolved test failures in their specific area
+  - Has demonstrated an in-depth knowledge of the specific area
+  - Commits to being responsible for that specific area
+  - Is supportive of new and occasional contributors and helps get useful PRs in shape to commit
+- Additional privileges:
+  - Has GitHub or CI/CD rights to approve pull requests in specific directories
+  - Can recommend and review other contributors to become Reviewers
 
 The process of becoming a Reviewer is:
 
@@ -126,15 +126,15 @@ The current list of maintainers can be found in the [MAINTAINERS](https://github
 
 ## An active maintainer should
 
-* Actively participate in reviewing pull requests and incoming issues. There are no hard rules on what is “active enough” and this is left up to the judgement of the current group of maintainers.
+- Actively participate in reviewing pull requests and incoming issues. There are no hard rules on what is “active enough” and this is left up to the judgement of the current group of maintainers.
 
-* Actively participate in discussions about design and the future of the project.
+- Actively participate in discussions about design and the future of the project.
 
-* Take responsibility for backports to appropriate branches for PRs they approve and merge.
+- Take responsibility for backports to appropriate branches for PRs they approve and merge.
 
-* Do their best to follow all code, testing, and design conventions as determined by consensus among active maintainers.
+- Do their best to follow all code, testing, and design conventions as determined by consensus among active maintainers.
 
-* Gracefully step down from their maintainership role when they are no longer planning to actively participate in the project.
+- Gracefully step down from their maintainership role when they are no longer planning to actively participate in the project.
 
 ## How to be a maintainer
 
@@ -150,12 +150,12 @@ It is normal for maintainers to come and go based on their other responsibilitie
 
 It is important for contributors to be and stay active to set an example and show commitment to the project. Inactivity is harmful to the project as it may lead to unexpected delays, contributor attrition, and a lost of trust in the project.
 
-* Inactivity is measured by:
-  * Periods of no contributions for longer than 3 months
-  * Periods of no communication for longer than 3 months
-* Consequences of being inactive include:
-  * Involuntary removal or demotion
-  * Being asked to move to Emeritus status
+- Inactivity is measured by:
+  - Periods of no contributions for longer than 3 months
+  - Periods of no communication for longer than 3 months
+- Consequences of being inactive include:
+  - Involuntary removal or demotion
+  - Being asked to move to Emeritus status
 
 ## Involuntary Removal or Demotion
 

--- a/versioned_docs/version-v2.4.1/key-features/features.md
+++ b/versioned_docs/version-v2.4.1/key-features/features.md
@@ -4,15 +4,15 @@ title: Key Features
 
 ## Cross-cloud multi-cluster multi-mode management
 Karmada supports:
-* Safe isolation:
-  * Create a namespace for each cluster, prefixed with `karmada-es-`.
-* [Multi-mode](https://karmada.io/docs/userguide/clustermanager/cluster-registration) connection:
-  * Push: Karmada is directly connected to the cluster kube-apiserver.
-  * Pull: Deploy one agent component in the cluster, Karmada delegates tasks to the agent component.
-* Multi-cloud support(Only if compliant with Kubernetes specifications):
-  * Support various public cloud vendors.
-  * Support for private cloud.
-  * Support self-built clusters.
+- Safe isolation:
+  - Create a namespace for each cluster, prefixed with `karmada-es-`.
+- [Multi-mode](https://karmada.io/docs/userguide/clustermanager/cluster-registration) connection:
+  - Push: Karmada is directly connected to the cluster kube-apiserver.
+  - Pull: Deploy one agent component in the cluster, Karmada delegates tasks to the agent component.
+- Multi-cloud support(Only if compliant with Kubernetes specifications):
+  - Support various public cloud vendors.
+  - Support for private cloud.
+  - Support self-built clusters.
 
 The overall relationship between the member cluster and the control plane is shown in the following figure:  
 
@@ -21,19 +21,19 @@ The overall relationship between the member cluster and the control plane is sho
 
 ## Multi-policy multi-cluster scheduling
 Karmada supports:
-* Cluster distribution capability under [different scheduling strategies](https://karmada.io/docs/userguide/scheduling/resource-propagating):
-  * ClusterAffinity: Oriented scheduling based on ClusterName, Label, Field.
-  * Toleration: Scheduling based on Taint and Toleration.
-  * SpreadConstraint: Scheduling based on cluster topology.
-  * ReplicasScheduling: Replication mode and split mode for instanced workloads.
-* Differential configuration([OverridePolicy](https://karmada.io/docs/userguide/scheduling/override-policy)):
-  * ImageOverrider: Differentiated configuration of mirrors.
-  * ArgsOverrider: Differentiated configuration of execution parameters.
-  * CommandOverrider: Differentiated configuration for execution commands.
-  * PlainText: Customized Differentiation Configuration.
-* [Support reschedule](https://karmada.io/docs/userguide/scheduling/descheduler) with following components:
-  * Descheduler(karmada-descheduler): Trigger rescheduling based on instance state changes in member clusters.
-  * Scheduler-estimator(karmada-scheduler-estimator): Provides the scheduler with a more precise desired state of the running instances of the member cluster.
+- Cluster distribution capability under [different scheduling strategies](https://karmada.io/docs/userguide/scheduling/resource-propagating):
+  - ClusterAffinity: Oriented scheduling based on ClusterName, Label, Field.
+  - Toleration: Scheduling based on Taint and Toleration.
+  - SpreadConstraint: Scheduling based on cluster topology.
+  - ReplicasScheduling: Replication mode and split mode for instanced workloads.
+- Differential configuration([OverridePolicy](https://karmada.io/docs/userguide/scheduling/override-policy)):
+  - ImageOverrider: Differentiated configuration of mirrors.
+  - ArgsOverrider: Differentiated configuration of execution parameters.
+  - CommandOverrider: Differentiated configuration for execution commands.
+  - PlainText: Customized Differentiation Configuration.
+- [Support reschedule](https://karmada.io/docs/userguide/scheduling/descheduler) with following components:
+  - Descheduler(karmada-descheduler): Trigger rescheduling based on instance state changes in member clusters.
+  - Scheduler-estimator(karmada-scheduler-estimator): Provides the scheduler with a more precise desired state of the running instances of the member cluster.
 
 Much like k8s scheduling, Karmada support different scheduling policy. The overall scheduling process is shown in the figure below:  
 
@@ -46,12 +46,12 @@ If one cluster does not have enough resource to accommodate their pods, Karamda 
 
 ## Cross-cluster failover of applications
 Karmada supports:
-* [Cluster failover](https://karmada.io/docs/userguide/failover/):
-  * Karmada supports users to set distribution policies, and automatically migrates the faulty cluster replicas in a centralized or decentralized manner after a cluster failure.
-* Cluster taint settings:
-  * When the user sets a taint for the cluster and the resource distribution strategy cannot tolerate the taint, Karmada will also automatically trigger the migration of the cluster replicas.
-* Uninterrupted service:
-  * During the replicas migration process, Karmada can ensure that the service replicas does not drop to zero, thereby ensuring that the service will not be interrupted.
+- [Cluster failover](https://karmada.io/docs/userguide/failover/):
+  - Karmada supports users to set distribution policies, and automatically migrates the faulty cluster replicas in a centralized or decentralized manner after a cluster failure.
+- Cluster taint settings:
+  - When the user sets a taint for the cluster and the resource distribution strategy cannot tolerate the taint, Karmada will also automatically trigger the migration of the cluster replicas.
+- Uninterrupted service:
+  - During the replicas migration process, Karmada can ensure that the service replicas does not drop to zero, thereby ensuring that the service will not be interrupted.
 
 Karmada supports failover for clusters, one cluster failure will cause failover of replicas as follows:  
 
@@ -59,14 +59,14 @@ Karmada supports failover for clusters, one cluster failure will cause failover 
 
 ## Global Uniform Resource View
 Karmada supports:
-* [Resource status collection and aggregation](https://karmada.io/docs/userguide/globalview/customizing-resource-interpreter): Collect and aggregate state into resource templates with the help of the Resource Interpreter.
-  * User-defined resource, triggering webhook remote calls.
-  * Fixed encoding in Karmada for some common resource types.
-* [Unified resource management](https://karmada.io/docs/userguide/globalview/aggregated-api-endpoint): Unified management for `create`, `update`, `delete`, `query`.
-* [Unified operations](https://karmada.io/docs/userguide/globalview/proxy-global-resource): Exec operations command(`describe`, `exec`, `logs`) in one k8s context.
-* [Global search for resources and events](https://karmada.io/docs/tutorials/karmada-search/):
-  * Cache query: global fuzzy search and global precise search are supported.
-  * Third-party storage: Search engine (Elasticsearch or OpenSearch), relational database, graph database are supported.
+- [Resource status collection and aggregation](https://karmada.io/docs/userguide/globalview/customizing-resource-interpreter): Collect and aggregate state into resource templates with the help of the Resource Interpreter.
+  - User-defined resource, triggering webhook remote calls.
+  - Fixed encoding in Karmada for some common resource types.
+- [Unified resource management](https://karmada.io/docs/userguide/globalview/aggregated-api-endpoint): Unified management for `create`, `update`, `delete`, `query`.
+- [Unified operations](https://karmada.io/docs/userguide/globalview/proxy-global-resource): Exec operations command(`describe`, `exec`, `logs`) in one k8s context.
+- [Global search for resources and events](https://karmada.io/docs/tutorials/karmada-search/):
+  - Cache query: global fuzzy search and global precise search are supported.
+  - Third-party storage: Search engine (Elasticsearch or OpenSearch), relational database, graph database are supported.
 
 Users can access and operate all member clusters via karmada-apiserver:  
 
@@ -78,15 +78,15 @@ Users also can check and search all member clusters resources via karmada-apiser
 
 ## Separating the concerns of different roles
 karmada supports:
-* [Unified authentication](https://karmada.io/docs/userguide/roleseparation/unifiedAuth):
-  * Aggregate API unified access entry.
-  * Access control is consistent with member clusters.
-* Unified resource quota(`FederatedResourceQuota`):
-  * Globally configures the ResourceQuota of each member cluster.
-  * Configure ResourceQuota at the federation level.
-  * Collects the resource usage of each member cluster in real time.
-* Reusable scheduling strategy:
-  * Resource templates are decoupled from scheduling policies, plug and play.
+- [Unified authentication](https://karmada.io/docs/userguide/roleseparation/unifiedAuth):
+  - Aggregate API unified access entry.
+  - Access control is consistent with member clusters.
+- Unified resource quota(`FederatedResourceQuota`):
+  - Globally configures the ResourceQuota of each member cluster.
+  - Configure ResourceQuota at the federation level.
+  - Collects the resource usage of each member cluster in real time.
+- Reusable scheduling strategy:
+  - Resource templates are decoupled from scheduling policies, plug and play.
 
 Users can access all member clusters with unified authentication:
 
@@ -98,10 +98,10 @@ Users also can defined global resource quota via `FederatedResourceQuota`:
 
 ## Cross-cluster service governance
 karmada supports:
-* [Multi-cluster service discovery](https://karmada.io/docs/userguide/service/multi-cluster-service):
-  * With ServiceExport and ServiceImport, achieving cross-cluster service discovery.
-* [Multi-cluster network support](https://karmada.io/docs/userguide/network/working-with-submariner):
-  * Use `Submariner` to open up the container network between clusters.
+- [Multi-cluster service discovery](https://karmada.io/docs/userguide/service/multi-cluster-service):
+  - With ServiceExport and ServiceImport, achieving cross-cluster service discovery.
+- [Multi-cluster network support](https://karmada.io/docs/userguide/network/working-with-submariner):
+  - Use `Submariner` to open up the container network between clusters.
 
 Users can enable service governance for cross-cluster with Karmada:  
 

--- a/versioned_docs/version-v2.4.1/releases.md
+++ b/versioned_docs/version-v2.4.1/releases.md
@@ -22,13 +22,13 @@ Major releases contain large features, design and architectural changes, and may
 
 Minor releases contain features, enhancements, and fixes that are introduced in a backwards-compatible manner. Since Karmada is a fast growing project and features continue to iterate rapidly, having a minor release approximately every few months helps balance speed and stability.
 
-* Roughly every 3 months
+- Roughly every 3 months
 
 ### PATCH release
 
 Patch releases are for backwards-compatible bug fixes and very minor enhancements which do not impact stability or compatibility. Typically only critical fixes are selected for patch releases. Usually there will be at least one patch release in a minor release cycle.
 
-* When critical fixes are required, or roughly each month
+- When critical fixes are required, or roughly each month
 
 ### Versioning
 
@@ -47,15 +47,15 @@ Critical issues, with no work-arounds, are added to the next patch release.
 
 Release branches and PRs are managed as follows:
 
-* All changes are always first committed to `master`.
-* Branches are created for each major or minor release.
-* The branch name will contain the version, for example release-1.2.
-* Patch releases are created from a release branch.
-* For critical fixes that need to be included in a patch release, PRs should always be first merged to master and then cherry-picked to the release branch. PRs need to be guaranteed to have a release note written and these descriptions will be reflected in the next patch release.
+- All changes are always first committed to `master`.
+- Branches are created for each major or minor release.
+- The branch name will contain the version, for example release-1.2.
+- Patch releases are created from a release branch.
+- For critical fixes that need to be included in a patch release, PRs should always be first merged to master and then cherry-picked to the release branch. PRs need to be guaranteed to have a release note written and these descriptions will be reflected in the next patch release.
   The cherry-pick process of PRs is executed through the script. See usage [here](https://karmada.io/docs/contributor/cherry-picks).
-* For complex changes, specially critical bugfixes, separate PRs may be required for master and release branches.
-* The milestone mark (for example v1.4) will be added to PRs which means changes in PRs are one of the contents of the corresponding release.
-* During PR review, the Assignee selection is used to indicate the reviewer.
+- For complex changes, specially critical bugfixes, separate PRs may be required for master and release branches.
+- The milestone mark (for example v1.4) will be added to PRs which means changes in PRs are one of the contents of the corresponding release.
+- During PR review, the Assignee selection is used to indicate the reviewer.
 
 ### Release Planning
 
@@ -74,26 +74,26 @@ For example, [here](https://hub.docker.com/r/karmada/karmada-controller-manager)
 
 Since v1.2.0, the following artifacts are uploaded:
 
-* crds.tar.gz
-* karmada-chart-v\<version_number\>.tgz
-* karmadactl-darwin-amd64.tgz
-* karmadactl-darwin-amd64.tgz.sha256
-* karmadactl-darwin-arm64.tgz
-* karmadactl-darwin-arm64.tgz.sha256
-* karmadactl-linux-amd64.tgz
-* karmadactl-linux-amd64.tgz.sha256
-* karmadactl-linux-arm64.tgz
-* karmadactl-linux-arm64.tgz.sha256
-* kubectl-karmada-darwin-amd64.tgz
-* kubectl-karmada-darwin-amd64.tgz.sha256
-* kubectl-karmada-darwin-arm64.tgz
-* kubectl-karmada-darwin-arm64.tgz.sha256
-* kubectl-karmada-linux-amd64.tgz
-* kubectl-karmada-linux-amd64.tgz.sha256
-* kubectl-karmada-linux-arm64.tgz
-* kubectl-karmada-linux-arm64.tgz.sha256
-* Source code(zip)
-* Source code(tar.gz)
+- crds.tar.gz
+- karmada-chart-v\<version_number\>.tgz
+- karmadactl-darwin-amd64.tgz
+- karmadactl-darwin-amd64.tgz.sha256
+- karmadactl-darwin-arm64.tgz
+- karmadactl-darwin-arm64.tgz.sha256
+- karmadactl-linux-amd64.tgz
+- karmadactl-linux-amd64.tgz.sha256
+- karmadactl-linux-arm64.tgz
+- karmadactl-linux-arm64.tgz.sha256
+- kubectl-karmada-darwin-amd64.tgz
+- kubectl-karmada-darwin-amd64.tgz.sha256
+- kubectl-karmada-darwin-arm64.tgz
+- kubectl-karmada-darwin-arm64.tgz.sha256
+- kubectl-karmada-linux-amd64.tgz
+- kubectl-karmada-linux-amd64.tgz.sha256
+- kubectl-karmada-linux-arm64.tgz
+- kubectl-karmada-linux-arm64.tgz.sha256
+- Source code(zip)
+- Source code(tar.gz)
 
 You can visit `https://github.com/Project-HAMi/HAMi/releases/download/v<version_number>/<artifact_name>` to download the artifacts above.
 

--- a/versioned_docs/version-v2.4.1/roadmap.md
+++ b/versioned_docs/version-v2.4.1/roadmap.md
@@ -11,9 +11,9 @@ The items below are intended to inspire further community engagement to keep HAM
 
 ## 2022 H1
 - Multi-cluster HA scheduling policy
-    * spread by region
-    * spread by zone
-    * spread by provider
+    - spread by region
+    - spread by zone
+    - spread by provider
 - Multi-cluster Ingress
 - Multi-cluster HPA (Horizontal Pod Autoscaling)
 - Federated resource quota

--- a/versioned_docs/version-v2.4.1/userguide/ascend-device/enable-ascend-sharing.md
+++ b/versioned_docs/version-v2.4.1/userguide/ascend-device/enable-ascend-sharing.md
@@ -8,13 +8,13 @@ Memory slicing is supported based on virtualization template, lease available te
 
 ## Prerequisites
 
-* Ascend device type: 910B,910A,310P
-* driver version >= 24.1.rc1
-* Ascend docker runtime
+- Ascend device type: 910B,910A,310P
+- driver version >= 24.1.rc1
+- Ascend docker runtime
 
 ## Enabling Ascend-sharing Support
 
-* Due to dependencies with HAMi, you need to set 
+- Due to dependencies with HAMi, you need to set 
 
 ```
 devices.ascend.enabled=true
@@ -41,14 +41,14 @@ devices:
       - huawei.com/Ascend310P-memory
 ```
 
-* Tag Ascend node with the following command
+- Tag Ascend node with the following command
 ```
 kubectl label node {ascend-node} ascend=on
 ```
 
-* Install [Ascend docker runtime](https://gitee.com/ascend/ascend-docker-runtime)
+- Install [Ascend docker runtime](https://gitee.com/ascend/ascend-docker-runtime)
 
-* Download yaml for Ascend-vgpu-device-plugin from HAMi Project [here](https://github.com/Project-HAMi/ascend-device-plugin/blob/master/build/ascendplugin-hami.yaml), and deploy
+- Download yaml for Ascend-vgpu-device-plugin from HAMi Project [here](https://github.com/Project-HAMi/ascend-device-plugin/blob/master/build/ascendplugin-hami.yaml), and deploy
 
 ```
 wge https://raw.githubusercontent.com/Project-HAMi/ascend-device-plugin/refs/heads/main/ascend-device-plugin.yaml

--- a/versioned_docs/version-v2.4.1/userguide/cambricon-device/enable-cambricon-mlu-sharing.md
+++ b/versioned_docs/version-v2.4.1/userguide/cambricon-device/enable-cambricon-mlu-sharing.md
@@ -16,13 +16,13 @@ title: Enable cambricon MLU sharing
 
 ## Prerequisites
 
-* neuware-mlu370-driver > 5.0.0
-* cambricon-device-plugin > 2.0.9
-* cntoolkit > 2.5.3
+- neuware-mlu370-driver > 5.0.0
+- cambricon-device-plugin > 2.0.9
+- cntoolkit > 2.5.3
 
 ## Enabling MLU-sharing Support
 
-* Contact your device provider to acquire cambricon-device-plugin>2.0.9, edit parameter `mode` to 'dynamic-smlu` in containers.args field.
+- Contact your device provider to acquire cambricon-device-plugin>2.0.9, edit parameter `mode` to 'dynamic-smlu` in containers.args field.
 
 ```
         args:
@@ -30,11 +30,11 @@ title: Enable cambricon MLU sharing
 	...
 ```
 
-* Deploy modified cambricon-device-plugin
+- Deploy modified cambricon-device-plugin
 
-* Install the chart using helm, See 'enabling vGPU support in kubernetes' section [here](https://github.com/Project-HAMi/HAMi#enabling-vgpu-support-in-kubernetes)
+- Install the chart using helm, See 'enabling vGPU support in kubernetes' section [here](https://github.com/Project-HAMi/HAMi#enabling-vgpu-support-in-kubernetes)
 
-* Activate the smlu mode for each MLUs on that node
+- Activate the smlu mode for each MLUs on that node
 ```
 cnmon set -c 0 -smlu on
 cnmon set -c 1 -smlu on

--- a/versioned_docs/version-v2.4.1/userguide/configure.md
+++ b/versioned_docs/version-v2.4.1/userguide/configure.md
@@ -21,29 +21,29 @@ You can update these configurations using one of the following methods:
     After making changes, restart the related HAMi components to apply the updated configurations.
 2. Modify Helm Chart: Update the corresponding values in the [ConfigMap](https://raw.githubusercontent.com/archlitchi/HAMi/refs/heads/master/charts/hami/templates/scheduler/device-configmap.yaml), then reapply the Helm Chart to regenerate the ConfigMap.
 
-* `nvidia.deviceMemoryScaling:` 
+- `nvidia.deviceMemoryScaling:` 
   Float type, by default: 1. The ratio for NVIDIA device memory scaling, can be greater than 1 (enable virtual device memory, experimental feature). For NVIDIA GPU with *M* memory, if `nvidia.deviceMemoryScaling` is set argument to *S*, vGPUs split by this GPU will totally get `S * M` memory in Kubernetes with the HAMi device plugin.
-* `nvidia.deviceSplitCount:` 
+- `nvidia.deviceSplitCount:` 
   Integer type, by default: equals 10. Maximum tasks assigned to a simple GPU device.
-* `nvidia.migstrategy:`
+- `nvidia.migstrategy:`
   String type, "none" for ignoring MIG features or "mixed" for allocating MIG device by separate resources. Default "none"
-* `nvidia.disablecorelimit:`
+- `nvidia.disablecorelimit:`
   String type, "true" for disable core limit, "false" for enable core limit, default: false
-* `nvidia.defaultMem:` 
+- `nvidia.defaultMem:` 
   Integer type, by default: 0. The default device memory of the current task, in MB.'0' means use 100% device memory
-* `nvidia.defaultCores:` 
+- `nvidia.defaultCores:` 
   Integer type, by default: equals 0. Percentage of GPU cores reserved for the current task. If assigned to 0, it may fit in any GPU with enough device memory. If assigned to 100, it will use an entire GPU card exclusively.
-* `nvidia.defaultGPUNum:`
+- `nvidia.defaultGPUNum:`
   Integer type, by default: equals 1, if configuration value is 0, then the configuration value will not take effect and will be filtered. when a user does not set nvidia.com/gpu this key in pod resource, webhook should check nvidia.com/gpumem、resource-mem-percentage、nvidia.com/gpucores this three key, anyone a key having value, webhook should add nvidia.com/gpu key and this default value to resources limits map.
-* `nvidia.resourceCountName:`
+- `nvidia.resourceCountName:`
   String type, vgpu number resource name, default: "nvidia.com/gpu"
-* `nvidia.resourceMemoryName:`
+- `nvidia.resourceMemoryName:`
   String type, vgpu memory size resource name, default: "nvidia.com/gpumem"
-* `nvidia.resourceMemoryPercentageName:`
+- `nvidia.resourceMemoryPercentageName:`
   String type, vgpu memory fraction resource name, default: "nvidia.com/gpumem-percentage" 
-* `nvidia.resourceCoreName:`
+- `nvidia.resourceCoreName:`
   String type, vgpu cores resource name, default: "nvidia.com/cores"
-* `nvidia.resourcePriorityName:`
+- `nvidia.resourcePriorityName:`
   String type, vgpu task priority name, default: "nvidia.com/priority"
 
 ## Chart Configs: parameters
@@ -54,47 +54,47 @@ you can customize your vGPU support by setting the following parameters using `-
 helm install hami hami-charts/hami --set devicePlugin.deviceMemoryScaling=5 ...
 ```
 
-* `devicePlugin.service.schedulerPort:`
+- `devicePlugin.service.schedulerPort:`
   Integer type, by default: 31998, scheduler webhook service nodePort.
-* `scheduler.defaultSchedulerPolicy.nodeSchedulerPolicy:` String type, default value is "binpack", representing the GPU node scheduling policy. "binpack" means trying to allocate tasks to the same GPU node as much as possible, while "spread" means trying to allocate tasks to different GPU nodes as much as possible.
-* `scheduler.defaultSchedulerPolicy.gpuSchedulerPolicy:` String type, default value is "spread", representing the GPU scheduling policy. "binpack" means trying to allocate tasks to the same GPU as much as possible, while "spread" means trying to allocate tasks to different GPUs as much as possible.
+- `scheduler.defaultSchedulerPolicy.nodeSchedulerPolicy:` String type, default value is "binpack", representing the GPU node scheduling policy. "binpack" means trying to allocate tasks to the same GPU node as much as possible, while "spread" means trying to allocate tasks to different GPU nodes as much as possible.
+- `scheduler.defaultSchedulerPolicy.gpuSchedulerPolicy:` String type, default value is "spread", representing the GPU scheduling policy. "binpack" means trying to allocate tasks to the same GPU as much as possible, while "spread" means trying to allocate tasks to different GPUs as much as possible.
 
 ## Pod configs: annotations
 
-* `nvidia.com/use-gpuuuid:` 
+- `nvidia.com/use-gpuuuid:` 
   String type, ie: "GPU-AAA,GPU-BBB"
   If set, devices allocated by this pod must be one of UUIDs defined in this string.
-* `nvidia.com/nouse-gpuuuid`
+- `nvidia.com/nouse-gpuuuid`
   String type, ie: "GPU-AAA,GPU-BBB"
   If set, devices allocated by this pod will NOT in UUIDs defined in this string.
-* `nvidia.com/nouse-gputype:`
+- `nvidia.com/nouse-gputype:`
   String type, ie: "Tesla V100-PCIE-32GB, NVIDIA A10"
   If set, devices allocated by this pod will NOT in types defined in this string.
-* `nvidia.com/use-gputype`
+- `nvidia.com/use-gputype`
   String type, ie: "Tesla V100-PCIE-32GB, NVIDIA A10"
   If set, devices allocated by this pod MUST be one of types defined in this string.
-* `hami.io/node-scheduler-policy`
+- `hami.io/node-scheduler-policy`
   String type, "binpack" or "spread"
   binpack: the scheduler will try to allocate the pod to used GPU nodes for execution. 
   spread: the scheduler will try to allocate the pod to different GPU nodes for execution.
-* `hami.io/gpu-scheduler-policy`
+- `hami.io/gpu-scheduler-policy`
   String type, "binpack" or "spread"
   binpack: the scheduler will try to allocate the pod to the same GPU card for execution.
   spread:the scheduler will try to allocate the pod to different GPU card for execution. 
-* `nvidia.com/vgpu-mode`
+- `nvidia.com/vgpu-mode`
   String type, "hami-core" or "mig"
   Which type of vgpu instance this pod wish to use
 
 
 ## Container configs: env
 
-* `GPU_CORE_UTILIZATION_POLICY:`
+- `GPU_CORE_UTILIZATION_POLICY:`
   String type, "default", "force", "disable"
   default: "default"
   "default" means the default utilization policy
   "force" means the container will always limit the core utilization below "nvidia.com/gpucores"
   "disable" means the container will ignore the utilization limitation set by "nvidia.com/gpucores" during task execution
-* `CUDA_DISABLE_CONTROL`
+- `CUDA_DISABLE_CONTROL`
   Bool type, "true","false"
   default: false
   "true" means the HAMi-core will not be used inside container, as a result, there will be no resource isolation and limitation in that container, only for debug. 

--- a/versioned_docs/version-v2.4.1/userguide/hygon-device/enable-hygon-dcu-sharing.md
+++ b/versioned_docs/version-v2.4.1/userguide/hygon-device/enable-hygon-dcu-sharing.md
@@ -16,11 +16,11 @@ title: Enable Hygon DCU sharing
 
 ## Prerequisites
 
-* dtk driver >= 24.04
+- dtk driver >= 24.04
 
 ## Enabling DCU-sharing Support
 
-* Deploy the dcu-vgpu-device-plugin [here](https://github.com/Project-HAMi/dcu-vgpu-device-plugin)
+- Deploy the dcu-vgpu-device-plugin [here](https://github.com/Project-HAMi/dcu-vgpu-device-plugin)
 
 ## Running DCU jobs
 

--- a/versioned_docs/version-v2.4.1/userguide/metax-device/enable-metax-gpu-schedule.md
+++ b/versioned_docs/version-v2.4.1/userguide/metax-device/enable-metax-gpu-schedule.md
@@ -31,14 +31,14 @@ Equipped with MetaXLink interconnected resources.
 
 ## Prerequisites
 
-* Metax GPU extensions >= 0.8.0
-* Kubernetes >= 1.23
+- Metax GPU extensions >= 0.8.0
+- Kubernetes >= 1.23
 
 ## Enabling topo-awareness scheduling
 
-* Deploy Metax GPU Extensions on metax nodes (Please consult your device provider to acquire its package and document)
+- Deploy Metax GPU Extensions on metax nodes (Please consult your device provider to acquire its package and document)
 
-* Deploy HAMi according to README.md
+- Deploy HAMi according to README.md
 
 ## Running Metax jobs
 

--- a/versioned_docs/version-v2.4.1/userguide/mthreads-device/enable-mthreads-gpu-sharing.md
+++ b/versioned_docs/version-v2.4.1/userguide/mthreads-device/enable-mthreads-gpu-sharing.md
@@ -24,16 +24,16 @@ title: Enable Mthreads GPU sharing
 
 ## Prerequisites
 
-* [MT CloudNative Toolkits > 1.9.0](https://docs.mthreads.com/cloud-native/cloud-native-doc-online/)
-* driver version >= 1.2.0
+- [MT CloudNative Toolkits > 1.9.0](https://docs.mthreads.com/cloud-native/cloud-native-doc-online/)
+- driver version >= 1.2.0
 
 ## Enabling GPU-sharing Support
 
-* Deploy MT-CloudNative Toolkit on mthreads nodes (Please consult your device provider to acquire its package and document)
+- Deploy MT-CloudNative Toolkit on mthreads nodes (Please consult your device provider to acquire its package and document)
 
 > **NOTICE:** *You can remove mt-mutating-webhook and mt-gpu-scheduler after installation(optional).*
 
-* set the 'devices.mthreads.enabled = true' when installing hami
+- set the 'devices.mthreads.enabled = true' when installing hami
 
 ```
 helm install hami hami-charts/hami --set scheduler.kubeScheduler.imageTag={your kubernetes version} --set device.mthreads.enabled=true -n kube-system

--- a/versioned_docs/version-v2.4.1/userguide/nvidia-device/dynamic-mig-support.md
+++ b/versioned_docs/version-v2.4.1/userguide/nvidia-device/dynamic-mig-support.md
@@ -18,15 +18,15 @@ title: Enable dynamic-mig feature
 
 ## Prerequisites
 
-* NVIDIA Blackwell and Hopper™ and Ampere Devices
-* HAMi > v2.5.0
-* NVIDIA Container Toolkit
+- NVIDIA Blackwell and Hopper™ and Ampere Devices
+- HAMi > v2.5.0
+- NVIDIA Container Toolkit
 
 ## Enabling Dynamic-mig Support
 
-* Install the chart using helm, See 'enabling vGPU support in kubernetes' section [here](https://github.com/Project-HAMi/HAMi#enabling-vgpu-support-in-kubernetes)
+- Install the chart using helm, See 'enabling vGPU support in kubernetes' section [here](https://github.com/Project-HAMi/HAMi#enabling-vgpu-support-in-kubernetes)
 
-* Configure `mode` in device-plugin configMap to `mig` for MIG nodes
+- Configure `mode` in device-plugin configMap to `mig` for MIG nodes
 ```
 kubectl describe cm  hami-device-plugin -n kube-system
 ```
@@ -46,9 +46,9 @@ kubectl describe cm  hami-device-plugin -n kube-system
 }
 ```
 
-* Restart the following pods for the change to take effect:
-  * hami-scheduler 
-  * hami-device-plugin on 'MIG-NODE-A'
+- Restart the following pods for the change to take effect:
+  - hami-scheduler 
+  - hami-device-plugin on 'MIG-NODE-A'
 
 ## Custom mig configuration (Optional)
 HAMi currently has a [built-in mig configuration](https://github.com/Project-HAMi/HAMi/blob/master/charts/hami/templates/scheduler/device-configmap.yaml) for MIG.

--- a/versioned_docs/version-v2.5.0/contributor/governance.md
+++ b/versioned_docs/version-v2.5.0/contributor/governance.md
@@ -8,21 +8,21 @@ Heterogeneous AI Computing Virtualization Middleware (HAMi), formerly known as k
 
 The HAMi and its leadership embrace the following values:
 
-* Openness: Communication and decision-making happens in the open and is discoverable for future
+- Openness: Communication and decision-making happens in the open and is discoverable for future
   reference. As much as possible, all discussions and work take place in public
   forums and open repositories.
 
-* Fairness: All stakeholders have the opportunity to provide feedback and submit
+- Fairness: All stakeholders have the opportunity to provide feedback and submit
   contributions, which will be considered on their merits.
 
-* Community over Product or Company: Sustaining and growing the community takes
+- Community over Product or Company: Sustaining and growing the community takes
   priority over shipping code or sponsors' organizational goals. Each
   contributor participates in the project as an individual.
 
-* Inclusivity: Innovation comes from different perspectives and skill sets, and this
+- Inclusivity: Innovation comes from different perspectives and skill sets, and this
   can only be accomplished in a welcoming and respectful environment.
 
-* Participation: Responsibilities within the project are earned through
+- Participation: Responsibilities within the project are earned through
   participation, and there is a clear path up the contributor ladder into leadership
   positions.
 

--- a/versioned_docs/version-v2.5.0/contributor/ladder.md
+++ b/versioned_docs/version-v2.5.0/contributor/ladder.md
@@ -12,38 +12,38 @@ Each of the contributor roles below is organized into lists of three types of th
 
 Description: A Community Participant engages with the project and its community, contributing their time, thoughts, etc. Community participants are usually users who have stopped being anonymous and started being active in project discussions.
 
-* Responsibilities:
-  * Must follow the [CNCF CoC](https://github.com/cncf/foundation/blob/main/code-of-conduct.md)
-* How users can get involved with the community:
-  * Participating in community discussions
-  * Helping other users
-  * Submitting bug reports
-  * Commenting on issues
-  * Trying out new releases
-  * Attending community events
+- Responsibilities:
+  - Must follow the [CNCF CoC](https://github.com/cncf/foundation/blob/main/code-of-conduct.md)
+- How users can get involved with the community:
+  - Participating in community discussions
+  - Helping other users
+  - Submitting bug reports
+  - Commenting on issues
+  - Trying out new releases
+  - Attending community events
 
 ## Contributor
 
 Description: A Contributor contributes directly to the project and adds value to it. Contributions need not be code. People at the Contributor level may be new contributors, or they may only contribute occasionally.
 
-* Responsibilities include:
-  * Follow the CNCF CoC
-  * Follow the project contributing guide
-* Requirements (one or several of the below):
-  * Report and sometimes resolve issues
-  * Occasionally submit PRs
-  * Contribute to the documentation
-  * Show up at meetings, takes notes
-  * Answer questions from other community members
-  * Submit feedback on issues and PRs
-  * Test releases and patches and submit reviews
-  * Run or helps run events
-  * Promote the project in public
-  * Help run the project infrastructure
-  * [TODO: other small contributions]
-* Privileges:
-  * Invitations to contributor events
-  * Eligible to become an Organization Member
+- Responsibilities include:
+  - Follow the CNCF CoC
+  - Follow the project contributing guide
+- Requirements (one or several of the below):
+  - Report and sometimes resolve issues
+  - Occasionally submit PRs
+  - Contribute to the documentation
+  - Show up at meetings, takes notes
+  - Answer questions from other community members
+  - Submit feedback on issues and PRs
+  - Test releases and patches and submit reviews
+  - Run or helps run events
+  - Promote the project in public
+  - Help run the project infrastructure
+  - [TODO: other small contributions]
+- Privileges:
+  - Invitations to contributor events
+  - Eligible to become an Organization Member
 
 A very special thanks to the [long list of people](https://github.com/Project-HAMi/HAMi/blob/master/AUTHORS.md) who have contributed to and helped maintain the project. Thanks to everyone who contributed and helped maintain the project.
 
@@ -55,31 +55,31 @@ Description: An Organization Member is an established contributor who regularly 
 
 An Organization Member must meet the responsibilities and has the requirements of a Contributor, plus:
 
-* Responsibilities include:
-  * Continues to contribute regularly, as demonstrated by having at least 50 GitHub contributions per year
-* Requirements:
-  * Enabled [two-factor authentication] on their GitHub account
-  * Must have successful contributions to the project or community, including at least one of the following:
-    * 5 accepted PRs,
-    * Reviewed 5 PRs,
-    * Resolved and closed 3 Issues,
-    * Become responsible for a key project management area,
-    * Or some equivalent combination or contribution
-  * Must have been contributing for at least 1 months
-  * Must be actively contributing to at least one project area
-  * Must have two sponsors who are also Organization Members, at least one of whom does not work for the same employer
-  * **Open an issue against the Project-HAMi/HAMi repo**
-    * Ensure your sponsors are @mentioned on the issue
-    * Complete every item on the issue checklist
-    * Make sure that the list of contributions included is representative of your work on the project.
-  * Have your sponsoring reviewers reply confirmation of sponsorship: `+1`
-  * Once your sponsors have responded, your request will be handled by the `HAMi GitHub Admin team`.
+- Responsibilities include:
+  - Continues to contribute regularly, as demonstrated by having at least 50 GitHub contributions per year
+- Requirements:
+  - Enabled [two-factor authentication] on their GitHub account
+  - Must have successful contributions to the project or community, including at least one of the following:
+    - 5 accepted PRs,
+    - Reviewed 5 PRs,
+    - Resolved and closed 3 Issues,
+    - Become responsible for a key project management area,
+    - Or some equivalent combination or contribution
+  - Must have been contributing for at least 1 months
+  - Must be actively contributing to at least one project area
+  - Must have two sponsors who are also Organization Members, at least one of whom does not work for the same employer
+  - **Open an issue against the Project-HAMi/HAMi repo**
+    - Ensure your sponsors are @mentioned on the issue
+    - Complete every item on the issue checklist
+    - Make sure that the list of contributions included is representative of your work on the project.
+  - Have your sponsoring reviewers reply confirmation of sponsorship: `+1`
+  - Once your sponsors have responded, your request will be handled by the `HAMi GitHub Admin team`.
 
-* Privileges:
-  * May be assigned Issues and Reviews
-  * May give commands to CI/CD automation
-  * Can be added to [TODO: Repo Host] teams
-  * Can recommend other contributors to become Org Members
+- Privileges:
+  - May be assigned Issues and Reviews
+  - May give commands to CI/CD automation
+  - Can be added to [TODO: Repo Host] teams
+  - Can recommend other contributors to become Org Members
 
 The process for a Contributor to become an Organization Member is as follows:
 
@@ -94,22 +94,22 @@ Reviewers are responsible for a "specific area." This can be a specific code dir
 
 Reviewers have all the rights and responsibilities of an Organization Member, plus:
 
-* Responsibilities include:
-  * Following the reviewing guide
-  * Reviewing most Pull Requests against their specific areas of responsibility
-  * Reviewing at least 20 PRs per year
-  * Helping other contributors become reviewers
-* Requirements:
-  * Experience as a Contributor for at least 3 months
-  * Is an Organization Member
-  * Has reviewed, or helped review, at least 10 Pull Requests
-  * Has analyzed and resolved test failures in their specific area
-  * Has demonstrated an in-depth knowledge of the specific area
-  * Commits to being responsible for that specific area
-  * Is supportive of new and occasional contributors and helps get useful PRs in shape to commit
-* Additional privileges:
-  * Has GitHub or CI/CD rights to approve pull requests in specific directories
-  * Can recommend and review other contributors to become Reviewers
+- Responsibilities include:
+  - Following the reviewing guide
+  - Reviewing most Pull Requests against their specific areas of responsibility
+  - Reviewing at least 20 PRs per year
+  - Helping other contributors become reviewers
+- Requirements:
+  - Experience as a Contributor for at least 3 months
+  - Is an Organization Member
+  - Has reviewed, or helped review, at least 10 Pull Requests
+  - Has analyzed and resolved test failures in their specific area
+  - Has demonstrated an in-depth knowledge of the specific area
+  - Commits to being responsible for that specific area
+  - Is supportive of new and occasional contributors and helps get useful PRs in shape to commit
+- Additional privileges:
+  - Has GitHub or CI/CD rights to approve pull requests in specific directories
+  - Can recommend and review other contributors to become Reviewers
 
 The process of becoming a Reviewer is:
 
@@ -126,15 +126,15 @@ The current list of maintainers can be found in the [MAINTAINERS](https://github
 
 ## An active maintainer should
 
-* Actively participate in reviewing pull requests and incoming issues. There are no hard rules on what is “active enough” and this is left up to the judgement of the current group of maintainers.
+- Actively participate in reviewing pull requests and incoming issues. There are no hard rules on what is “active enough” and this is left up to the judgement of the current group of maintainers.
 
-* Actively participate in discussions about design and the future of the project.
+- Actively participate in discussions about design and the future of the project.
 
-* Take responsibility for backports to appropriate branches for PRs they approve and merge.
+- Take responsibility for backports to appropriate branches for PRs they approve and merge.
 
-* Do their best to follow all code, testing, and design conventions as determined by consensus among active maintainers.
+- Do their best to follow all code, testing, and design conventions as determined by consensus among active maintainers.
 
-* Gracefully step down from their maintainership role when they are no longer planning to actively participate in the project.
+- Gracefully step down from their maintainership role when they are no longer planning to actively participate in the project.
 
 ## How to be a maintainer
 
@@ -150,12 +150,12 @@ It is normal for maintainers to come and go based on their other responsibilitie
 
 It is important for contributors to be and stay active to set an example and show commitment to the project. Inactivity is harmful to the project as it may lead to unexpected delays, contributor attrition, and a lost of trust in the project.
 
-* Inactivity is measured by:
-  * Periods of no contributions for longer than 3 months
-  * Periods of no communication for longer than 3 months
-* Consequences of being inactive include:
-  * Involuntary removal or demotion
-  * Being asked to move to Emeritus status
+- Inactivity is measured by:
+  - Periods of no contributions for longer than 3 months
+  - Periods of no communication for longer than 3 months
+- Consequences of being inactive include:
+  - Involuntary removal or demotion
+  - Being asked to move to Emeritus status
 
 ## Involuntary Removal or Demotion
 

--- a/versioned_docs/version-v2.5.0/key-features/features.md
+++ b/versioned_docs/version-v2.5.0/key-features/features.md
@@ -4,15 +4,15 @@ title: Key Features
 
 ## Cross-cloud multi-cluster multi-mode management
 Karmada supports:
-* Safe isolation:
-  * Create a namespace for each cluster, prefixed with `karmada-es-`.
-* [Multi-mode](https://karmada.io/docs/userguide/clustermanager/cluster-registration) connection:
-  * Push: Karmada is directly connected to the cluster kube-apiserver.
-  * Pull: Deploy one agent component in the cluster, Karmada delegates tasks to the agent component.
-* Multi-cloud support(Only if compliant with Kubernetes specifications):
-  * Support various public cloud vendors.
-  * Support for private cloud.
-  * Support self-built clusters.
+- Safe isolation:
+  - Create a namespace for each cluster, prefixed with `karmada-es-`.
+- [Multi-mode](https://karmada.io/docs/userguide/clustermanager/cluster-registration) connection:
+  - Push: Karmada is directly connected to the cluster kube-apiserver.
+  - Pull: Deploy one agent component in the cluster, Karmada delegates tasks to the agent component.
+- Multi-cloud support(Only if compliant with Kubernetes specifications):
+  - Support various public cloud vendors.
+  - Support for private cloud.
+  - Support self-built clusters.
 
 The overall relationship between the member cluster and the control plane is shown in the following figure:  
 
@@ -21,19 +21,19 @@ The overall relationship between the member cluster and the control plane is sho
 
 ## Multi-policy multi-cluster scheduling
 Karmada supports:
-* Cluster distribution capability under [different scheduling strategies](https://karmada.io/docs/userguide/scheduling/resource-propagating):
-  * ClusterAffinity: Oriented scheduling based on ClusterName, Label, Field.
-  * Toleration: Scheduling based on Taint and Toleration.
-  * SpreadConstraint: Scheduling based on cluster topology.
-  * ReplicasScheduling: Replication mode and split mode for instanced workloads.
-* Differential configuration([OverridePolicy](https://karmada.io/docs/userguide/scheduling/override-policy)):
-  * ImageOverrider: Differentiated configuration of mirrors.
-  * ArgsOverrider: Differentiated configuration of execution parameters.
-  * CommandOverrider: Differentiated configuration for execution commands.
-  * PlainText: Customized Differentiation Configuration.
-* [Support reschedule](https://karmada.io/docs/userguide/scheduling/descheduler) with following components:
-  * Descheduler(karmada-descheduler): Trigger rescheduling based on instance state changes in member clusters.
-  * Scheduler-estimator(karmada-scheduler-estimator): Provides the scheduler with a more precise desired state of the running instances of the member cluster.
+- Cluster distribution capability under [different scheduling strategies](https://karmada.io/docs/userguide/scheduling/resource-propagating):
+  - ClusterAffinity: Oriented scheduling based on ClusterName, Label, Field.
+  - Toleration: Scheduling based on Taint and Toleration.
+  - SpreadConstraint: Scheduling based on cluster topology.
+  - ReplicasScheduling: Replication mode and split mode for instanced workloads.
+- Differential configuration([OverridePolicy](https://karmada.io/docs/userguide/scheduling/override-policy)):
+  - ImageOverrider: Differentiated configuration of mirrors.
+  - ArgsOverrider: Differentiated configuration of execution parameters.
+  - CommandOverrider: Differentiated configuration for execution commands.
+  - PlainText: Customized Differentiation Configuration.
+- [Support reschedule](https://karmada.io/docs/userguide/scheduling/descheduler) with following components:
+  - Descheduler(karmada-descheduler): Trigger rescheduling based on instance state changes in member clusters.
+  - Scheduler-estimator(karmada-scheduler-estimator): Provides the scheduler with a more precise desired state of the running instances of the member cluster.
 
 Much like k8s scheduling, Karmada support different scheduling policy. The overall scheduling process is shown in the figure below:  
 
@@ -46,12 +46,12 @@ If one cluster does not have enough resource to accommodate their pods, Karamda 
 
 ## Cross-cluster failover of applications
 Karmada supports:
-* [Cluster failover](https://karmada.io/docs/userguide/failover/):
-  * Karmada supports users to set distribution policies, and automatically migrates the faulty cluster replicas in a centralized or decentralized manner after a cluster failure.
-* Cluster taint settings:
-  * When the user sets a taint for the cluster and the resource distribution strategy cannot tolerate the taint, Karmada will also automatically trigger the migration of the cluster replicas.
-* Uninterrupted service:
-  * During the replicas migration process, Karmada can ensure that the service replicas does not drop to zero, thereby ensuring that the service will not be interrupted.
+- [Cluster failover](https://karmada.io/docs/userguide/failover/):
+  - Karmada supports users to set distribution policies, and automatically migrates the faulty cluster replicas in a centralized or decentralized manner after a cluster failure.
+- Cluster taint settings:
+  - When the user sets a taint for the cluster and the resource distribution strategy cannot tolerate the taint, Karmada will also automatically trigger the migration of the cluster replicas.
+- Uninterrupted service:
+  - During the replicas migration process, Karmada can ensure that the service replicas does not drop to zero, thereby ensuring that the service will not be interrupted.
 
 Karmada supports failover for clusters, one cluster failure will cause failover of replicas as follows:  
 
@@ -59,14 +59,14 @@ Karmada supports failover for clusters, one cluster failure will cause failover 
 
 ## Global Uniform Resource View
 Karmada supports:
-* [Resource status collection and aggregation](https://karmada.io/docs/userguide/globalview/customizing-resource-interpreter): Collect and aggregate state into resource templates with the help of the Resource Interpreter.
-  * User-defined resource, triggering webhook remote calls.
-  * Fixed encoding in Karmada for some common resource types.
-* [Unified resource management](https://karmada.io/docs/userguide/globalview/aggregated-api-endpoint): Unified management for `create`, `update`, `delete`, `query`.
-* [Unified operations](https://karmada.io/docs/userguide/globalview/proxy-global-resource): Exec operations command(`describe`, `exec`, `logs`) in one k8s context.
-* [Global search for resources and events](https://karmada.io/docs/tutorials/karmada-search/):
-  * Cache query: global fuzzy search and global precise search are supported.
-  * Third-party storage: Search engine (Elasticsearch or OpenSearch), relational database, graph database are supported.
+- [Resource status collection and aggregation](https://karmada.io/docs/userguide/globalview/customizing-resource-interpreter): Collect and aggregate state into resource templates with the help of the Resource Interpreter.
+  - User-defined resource, triggering webhook remote calls.
+  - Fixed encoding in Karmada for some common resource types.
+- [Unified resource management](https://karmada.io/docs/userguide/globalview/aggregated-api-endpoint): Unified management for `create`, `update`, `delete`, `query`.
+- [Unified operations](https://karmada.io/docs/userguide/globalview/proxy-global-resource): Exec operations command(`describe`, `exec`, `logs`) in one k8s context.
+- [Global search for resources and events](https://karmada.io/docs/tutorials/karmada-search/):
+  - Cache query: global fuzzy search and global precise search are supported.
+  - Third-party storage: Search engine (Elasticsearch or OpenSearch), relational database, graph database are supported.
 
 Users can access and operate all member clusters via karmada-apiserver:  
 
@@ -78,15 +78,15 @@ Users also can check and search all member clusters resources via karmada-apiser
 
 ## Separating the concerns of different roles
 karmada supports:
-* [Unified authentication](https://karmada.io/docs/userguide/roleseparation/unifiedAuth):
-  * Aggregate API unified access entry.
-  * Access control is consistent with member clusters.
-* Unified resource quota(`FederatedResourceQuota`):
-  * Globally configures the ResourceQuota of each member cluster.
-  * Configure ResourceQuota at the federation level.
-  * Collects the resource usage of each member cluster in real time.
-* Reusable scheduling strategy:
-  * Resource templates are decoupled from scheduling policies, plug and play.
+- [Unified authentication](https://karmada.io/docs/userguide/roleseparation/unifiedAuth):
+  - Aggregate API unified access entry.
+  - Access control is consistent with member clusters.
+- Unified resource quota(`FederatedResourceQuota`):
+  - Globally configures the ResourceQuota of each member cluster.
+  - Configure ResourceQuota at the federation level.
+  - Collects the resource usage of each member cluster in real time.
+- Reusable scheduling strategy:
+  - Resource templates are decoupled from scheduling policies, plug and play.
 
 Users can access all member clusters with unified authentication:
 
@@ -98,10 +98,10 @@ Users also can defined global resource quota via `FederatedResourceQuota`:
 
 ## Cross-cluster service governance
 karmada supports:
-* [Multi-cluster service discovery](https://karmada.io/docs/userguide/service/multi-cluster-service):
-  * With ServiceExport and ServiceImport, achieving cross-cluster service discovery.
-* [Multi-cluster network support](https://karmada.io/docs/userguide/network/working-with-submariner):
-  * Use `Submariner` to open up the container network between clusters.
+- [Multi-cluster service discovery](https://karmada.io/docs/userguide/service/multi-cluster-service):
+  - With ServiceExport and ServiceImport, achieving cross-cluster service discovery.
+- [Multi-cluster network support](https://karmada.io/docs/userguide/network/working-with-submariner):
+  - Use `Submariner` to open up the container network between clusters.
 
 Users can enable service governance for cross-cluster with Karmada:  
 

--- a/versioned_docs/version-v2.5.0/releases.md
+++ b/versioned_docs/version-v2.5.0/releases.md
@@ -26,14 +26,14 @@ Minor releases contain features, enhancements, and fixes that are introduced in 
 Since HAMi is a fast growing project and features continue to iterate rapidly,
 having a minor release approximately every few months helps balance speed and stability.
 
-* Roughly every 3 months
+- Roughly every 3 months
 
 ### PATCH release
 
 Patch releases are for backwards-compatible bug fixes and very minor enhancements which do not impact stability or compatibility.
 Typically only critical fixes are selected for patch releases. Usually there will be at least one patch release in a minor release cycle.
 
-* When critical fixes are required, or roughly each month
+- When critical fixes are required, or roughly each month
 
 ### Versioning
 
@@ -53,17 +53,17 @@ Critical issues, with no work-arounds, are added to the next patch release.
 
 Release branches and PRs are managed as follows:
 
-* All changes are always first committed to `master`.
-* Branches are created for each major or minor release.
-* The branch name will contain the version, for example release-1.2.
-* Patch releases are created from a release branch.
-* For critical fixes that need to be included in a patch release, PRs should always be first merged to master
+- All changes are always first committed to `master`.
+- Branches are created for each major or minor release.
+- The branch name will contain the version, for example release-1.2.
+- Patch releases are created from a release branch.
+- For critical fixes that need to be included in a patch release, PRs should always be first merged to master
   and then cherry-picked to the release branch. PRs need to be guaranteed to have a release note written and
   these descriptions will be reflected in the next patch release.
   The cherry-pick process of PRs is executed through the script. See usage [here](https://project-hami.io/docs/contributor/cherry-picks).
-* For complex changes, specially critical bugfixes, separate PRs may be required for master and release branches.
-* The milestone mark (for example v1.4) will be added to PRs which means changes in PRs are one of the contents of the corresponding release.
-* During PR review, the Assignee selection is used to indicate the reviewer.
+- For complex changes, specially critical bugfixes, separate PRs may be required for master and release branches.
+- The milestone mark (for example v1.4) will be added to PRs which means changes in PRs are one of the contents of the corresponding release.
+- During PR review, the Assignee selection is used to indicate the reviewer.
 
 ### Release Planning
 
@@ -85,26 +85,26 @@ For example, [here](https://hub.docker.com/r/karmada/karmada-controller-manager)
 
 Since v1.2.0, the following artifacts are uploaded:
 
-* crds.tar.gz
-* karmada-chart-v\<version_number\>.tgz
-* karmadactl-darwin-amd64.tgz
-* karmadactl-darwin-amd64.tgz.sha256
-* karmadactl-darwin-arm64.tgz
-* karmadactl-darwin-arm64.tgz.sha256
-* karmadactl-linux-amd64.tgz
-* karmadactl-linux-amd64.tgz.sha256
-* karmadactl-linux-arm64.tgz
-* karmadactl-linux-arm64.tgz.sha256
-* kubectl-karmada-darwin-amd64.tgz
-* kubectl-karmada-darwin-amd64.tgz.sha256
-* kubectl-karmada-darwin-arm64.tgz
-* kubectl-karmada-darwin-arm64.tgz.sha256
-* kubectl-karmada-linux-amd64.tgz
-* kubectl-karmada-linux-amd64.tgz.sha256
-* kubectl-karmada-linux-arm64.tgz
-* kubectl-karmada-linux-arm64.tgz.sha256
-* Source code(zip)
-* Source code(tar.gz)
+- crds.tar.gz
+- karmada-chart-v\<version_number\>.tgz
+- karmadactl-darwin-amd64.tgz
+- karmadactl-darwin-amd64.tgz.sha256
+- karmadactl-darwin-arm64.tgz
+- karmadactl-darwin-arm64.tgz.sha256
+- karmadactl-linux-amd64.tgz
+- karmadactl-linux-amd64.tgz.sha256
+- karmadactl-linux-arm64.tgz
+- karmadactl-linux-arm64.tgz.sha256
+- kubectl-karmada-darwin-amd64.tgz
+- kubectl-karmada-darwin-amd64.tgz.sha256
+- kubectl-karmada-darwin-arm64.tgz
+- kubectl-karmada-darwin-arm64.tgz.sha256
+- kubectl-karmada-linux-amd64.tgz
+- kubectl-karmada-linux-amd64.tgz.sha256
+- kubectl-karmada-linux-arm64.tgz
+- kubectl-karmada-linux-arm64.tgz.sha256
+- Source code(zip)
+- Source code(tar.gz)
 
 You can visit `https://github.com/Project-HAMi/HAMi/releases/download/v<version_number>/<artifact_name>` to download the artifacts above.
 

--- a/versioned_docs/version-v2.5.0/roadmap.md
+++ b/versioned_docs/version-v2.5.0/roadmap.md
@@ -11,9 +11,9 @@ The items below are intended to inspire further community engagement to keep HAM
 
 ## 2022 H1
 - Multi-cluster HA scheduling policy
-    * spread by region
-    * spread by zone
-    * spread by provider
+    - spread by region
+    - spread by zone
+    - spread by provider
 - Multi-cluster Ingress
 - Multi-cluster HPA (Horizontal Pod Autoscaling)
 - Federated resource quota

--- a/versioned_docs/version-v2.5.0/userguide/ascend-device/enable-ascend-sharing.md
+++ b/versioned_docs/version-v2.5.0/userguide/ascend-device/enable-ascend-sharing.md
@@ -8,13 +8,13 @@ Memory slicing is supported based on virtualization template, lease available te
 
 ## Prerequisites
 
-* Ascend device type: 910B,910A,310P
-* driver version >= 24.1.rc1
-* Ascend docker runtime
+- Ascend device type: 910B,910A,310P
+- driver version >= 24.1.rc1
+- Ascend docker runtime
 
 ## Enabling Ascend-sharing Support
 
-* Due to dependencies with HAMi, you need to set 
+- Due to dependencies with HAMi, you need to set 
 
 ```
 devices.ascend.enabled=true
@@ -41,14 +41,14 @@ devices:
       - huawei.com/Ascend310P-memory
 ```
 
-* Tag Ascend node with the following command
+- Tag Ascend node with the following command
 ```
 kubectl label node {ascend-node} ascend=on
 ```
 
-* Install [Ascend docker runtime](https://gitee.com/ascend/ascend-docker-runtime)
+- Install [Ascend docker runtime](https://gitee.com/ascend/ascend-docker-runtime)
 
-* Download yaml for Ascend-vgpu-device-plugin from HAMi Project [here](https://github.com/Project-HAMi/ascend-device-plugin/blob/master/build/ascendplugin-hami.yaml), and deploy
+- Download yaml for Ascend-vgpu-device-plugin from HAMi Project [here](https://github.com/Project-HAMi/ascend-device-plugin/blob/master/build/ascendplugin-hami.yaml), and deploy
 
 ```
 wge https://raw.githubusercontent.com/Project-HAMi/ascend-device-plugin/refs/heads/main/ascend-device-plugin.yaml

--- a/versioned_docs/version-v2.5.0/userguide/cambricon-device/enable-cambricon-mlu-sharing.md
+++ b/versioned_docs/version-v2.5.0/userguide/cambricon-device/enable-cambricon-mlu-sharing.md
@@ -16,13 +16,13 @@ title: Enable cambricon MLU sharing
 
 ## Prerequisites
 
-* neuware-mlu370-driver > 5.0.0
-* cambricon-device-plugin > 2.0.9
-* cntoolkit > 2.5.3
+- neuware-mlu370-driver > 5.0.0
+- cambricon-device-plugin > 2.0.9
+- cntoolkit > 2.5.3
 
 ## Enabling MLU-sharing Support
 
-* Contact your device provider to acquire cambricon-device-plugin>2.0.9, edit parameter `mode` to 'dynamic-smlu` in containers.args field.
+- Contact your device provider to acquire cambricon-device-plugin>2.0.9, edit parameter `mode` to 'dynamic-smlu` in containers.args field.
 
 ```
         args:
@@ -30,11 +30,11 @@ title: Enable cambricon MLU sharing
 	...
 ```
 
-* Deploy modified cambricon-device-plugin
+- Deploy modified cambricon-device-plugin
 
-* Install the chart using helm, See 'enabling vGPU support in kubernetes' section [here](https://github.com/Project-HAMi/HAMi#enabling-vgpu-support-in-kubernetes)
+- Install the chart using helm, See 'enabling vGPU support in kubernetes' section [here](https://github.com/Project-HAMi/HAMi#enabling-vgpu-support-in-kubernetes)
 
-* Activate the smlu mode for each MLUs on that node
+- Activate the smlu mode for each MLUs on that node
 ```
 cnmon set -c 0 -smlu on
 cnmon set -c 1 -smlu on

--- a/versioned_docs/version-v2.5.0/userguide/configure.md
+++ b/versioned_docs/version-v2.5.0/userguide/configure.md
@@ -21,29 +21,29 @@ You can update these configurations using one of the following methods:
     After making changes, restart the related HAMi components to apply the updated configurations.
 2. Modify Helm Chart: Update the corresponding values in the [ConfigMap](https://raw.githubusercontent.com/archlitchi/HAMi/refs/heads/master/charts/hami/templates/scheduler/device-configmap.yaml), then reapply the Helm Chart to regenerate the ConfigMap.
 
-* `nvidia.deviceMemoryScaling:` 
+- `nvidia.deviceMemoryScaling:` 
   Float type, by default: 1. The ratio for NVIDIA device memory scaling, can be greater than 1 (enable virtual device memory, experimental feature). For NVIDIA GPU with *M* memory, if `nvidia.deviceMemoryScaling` is set argument to *S*, vGPUs split by this GPU will totally get `S * M` memory in Kubernetes with the HAMi device plugin.
-* `nvidia.deviceSplitCount:` 
+- `nvidia.deviceSplitCount:` 
   Integer type, by default: equals 10. Maximum tasks assigned to a simple GPU device.
-* `nvidia.migstrategy:`
+- `nvidia.migstrategy:`
   String type, "none" for ignoring MIG features or "mixed" for allocating MIG device by separate resources. Default "none"
-* `nvidia.disablecorelimit:`
+- `nvidia.disablecorelimit:`
   String type, "true" for disable core limit, "false" for enable core limit, default: false
-* `nvidia.defaultMem:` 
+- `nvidia.defaultMem:` 
   Integer type, by default: 0. The default device memory of the current task, in MB.'0' means use 100% device memory
-* `nvidia.defaultCores:` 
+- `nvidia.defaultCores:` 
   Integer type, by default: equals 0. Percentage of GPU cores reserved for the current task. If assigned to 0, it may fit in any GPU with enough device memory. If assigned to 100, it will use an entire GPU card exclusively.
-* `nvidia.defaultGPUNum:`
+- `nvidia.defaultGPUNum:`
   Integer type, by default: equals 1, if configuration value is 0, then the configuration value will not take effect and will be filtered. when a user does not set nvidia.com/gpu this key in pod resource, webhook should check nvidia.com/gpumem、resource-mem-percentage、nvidia.com/gpucores this three key, anyone a key having value, webhook should add nvidia.com/gpu key and this default value to resources limits map.
-* `nvidia.resourceCountName:`
+- `nvidia.resourceCountName:`
   String type, vgpu number resource name, default: "nvidia.com/gpu"
-* `nvidia.resourceMemoryName:`
+- `nvidia.resourceMemoryName:`
   String type, vgpu memory size resource name, default: "nvidia.com/gpumem"
-* `nvidia.resourceMemoryPercentageName:`
+- `nvidia.resourceMemoryPercentageName:`
   String type, vgpu memory fraction resource name, default: "nvidia.com/gpumem-percentage" 
-* `nvidia.resourceCoreName:`
+- `nvidia.resourceCoreName:`
   String type, vgpu cores resource name, default: "nvidia.com/cores"
-* `nvidia.resourcePriorityName:`
+- `nvidia.resourcePriorityName:`
   String type, vgpu task priority name, default: "nvidia.com/priority"
 
 ## Chart Configs: parameters
@@ -54,47 +54,47 @@ you can customize your vGPU support by setting the following parameters using `-
 helm install hami hami-charts/hami --set devicePlugin.deviceMemoryScaling=5 ...
 ```
 
-* `devicePlugin.service.schedulerPort:`
+- `devicePlugin.service.schedulerPort:`
   Integer type, by default: 31998, scheduler webhook service nodePort.
-* `scheduler.defaultSchedulerPolicy.nodeSchedulerPolicy:` String type, default value is "binpack", representing the GPU node scheduling policy. "binpack" means trying to allocate tasks to the same GPU node as much as possible, while "spread" means trying to allocate tasks to different GPU nodes as much as possible.
-* `scheduler.defaultSchedulerPolicy.gpuSchedulerPolicy:` String type, default value is "spread", representing the GPU scheduling policy. "binpack" means trying to allocate tasks to the same GPU as much as possible, while "spread" means trying to allocate tasks to different GPUs as much as possible.
+- `scheduler.defaultSchedulerPolicy.nodeSchedulerPolicy:` String type, default value is "binpack", representing the GPU node scheduling policy. "binpack" means trying to allocate tasks to the same GPU node as much as possible, while "spread" means trying to allocate tasks to different GPU nodes as much as possible.
+- `scheduler.defaultSchedulerPolicy.gpuSchedulerPolicy:` String type, default value is "spread", representing the GPU scheduling policy. "binpack" means trying to allocate tasks to the same GPU as much as possible, while "spread" means trying to allocate tasks to different GPUs as much as possible.
 
 ## Pod configs: annotations
 
-* `nvidia.com/use-gpuuuid:` 
+- `nvidia.com/use-gpuuuid:` 
   String type, ie: "GPU-AAA,GPU-BBB"
   If set, devices allocated by this pod must be one of UUIDs defined in this string.
-* `nvidia.com/nouse-gpuuuid`
+- `nvidia.com/nouse-gpuuuid`
   String type, ie: "GPU-AAA,GPU-BBB"
   If set, devices allocated by this pod will NOT in UUIDs defined in this string.
-* `nvidia.com/nouse-gputype:`
+- `nvidia.com/nouse-gputype:`
   String type, ie: "Tesla V100-PCIE-32GB, NVIDIA A10"
   If set, devices allocated by this pod will NOT in types defined in this string.
-* `nvidia.com/use-gputype`
+- `nvidia.com/use-gputype`
   String type, ie: "Tesla V100-PCIE-32GB, NVIDIA A10"
   If set, devices allocated by this pod MUST be one of types defined in this string.
-* `hami.io/node-scheduler-policy`
+- `hami.io/node-scheduler-policy`
   String type, "binpack" or "spread"
   binpack: the scheduler will try to allocate the pod to used GPU nodes for execution. 
   spread: the scheduler will try to allocate the pod to different GPU nodes for execution.
-* `hami.io/gpu-scheduler-policy`
+- `hami.io/gpu-scheduler-policy`
   String type, "binpack" or "spread"
   binpack: the scheduler will try to allocate the pod to the same GPU card for execution.
   spread:the scheduler will try to allocate the pod to different GPU card for execution. 
-* `nvidia.com/vgpu-mode`
+- `nvidia.com/vgpu-mode`
   String type, "hami-core" or "mig"
   Which type of vgpu instance this pod wish to use
 
 
 ## Container configs: env
 
-* `GPU_CORE_UTILIZATION_POLICY:`
+- `GPU_CORE_UTILIZATION_POLICY:`
   String type, "default", "force", "disable"
   default: "default"
   "default" means the default utilization policy
   "force" means the container will always limit the core utilization below "nvidia.com/gpucores"
   "disable" means the container will ignore the utilization limitation set by "nvidia.com/gpucores" during task execution
-* `CUDA_DISABLE_CONTROL`
+- `CUDA_DISABLE_CONTROL`
   Bool type, "true","false"
   default: false
   "true" means the HAMi-core will not be used inside container, as a result, there will be no resource isolation and limitation in that container, only for debug. 

--- a/versioned_docs/version-v2.5.0/userguide/enflame-device/enable-enflame-gpu-sharing.md
+++ b/versioned_docs/version-v2.5.0/userguide/enflame-device/enable-enflame-gpu-sharing.md
@@ -16,14 +16,14 @@ title: Enable Enflame GCU sharing
 
 ## Prerequisites
 
-* Enflame gcushare-device-plugin >= 2.1.6 (please consult your device provider, gcushare has two components: gcushare-scheduler-plugin and gcushare-device-plugin, only gcushare-device-plugin is needed here )
-* driver version >= 1.2.3.14
-* kubernetes >= 1.24
-* enflame-container-toolkit >=2.0.50
+- Enflame gcushare-device-plugin >= 2.1.6 (please consult your device provider, gcushare has two components: gcushare-scheduler-plugin and gcushare-device-plugin, only gcushare-device-plugin is needed here )
+- driver version >= 1.2.3.14
+- kubernetes >= 1.24
+- enflame-container-toolkit >=2.0.50
 
 ## Enabling GCU-sharing Support
 
-* Deploy gcushare-device-plugin on enflame nodes (Please consult your device provider to acquire its package and document)
+- Deploy gcushare-device-plugin on enflame nodes (Please consult your device provider to acquire its package and document)
 
 :::note
 
@@ -41,7 +41,7 @@ You can customize these names by modifying `hami-scheduler-device` configMap abo
 
 :::
 
-* Set 'devices.enflame.enabled=true' when deploy HAMi
+- Set 'devices.enflame.enabled=true' when deploy HAMi
 
 ```
 helm install hami hami-charts/hami --set devices.enflame.enabled=true -n kube-system

--- a/versioned_docs/version-v2.5.0/userguide/hygon-device/enable-hygon-dcu-sharing.md
+++ b/versioned_docs/version-v2.5.0/userguide/hygon-device/enable-hygon-dcu-sharing.md
@@ -16,11 +16,11 @@ title: Enable Hygon DCU sharing
 
 ## Prerequisites
 
-* dtk driver >= 24.04
+- dtk driver >= 24.04
 
 ## Enabling DCU-sharing Support
 
-* Deploy the dcu-vgpu-device-plugin [here](https://github.com/Project-HAMi/dcu-vgpu-device-plugin)
+- Deploy the dcu-vgpu-device-plugin [here](https://github.com/Project-HAMi/dcu-vgpu-device-plugin)
 
 ## Running DCU jobs
 

--- a/versioned_docs/version-v2.5.0/userguide/iluvatar-device/enable-iluvatar-gpu-sharing.md
+++ b/versioned_docs/version-v2.5.0/userguide/iluvatar-device/enable-iluvatar-gpu-sharing.md
@@ -18,18 +18,18 @@ title: Enable Iluvatar GCU sharing
 
 ## Prerequisites
 
-* Iluvatar gpu-manager (please consult your device provider)
-* driver version > 3.1.0
+- Iluvatar gpu-manager (please consult your device provider)
+- driver version > 3.1.0
 
 ## Enabling GPU-sharing Support
 
-* Deploy gpu-manager on iluvatar nodes (Please consult your device provider to acquire its package and document)
+- Deploy gpu-manager on iluvatar nodes (Please consult your device provider to acquire its package and document)
 
 > **NOTICE:** *Install only gpu-manager, don't install gpu-admission package.*
 
-* Identify the resource name about core and memory usage(i.e 'iluvatar.ai/vcuda-core', 'iluvatar.ai/vcuda-memory')
+- Identify the resource name about core and memory usage(i.e 'iluvatar.ai/vcuda-core', 'iluvatar.ai/vcuda-memory')
 
-* set the 'iluvatarResourceMem' and 'iluvatarResourceCore' parameters when install hami
+- set the 'iluvatarResourceMem' and 'iluvatarResourceCore' parameters when install hami
 
 ```
 helm install hami hami-charts/hami --set scheduler.kubeScheduler.imageTag={your kubernetes version} --set iluvatarResourceMem=iluvatar.ai/vcuda-memory --set iluvatarResourceCore=iluvatar.ai/vcuda-core -n kube-system

--- a/versioned_docs/version-v2.5.0/userguide/metax-device/enable-metax-gpu-schedule.md
+++ b/versioned_docs/version-v2.5.0/userguide/metax-device/enable-metax-gpu-schedule.md
@@ -31,14 +31,14 @@ Equipped with MetaXLink interconnected resources.
 
 ## Prerequisites
 
-* Metax GPU extensions >= 0.8.0
-* Kubernetes >= 1.23
+- Metax GPU extensions >= 0.8.0
+- Kubernetes >= 1.23
 
 ## Enabling topo-awareness scheduling
 
-* Deploy Metax GPU Extensions on metax nodes (Please consult your device provider to acquire its package and document)
+- Deploy Metax GPU Extensions on metax nodes (Please consult your device provider to acquire its package and document)
 
-* Deploy HAMi according to README.md
+- Deploy HAMi according to README.md
 
 ## Running Metax jobs
 

--- a/versioned_docs/version-v2.5.0/userguide/mthreads-device/enable-mthreads-gpu-sharing.md
+++ b/versioned_docs/version-v2.5.0/userguide/mthreads-device/enable-mthreads-gpu-sharing.md
@@ -24,16 +24,16 @@ title: Enable Mthreads GPU sharing
 
 ## Prerequisites
 
-* [MT CloudNative Toolkits > 1.9.0](https://docs.mthreads.com/cloud-native/cloud-native-doc-online/)
-* driver version >= 1.2.0
+- [MT CloudNative Toolkits > 1.9.0](https://docs.mthreads.com/cloud-native/cloud-native-doc-online/)
+- driver version >= 1.2.0
 
 ## Enabling GPU-sharing Support
 
-* Deploy MT-CloudNative Toolkit on mthreads nodes (Please consult your device provider to acquire its package and document)
+- Deploy MT-CloudNative Toolkit on mthreads nodes (Please consult your device provider to acquire its package and document)
 
 > **NOTICE:** *You can remove mt-mutating-webhook and mt-gpu-scheduler after installation(optional).*
 
-* set the 'devices.mthreads.enabled = true' when installing hami
+- set the 'devices.mthreads.enabled = true' when installing hami
 
 ```
 helm install hami hami-charts/hami --set scheduler.kubeScheduler.imageTag={your kubernetes version} --set device.mthreads.enabled=true -n kube-system

--- a/versioned_docs/version-v2.5.0/userguide/nvidia-device/dynamic-mig-support.md
+++ b/versioned_docs/version-v2.5.0/userguide/nvidia-device/dynamic-mig-support.md
@@ -18,15 +18,15 @@ title: Enable dynamic-mig feature
 
 ## Prerequisites
 
-* NVIDIA Blackwell and Hopper™ and Ampere Devices
-* HAMi > v2.5.0
-* NVIDIA Container Toolkit
+- NVIDIA Blackwell and Hopper™ and Ampere Devices
+- HAMi > v2.5.0
+- NVIDIA Container Toolkit
 
 ## Enabling Dynamic-mig Support
 
-* Install the chart using helm, See 'enabling vGPU support in kubernetes' section [here](https://github.com/Project-HAMi/HAMi#enabling-vgpu-support-in-kubernetes)
+- Install the chart using helm, See 'enabling vGPU support in kubernetes' section [here](https://github.com/Project-HAMi/HAMi#enabling-vgpu-support-in-kubernetes)
 
-* Configure `mode` in device-plugin configMap to `mig` for MIG nodes
+- Configure `mode` in device-plugin configMap to `mig` for MIG nodes
 ```
 kubectl describe cm  hami-device-plugin -n kube-system
 ```
@@ -46,9 +46,9 @@ kubectl describe cm  hami-device-plugin -n kube-system
 }
 ```
 
-* Restart the following pods for the change to take effect:
-  * hami-scheduler 
-  * hami-device-plugin on 'MIG-NODE-A'
+- Restart the following pods for the change to take effect:
+  - hami-scheduler 
+  - hami-device-plugin on 'MIG-NODE-A'
 
 ## Custom mig configuration (Optional)
 HAMi currently has a [built-in mig configuration](https://github.com/Project-HAMi/HAMi/blob/master/charts/hami/templates/scheduler/device-configmap.yaml) for MIG.

--- a/versioned_docs/version-v2.5.1/contributor/governance.md
+++ b/versioned_docs/version-v2.5.1/contributor/governance.md
@@ -8,21 +8,21 @@ Heterogeneous AI Computing Virtualization Middleware (HAMi), formerly known as k
 
 The HAMi and its leadership embrace the following values:
 
-* Openness: Communication and decision-making happens in the open and is discoverable for future
+- Openness: Communication and decision-making happens in the open and is discoverable for future
   reference. As much as possible, all discussions and work take place in public
   forums and open repositories.
 
-* Fairness: All stakeholders have the opportunity to provide feedback and submit
+- Fairness: All stakeholders have the opportunity to provide feedback and submit
   contributions, which will be considered on their merits.
 
-* Community over Product or Company: Sustaining and growing the community takes
+- Community over Product or Company: Sustaining and growing the community takes
   priority over shipping code or sponsors' organizational goals. Each
   contributor participates in the project as an individual.
 
-* Inclusivity: Innovation comes from different perspectives and skill sets, and this
+- Inclusivity: Innovation comes from different perspectives and skill sets, and this
   can only be accomplished in a welcoming and respectful environment.
 
-* Participation: Responsibilities within the project are earned through
+- Participation: Responsibilities within the project are earned through
   participation, and there is a clear path up the contributor ladder into leadership
   positions.
 

--- a/versioned_docs/version-v2.5.1/contributor/ladder.md
+++ b/versioned_docs/version-v2.5.1/contributor/ladder.md
@@ -12,38 +12,38 @@ Each of the contributor roles below is organized into lists of three types of th
 
 Description: A Community Participant engages with the project and its community, contributing their time, thoughts, etc. Community participants are usually users who have stopped being anonymous and started being active in project discussions.
 
-* Responsibilities:
-  * Must follow the [CNCF CoC](https://github.com/cncf/foundation/blob/main/code-of-conduct.md)
-* How users can get involved with the community:
-  * Participating in community discussions
-  * Helping other users
-  * Submitting bug reports
-  * Commenting on issues
-  * Trying out new releases
-  * Attending community events
+- Responsibilities:
+  - Must follow the [CNCF CoC](https://github.com/cncf/foundation/blob/main/code-of-conduct.md)
+- How users can get involved with the community:
+  - Participating in community discussions
+  - Helping other users
+  - Submitting bug reports
+  - Commenting on issues
+  - Trying out new releases
+  - Attending community events
 
 ## Contributor
 
 Description: A Contributor contributes directly to the project and adds value to it. Contributions need not be code. People at the Contributor level may be new contributors, or they may only contribute occasionally.
 
-* Responsibilities include:
-  * Follow the CNCF CoC
-  * Follow the project contributing guide
-* Requirements (one or several of the below):
-  * Report and sometimes resolve issues
-  * Occasionally submit PRs
-  * Contribute to the documentation
-  * Show up at meetings, takes notes
-  * Answer questions from other community members
-  * Submit feedback on issues and PRs
-  * Test releases and patches and submit reviews
-  * Run or helps run events
-  * Promote the project in public
-  * Help run the project infrastructure
-  * [TODO: other small contributions]
-* Privileges:
-  * Invitations to contributor events
-  * Eligible to become an Organization Member
+- Responsibilities include:
+  - Follow the CNCF CoC
+  - Follow the project contributing guide
+- Requirements (one or several of the below):
+  - Report and sometimes resolve issues
+  - Occasionally submit PRs
+  - Contribute to the documentation
+  - Show up at meetings, takes notes
+  - Answer questions from other community members
+  - Submit feedback on issues and PRs
+  - Test releases and patches and submit reviews
+  - Run or helps run events
+  - Promote the project in public
+  - Help run the project infrastructure
+  - [TODO: other small contributions]
+- Privileges:
+  - Invitations to contributor events
+  - Eligible to become an Organization Member
 
 A very special thanks to the [long list of people](https://github.com/Project-HAMi/HAMi/blob/master/AUTHORS.md) who have contributed to and helped maintain the project. Thanks to everyone who contributed and helped maintain the project.
 
@@ -55,31 +55,31 @@ Description: An Organization Member is an established contributor who regularly 
 
 An Organization Member must meet the responsibilities and has the requirements of a Contributor, plus:
 
-* Responsibilities include:
-  * Continues to contribute regularly, as demonstrated by having at least 50 GitHub contributions per year
-* Requirements:
-  * Enabled [two-factor authentication] on their GitHub account
-  * Must have successful contributions to the project or community, including at least one of the following:
-    * 5 accepted PRs,
-    * Reviewed 5 PRs,
-    * Resolved and closed 3 Issues,
-    * Become responsible for a key project management area,
-    * Or some equivalent combination or contribution
-  * Must have been contributing for at least 1 months
-  * Must be actively contributing to at least one project area
-  * Must have two sponsors who are also Organization Members, at least one of whom does not work for the same employer
-  * **Open an issue against the Project-HAMi/HAMi repo**
-    * Ensure your sponsors are @mentioned on the issue
-    * Complete every item on the issue checklist
-    * Make sure that the list of contributions included is representative of your work on the project.
-  * Have your sponsoring reviewers reply confirmation of sponsorship: `+1`
-  * Once your sponsors have responded, your request will be handled by the `HAMi GitHub Admin team`.
+- Responsibilities include:
+  - Continues to contribute regularly, as demonstrated by having at least 50 GitHub contributions per year
+- Requirements:
+  - Enabled [two-factor authentication] on their GitHub account
+  - Must have successful contributions to the project or community, including at least one of the following:
+    - 5 accepted PRs,
+    - Reviewed 5 PRs,
+    - Resolved and closed 3 Issues,
+    - Become responsible for a key project management area,
+    - Or some equivalent combination or contribution
+  - Must have been contributing for at least 1 months
+  - Must be actively contributing to at least one project area
+  - Must have two sponsors who are also Organization Members, at least one of whom does not work for the same employer
+  - **Open an issue against the Project-HAMi/HAMi repo**
+    - Ensure your sponsors are @mentioned on the issue
+    - Complete every item on the issue checklist
+    - Make sure that the list of contributions included is representative of your work on the project.
+  - Have your sponsoring reviewers reply confirmation of sponsorship: `+1`
+  - Once your sponsors have responded, your request will be handled by the `HAMi GitHub Admin team`.
 
-* Privileges:
-  * May be assigned Issues and Reviews
-  * May give commands to CI/CD automation
-  * Can be added to [TODO: Repo Host] teams
-  * Can recommend other contributors to become Org Members
+- Privileges:
+  - May be assigned Issues and Reviews
+  - May give commands to CI/CD automation
+  - Can be added to [TODO: Repo Host] teams
+  - Can recommend other contributors to become Org Members
 
 The process for a Contributor to become an Organization Member is as follows:
 
@@ -94,22 +94,22 @@ Reviewers are responsible for a "specific area." This can be a specific code dir
 
 Reviewers have all the rights and responsibilities of an Organization Member, plus:
 
-* Responsibilities include:
-  * Following the reviewing guide
-  * Reviewing most Pull Requests against their specific areas of responsibility
-  * Reviewing at least 20 PRs per year
-  * Helping other contributors become reviewers
-* Requirements:
-  * Experience as a Contributor for at least 3 months
-  * Is an Organization Member
-  * Has reviewed, or helped review, at least 10 Pull Requests
-  * Has analyzed and resolved test failures in their specific area
-  * Has demonstrated an in-depth knowledge of the specific area
-  * Commits to being responsible for that specific area
-  * Is supportive of new and occasional contributors and helps get useful PRs in shape to commit
-* Additional privileges:
-  * Has GitHub or CI/CD rights to approve pull requests in specific directories
-  * Can recommend and review other contributors to become Reviewers
+- Responsibilities include:
+  - Following the reviewing guide
+  - Reviewing most Pull Requests against their specific areas of responsibility
+  - Reviewing at least 20 PRs per year
+  - Helping other contributors become reviewers
+- Requirements:
+  - Experience as a Contributor for at least 3 months
+  - Is an Organization Member
+  - Has reviewed, or helped review, at least 10 Pull Requests
+  - Has analyzed and resolved test failures in their specific area
+  - Has demonstrated an in-depth knowledge of the specific area
+  - Commits to being responsible for that specific area
+  - Is supportive of new and occasional contributors and helps get useful PRs in shape to commit
+- Additional privileges:
+  - Has GitHub or CI/CD rights to approve pull requests in specific directories
+  - Can recommend and review other contributors to become Reviewers
 
 The process of becoming a Reviewer is:
 
@@ -126,15 +126,15 @@ The current list of maintainers can be found in the [MAINTAINERS](https://github
 
 ## An active maintainer should
 
-* Actively participate in reviewing pull requests and incoming issues. There are no hard rules on what is “active enough” and this is left up to the judgement of the current group of maintainers.
+- Actively participate in reviewing pull requests and incoming issues. There are no hard rules on what is “active enough” and this is left up to the judgement of the current group of maintainers.
 
-* Actively participate in discussions about design and the future of the project.
+- Actively participate in discussions about design and the future of the project.
 
-* Take responsibility for backports to appropriate branches for PRs they approve and merge.
+- Take responsibility for backports to appropriate branches for PRs they approve and merge.
 
-* Do their best to follow all code, testing, and design conventions as determined by consensus among active maintainers.
+- Do their best to follow all code, testing, and design conventions as determined by consensus among active maintainers.
 
-* Gracefully step down from their maintainership role when they are no longer planning to actively participate in the project.
+- Gracefully step down from their maintainership role when they are no longer planning to actively participate in the project.
 
 ## How to be a maintainer
 
@@ -150,12 +150,12 @@ It is normal for maintainers to come and go based on their other responsibilitie
 
 It is important for contributors to be and stay active to set an example and show commitment to the project. Inactivity is harmful to the project as it may lead to unexpected delays, contributor attrition, and a lost of trust in the project.
 
-* Inactivity is measured by:
-  * Periods of no contributions for longer than 3 months
-  * Periods of no communication for longer than 3 months
-* Consequences of being inactive include:
-  * Involuntary removal or demotion
-  * Being asked to move to Emeritus status
+- Inactivity is measured by:
+  - Periods of no contributions for longer than 3 months
+  - Periods of no communication for longer than 3 months
+- Consequences of being inactive include:
+  - Involuntary removal or demotion
+  - Being asked to move to Emeritus status
 
 ## Involuntary Removal or Demotion
 

--- a/versioned_docs/version-v2.5.1/releases.md
+++ b/versioned_docs/version-v2.5.1/releases.md
@@ -26,14 +26,14 @@ Minor releases contain features, enhancements, and fixes that are introduced in 
 Since HAMi is a fast growing project and features continue to iterate rapidly,
 having a minor release approximately every few months helps balance speed and stability.
 
-* Roughly every 3 months
+- Roughly every 3 months
 
 ### PATCH release
 
 Patch releases are for backwards-compatible bug fixes and very minor enhancements which do not impact stability or compatibility.
 Typically only critical fixes are selected for patch releases. Usually there will be at least one patch release in a minor release cycle.
 
-* When critical fixes are required, or roughly each month
+- When critical fixes are required, or roughly each month
 
 ### Versioning
 
@@ -53,17 +53,17 @@ Critical issues, with no work-arounds, are added to the next patch release.
 
 Release branches and PRs are managed as follows:
 
-* All changes are always first committed to `master`.
-* Branches are created for each major or minor release.
-* The branch name will contain the version, for example release-1.2.
-* Patch releases are created from a release branch.
-* For critical fixes that need to be included in a patch release, PRs should always be first merged to master
+- All changes are always first committed to `master`.
+- Branches are created for each major or minor release.
+- The branch name will contain the version, for example release-1.2.
+- Patch releases are created from a release branch.
+- For critical fixes that need to be included in a patch release, PRs should always be first merged to master
   and then cherry-picked to the release branch. PRs need to be guaranteed to have a release note written and
   these descriptions will be reflected in the next patch release.
   The cherry-pick process of PRs is executed through the script. See usage [here](https://project-hami.io/docs/contributor/cherry-picks).
-* For complex changes, specially critical bugfixes, separate PRs may be required for master and release branches.
-* The milestone mark (for example v1.4) will be added to PRs which means changes in PRs are one of the contents of the corresponding release.
-* During PR review, the Assignee selection is used to indicate the reviewer.
+- For complex changes, specially critical bugfixes, separate PRs may be required for master and release branches.
+- The milestone mark (for example v1.4) will be added to PRs which means changes in PRs are one of the contents of the corresponding release.
+- During PR review, the Assignee selection is used to indicate the reviewer.
 
 ### Release Planning
 
@@ -85,26 +85,26 @@ For example, [here](https://hub.docker.com/r/karmada/karmada-controller-manager)
 
 Since v1.2.0, the following artifacts are uploaded:
 
-* crds.tar.gz
-* karmada-chart-v\<version_number\>.tgz
-* karmadactl-darwin-amd64.tgz
-* karmadactl-darwin-amd64.tgz.sha256
-* karmadactl-darwin-arm64.tgz
-* karmadactl-darwin-arm64.tgz.sha256
-* karmadactl-linux-amd64.tgz
-* karmadactl-linux-amd64.tgz.sha256
-* karmadactl-linux-arm64.tgz
-* karmadactl-linux-arm64.tgz.sha256
-* kubectl-karmada-darwin-amd64.tgz
-* kubectl-karmada-darwin-amd64.tgz.sha256
-* kubectl-karmada-darwin-arm64.tgz
-* kubectl-karmada-darwin-arm64.tgz.sha256
-* kubectl-karmada-linux-amd64.tgz
-* kubectl-karmada-linux-amd64.tgz.sha256
-* kubectl-karmada-linux-arm64.tgz
-* kubectl-karmada-linux-arm64.tgz.sha256
-* Source code(zip)
-* Source code(tar.gz)
+- crds.tar.gz
+- karmada-chart-v\<version_number\>.tgz
+- karmadactl-darwin-amd64.tgz
+- karmadactl-darwin-amd64.tgz.sha256
+- karmadactl-darwin-arm64.tgz
+- karmadactl-darwin-arm64.tgz.sha256
+- karmadactl-linux-amd64.tgz
+- karmadactl-linux-amd64.tgz.sha256
+- karmadactl-linux-arm64.tgz
+- karmadactl-linux-arm64.tgz.sha256
+- kubectl-karmada-darwin-amd64.tgz
+- kubectl-karmada-darwin-amd64.tgz.sha256
+- kubectl-karmada-darwin-arm64.tgz
+- kubectl-karmada-darwin-arm64.tgz.sha256
+- kubectl-karmada-linux-amd64.tgz
+- kubectl-karmada-linux-amd64.tgz.sha256
+- kubectl-karmada-linux-arm64.tgz
+- kubectl-karmada-linux-arm64.tgz.sha256
+- Source code(zip)
+- Source code(tar.gz)
 
 You can visit `https://github.com/Project-HAMi/HAMi/releases/download/v<version_number>/<artifact_name>` to download the artifacts above.
 

--- a/versioned_docs/version-v2.5.1/userguide/ascend-device/enable-ascend-sharing.md
+++ b/versioned_docs/version-v2.5.1/userguide/ascend-device/enable-ascend-sharing.md
@@ -6,13 +6,13 @@ Memory slicing is supported based on virtualization template, lease available te
 
 ## Prerequisites
 
-* Ascend device type: 910B, 910A, 310P
-* driver version >= 24.1.rc1
-* Ascend docker runtime
+- Ascend device type: 910B, 910A, 310P
+- driver version >= 24.1.rc1
+- Ascend docker runtime
 
 ## Enabling Ascend-sharing support
 
-* Due to dependencies with HAMi, you need to set the arguments in the process of installing HAMi:
+- Due to dependencies with HAMi, you need to set the arguments in the process of installing HAMi:
 
   ```
   devices.ascend.enabled=true
@@ -39,15 +39,15 @@ Memory slicing is supported based on virtualization template, lease available te
         - huawei.com/Ascend310P-memory
   ```
 
-* Tag Ascend node with the following command
+- Tag Ascend node with the following command
 
   ```bash
   kubectl label node {ascend-node} ascend=on
   ```
 
-* Install [Ascend docker runtime](https://gitee.com/ascend/ascend-docker-runtime)
+- Install [Ascend docker runtime](https://gitee.com/ascend/ascend-docker-runtime)
 
-* [Download YAML for Ascend-vgpu-device-plugin](https://github.com/Project-HAMi/ascend-device-plugin/blob/master/build/ascendplugin-hami.yaml) from HAMi Project, and run the following commands to deploy
+- [Download YAML for Ascend-vgpu-device-plugin](https://github.com/Project-HAMi/ascend-device-plugin/blob/master/build/ascendplugin-hami.yaml) from HAMi Project, and run the following commands to deploy
 
   ```bash
   wge https://raw.githubusercontent.com/Project-HAMi/ascend-device-plugin/refs/heads/main/ascend-device-plugin.yaml

--- a/versioned_docs/version-v2.5.1/userguide/cambricon-device/enable-cambricon-mlu-sharing.md
+++ b/versioned_docs/version-v2.5.1/userguide/cambricon-device/enable-cambricon-mlu-sharing.md
@@ -16,13 +16,13 @@ title: Enable cambricon MLU sharing
 
 ## Prerequisites
 
-* neuware-mlu370-driver > 5.0.0
-* cambricon-device-plugin > 2.0.9
-* cntoolkit > 2.5.3
+- neuware-mlu370-driver > 5.0.0
+- cambricon-device-plugin > 2.0.9
+- cntoolkit > 2.5.3
 
 ## Enabling MLU-sharing Support
 
-* Contact your device provider to acquire cambricon-device-plugin>2.0.9, edit parameter `mode` to 'dynamic-smlu` in containers.args field.
+- Contact your device provider to acquire cambricon-device-plugin>2.0.9, edit parameter `mode` to 'dynamic-smlu` in containers.args field.
 
 ```
         args:
@@ -30,11 +30,11 @@ title: Enable cambricon MLU sharing
 	...
 ```
 
-* Deploy modified cambricon-device-plugin
+- Deploy modified cambricon-device-plugin
 
-* Install the chart using helm, See 'enabling vGPU support in kubernetes' section [here](https://github.com/Project-HAMi/HAMi#enabling-vgpu-support-in-kubernetes)
+- Install the chart using helm, See 'enabling vGPU support in kubernetes' section [here](https://github.com/Project-HAMi/HAMi#enabling-vgpu-support-in-kubernetes)
 
-* Activate the smlu mode for each MLUs on that node
+- Activate the smlu mode for each MLUs on that node
 ```
 cnmon set -c 0 -smlu on
 cnmon set -c 1 -smlu on

--- a/versioned_docs/version-v2.5.1/userguide/hygon-device/enable-hygon-dcu-sharing.md
+++ b/versioned_docs/version-v2.5.1/userguide/hygon-device/enable-hygon-dcu-sharing.md
@@ -16,11 +16,11 @@ title: Enable Hygon DCU sharing
 
 ## Prerequisites
 
-* dtk driver >= 24.04
+- dtk driver >= 24.04
 
 ## Enabling DCU-sharing Support
 
-* Deploy the dcu-vgpu-device-plugin [here](https://github.com/Project-HAMi/dcu-vgpu-device-plugin)
+- Deploy the dcu-vgpu-device-plugin [here](https://github.com/Project-HAMi/dcu-vgpu-device-plugin)
 
 ## Running DCU jobs
 

--- a/versioned_docs/version-v2.5.1/userguide/metax-device/enable-metax-gpu-schedule.md
+++ b/versioned_docs/version-v2.5.1/userguide/metax-device/enable-metax-gpu-schedule.md
@@ -31,14 +31,14 @@ Equipped with MetaXLink interconnected resources.
 
 ## Prerequisites
 
-* Metax GPU extensions >= 0.8.0
-* Kubernetes >= 1.23
+- Metax GPU extensions >= 0.8.0
+- Kubernetes >= 1.23
 
 ## Enabling topo-awareness scheduling
 
-* Deploy Metax GPU Extensions on metax nodes (Please consult your device provider to acquire its package and document)
+- Deploy Metax GPU Extensions on metax nodes (Please consult your device provider to acquire its package and document)
 
-* Deploy HAMi according to README.md
+- Deploy HAMi according to README.md
 
 ## Running Metax jobs
 

--- a/versioned_docs/version-v2.5.1/userguide/mthreads-device/enable-mthreads-gpu-sharing.md
+++ b/versioned_docs/version-v2.5.1/userguide/mthreads-device/enable-mthreads-gpu-sharing.md
@@ -24,16 +24,16 @@ title: Enable Mthreads GPU sharing
 
 ## Prerequisites
 
-* [MT CloudNative Toolkits > 1.9.0](https://docs.mthreads.com/cloud-native/cloud-native-doc-online/)
-* driver version >= 1.2.0
+- [MT CloudNative Toolkits > 1.9.0](https://docs.mthreads.com/cloud-native/cloud-native-doc-online/)
+- driver version >= 1.2.0
 
 ## Enabling GPU-sharing Support
 
-* Deploy MT-CloudNative Toolkit on mthreads nodes (Please consult your device provider to acquire its package and document)
+- Deploy MT-CloudNative Toolkit on mthreads nodes (Please consult your device provider to acquire its package and document)
 
 > **NOTICE:** *You can remove mt-mutating-webhook and mt-gpu-scheduler after installation(optional).*
 
-* set the 'devices.mthreads.enabled = true' when installing hami
+- set the 'devices.mthreads.enabled = true' when installing hami
 
 ```
 helm install hami hami-charts/hami --set scheduler.kubeScheduler.imageTag={your kubernetes version} --set device.mthreads.enabled=true -n kube-system

--- a/versioned_docs/version-v2.6.0/contributor/governance.md
+++ b/versioned_docs/version-v2.6.0/contributor/governance.md
@@ -8,21 +8,21 @@ Heterogeneous AI Computing Virtualization Middleware (HAMi), formerly known as k
 
 The HAMi and its leadership embrace the following values:
 
-* Openness: Communication and decision-making happens in the open and is discoverable for future
+- Openness: Communication and decision-making happens in the open and is discoverable for future
   reference. As much as possible, all discussions and work take place in public
   forums and open repositories.
 
-* Fairness: All stakeholders have the opportunity to provide feedback and submit
+- Fairness: All stakeholders have the opportunity to provide feedback and submit
   contributions, which will be considered on their merits.
 
-* Community over Product or Company: Sustaining and growing the community takes
+- Community over Product or Company: Sustaining and growing the community takes
   priority over shipping code or sponsors' organizational goals. Each
   contributor participates in the project as an individual.
 
-* Inclusivity: Innovation comes from different perspectives and skill sets, and this
+- Inclusivity: Innovation comes from different perspectives and skill sets, and this
   can only be accomplished in a welcoming and respectful environment.
 
-* Participation: Responsibilities within the project are earned through
+- Participation: Responsibilities within the project are earned through
   participation, and there is a clear path up the contributor ladder into leadership
   positions.
 

--- a/versioned_docs/version-v2.6.0/contributor/ladder.md
+++ b/versioned_docs/version-v2.6.0/contributor/ladder.md
@@ -12,38 +12,38 @@ Each of the contributor roles below is organized into lists of three types of th
 
 Description: A Community Participant engages with the project and its community, contributing their time, thoughts, etc. Community participants are usually users who have stopped being anonymous and started being active in project discussions.
 
-* Responsibilities:
-  * Must follow the [CNCF CoC](https://github.com/cncf/foundation/blob/main/code-of-conduct.md)
-* How users can get involved with the community:
-  * Participating in community discussions
-  * Helping other users
-  * Submitting bug reports
-  * Commenting on issues
-  * Trying out new releases
-  * Attending community events
+- Responsibilities:
+  - Must follow the [CNCF CoC](https://github.com/cncf/foundation/blob/main/code-of-conduct.md)
+- How users can get involved with the community:
+  - Participating in community discussions
+  - Helping other users
+  - Submitting bug reports
+  - Commenting on issues
+  - Trying out new releases
+  - Attending community events
 
 ## Contributor
 
 Description: A Contributor contributes directly to the project and adds value to it. Contributions need not be code. People at the Contributor level may be new contributors, or they may only contribute occasionally.
 
-* Responsibilities include:
-  * Follow the CNCF CoC
-  * Follow the project contributing guide
-* Requirements (one or several of the below):
-  * Report and sometimes resolve issues
-  * Occasionally submit PRs
-  * Contribute to the documentation
-  * Show up at meetings, takes notes
-  * Answer questions from other community members
-  * Submit feedback on issues and PRs
-  * Test releases and patches and submit reviews
-  * Run or helps run events
-  * Promote the project in public
-  * Help run the project infrastructure
-  * [TODO: other small contributions]
-* Privileges:
-  * Invitations to contributor events
-  * Eligible to become an Organization Member
+- Responsibilities include:
+  - Follow the CNCF CoC
+  - Follow the project contributing guide
+- Requirements (one or several of the below):
+  - Report and sometimes resolve issues
+  - Occasionally submit PRs
+  - Contribute to the documentation
+  - Show up at meetings, takes notes
+  - Answer questions from other community members
+  - Submit feedback on issues and PRs
+  - Test releases and patches and submit reviews
+  - Run or helps run events
+  - Promote the project in public
+  - Help run the project infrastructure
+  - [TODO: other small contributions]
+- Privileges:
+  - Invitations to contributor events
+  - Eligible to become an Organization Member
 
 A very special thanks to the [long list of people](https://github.com/Project-HAMi/HAMi/blob/master/AUTHORS.md) who have contributed to and helped maintain the project. Thanks to everyone who contributed and helped maintain the project.
 
@@ -55,31 +55,31 @@ Description: An Organization Member is an established contributor who regularly 
 
 An Organization Member must meet the responsibilities and has the requirements of a Contributor, plus:
 
-* Responsibilities include:
-  * Continues to contribute regularly, as demonstrated by having at least 50 GitHub contributions per year
-* Requirements:
-  * Enabled [two-factor authentication] on their GitHub account
-  * Must have successful contributions to the project or community, including at least one of the following:
-    * 5 accepted PRs,
-    * Reviewed 5 PRs,
-    * Resolved and closed 3 Issues,
-    * Become responsible for a key project management area,
-    * Or some equivalent combination or contribution
-  * Must have been contributing for at least 1 months
-  * Must be actively contributing to at least one project area
-  * Must have two sponsors who are also Organization Members, at least one of whom does not work for the same employer
-  * **Open an issue against the Project-HAMi/HAMi repo**
-    * Ensure your sponsors are @mentioned on the issue
-    * Complete every item on the issue checklist
-    * Make sure that the list of contributions included is representative of your work on the project.
-  * Have your sponsoring reviewers reply confirmation of sponsorship: `+1`
-  * Once your sponsors have responded, your request will be handled by the `HAMi GitHub Admin team`.
+- Responsibilities include:
+  - Continues to contribute regularly, as demonstrated by having at least 50 GitHub contributions per year
+- Requirements:
+  - Enabled [two-factor authentication] on their GitHub account
+  - Must have successful contributions to the project or community, including at least one of the following:
+    - 5 accepted PRs,
+    - Reviewed 5 PRs,
+    - Resolved and closed 3 Issues,
+    - Become responsible for a key project management area,
+    - Or some equivalent combination or contribution
+  - Must have been contributing for at least 1 months
+  - Must be actively contributing to at least one project area
+  - Must have two sponsors who are also Organization Members, at least one of whom does not work for the same employer
+  - **Open an issue against the Project-HAMi/HAMi repo**
+    - Ensure your sponsors are @mentioned on the issue
+    - Complete every item on the issue checklist
+    - Make sure that the list of contributions included is representative of your work on the project.
+  - Have your sponsoring reviewers reply confirmation of sponsorship: `+1`
+  - Once your sponsors have responded, your request will be handled by the `HAMi GitHub Admin team`.
 
-* Privileges:
-  * May be assigned Issues and Reviews
-  * May give commands to CI/CD automation
-  * Can be added to [TODO: Repo Host] teams
-  * Can recommend other contributors to become Org Members
+- Privileges:
+  - May be assigned Issues and Reviews
+  - May give commands to CI/CD automation
+  - Can be added to [TODO: Repo Host] teams
+  - Can recommend other contributors to become Org Members
 
 The process for a Contributor to become an Organization Member is as follows:
 
@@ -94,22 +94,22 @@ Reviewers are responsible for a "specific area." This can be a specific code dir
 
 Reviewers have all the rights and responsibilities of an Organization Member, plus:
 
-* Responsibilities include:
-  * Following the reviewing guide
-  * Reviewing most Pull Requests against their specific areas of responsibility
-  * Reviewing at least 20 PRs per year
-  * Helping other contributors become reviewers
-* Requirements:
-  * Experience as a Contributor for at least 3 months
-  * Is an Organization Member
-  * Has reviewed, or helped review, at least 10 Pull Requests
-  * Has analyzed and resolved test failures in their specific area
-  * Has demonstrated an in-depth knowledge of the specific area
-  * Commits to being responsible for that specific area
-  * Is supportive of new and occasional contributors and helps get useful PRs in shape to commit
-* Additional privileges:
-  * Has GitHub or CI/CD rights to approve pull requests in specific directories
-  * Can recommend and review other contributors to become Reviewers
+- Responsibilities include:
+  - Following the reviewing guide
+  - Reviewing most Pull Requests against their specific areas of responsibility
+  - Reviewing at least 20 PRs per year
+  - Helping other contributors become reviewers
+- Requirements:
+  - Experience as a Contributor for at least 3 months
+  - Is an Organization Member
+  - Has reviewed, or helped review, at least 10 Pull Requests
+  - Has analyzed and resolved test failures in their specific area
+  - Has demonstrated an in-depth knowledge of the specific area
+  - Commits to being responsible for that specific area
+  - Is supportive of new and occasional contributors and helps get useful PRs in shape to commit
+- Additional privileges:
+  - Has GitHub or CI/CD rights to approve pull requests in specific directories
+  - Can recommend and review other contributors to become Reviewers
 
 The process of becoming a Reviewer is:
 
@@ -126,15 +126,15 @@ The current list of maintainers can be found in the [MAINTAINERS](https://github
 
 ## An active maintainer should
 
-* Actively participate in reviewing pull requests and incoming issues. There are no hard rules on what is “active enough” and this is left up to the judgement of the current group of maintainers.
+- Actively participate in reviewing pull requests and incoming issues. There are no hard rules on what is “active enough” and this is left up to the judgement of the current group of maintainers.
 
-* Actively participate in discussions about design and the future of the project.
+- Actively participate in discussions about design and the future of the project.
 
-* Take responsibility for backports to appropriate branches for PRs they approve and merge.
+- Take responsibility for backports to appropriate branches for PRs they approve and merge.
 
-* Do their best to follow all code, testing, and design conventions as determined by consensus among active maintainers.
+- Do their best to follow all code, testing, and design conventions as determined by consensus among active maintainers.
 
-* Gracefully step down from their maintainership role when they are no longer planning to actively participate in the project.
+- Gracefully step down from their maintainership role when they are no longer planning to actively participate in the project.
 
 ## How to be a maintainer
 
@@ -150,12 +150,12 @@ It is normal for maintainers to come and go based on their other responsibilitie
 
 It is important for contributors to be and stay active to set an example and show commitment to the project. Inactivity is harmful to the project as it may lead to unexpected delays, contributor attrition, and a lost of trust in the project.
 
-* Inactivity is measured by:
-  * Periods of no contributions for longer than 3 months
-  * Periods of no communication for longer than 3 months
-* Consequences of being inactive include:
-  * Involuntary removal or demotion
-  * Being asked to move to Emeritus status
+- Inactivity is measured by:
+  - Periods of no contributions for longer than 3 months
+  - Periods of no communication for longer than 3 months
+- Consequences of being inactive include:
+  - Involuntary removal or demotion
+  - Being asked to move to Emeritus status
 
 ## Involuntary Removal or Demotion
 

--- a/versioned_docs/version-v2.6.0/releases.md
+++ b/versioned_docs/version-v2.6.0/releases.md
@@ -26,14 +26,14 @@ Minor releases contain features, enhancements, and fixes that are introduced in 
 Since HAMi is a fast growing project and features continue to iterate rapidly,
 having a minor release approximately every few months helps balance speed and stability.
 
-* Roughly every 3 months
+- Roughly every 3 months
 
 ### PATCH release
 
 Patch releases are for backwards-compatible bug fixes and very minor enhancements which do not impact stability or compatibility.
 Typically only critical fixes are selected for patch releases. Usually there will be at least one patch release in a minor release cycle.
 
-* When critical fixes are required, or roughly each month
+- When critical fixes are required, or roughly each month
 
 ### Versioning
 
@@ -53,17 +53,17 @@ Critical issues, with no work-arounds, are added to the next patch release.
 
 Release branches and PRs are managed as follows:
 
-* All changes are always first committed to `master`.
-* Branches are created for each major or minor release.
-* The branch name will contain the version, for example release-1.2.
-* Patch releases are created from a release branch.
-* For critical fixes that need to be included in a patch release, PRs should always be first merged to master
+- All changes are always first committed to `master`.
+- Branches are created for each major or minor release.
+- The branch name will contain the version, for example release-1.2.
+- Patch releases are created from a release branch.
+- For critical fixes that need to be included in a patch release, PRs should always be first merged to master
   and then cherry-picked to the release branch. PRs need to be guaranteed to have a release note written and
   these descriptions will be reflected in the next patch release.
   The cherry-pick process of PRs is executed through the script. See usage [here](https://project-hami.io/docs/contributor/cherry-picks).
-* For complex changes, specially critical bugfixes, separate PRs may be required for master and release branches.
-* The milestone mark (for example v1.4) will be added to PRs which means changes in PRs are one of the contents of the corresponding release.
-* During PR review, the Assignee selection is used to indicate the reviewer.
+- For complex changes, specially critical bugfixes, separate PRs may be required for master and release branches.
+- The milestone mark (for example v1.4) will be added to PRs which means changes in PRs are one of the contents of the corresponding release.
+- During PR review, the Assignee selection is used to indicate the reviewer.
 
 ### Release Planning
 
@@ -85,26 +85,26 @@ For example, [here](https://hub.docker.com/r/karmada/karmada-controller-manager)
 
 Since v1.2.0, the following artifacts are uploaded:
 
-* crds.tar.gz
-* karmada-chart-v\<version_number\>.tgz
-* karmadactl-darwin-amd64.tgz
-* karmadactl-darwin-amd64.tgz.sha256
-* karmadactl-darwin-arm64.tgz
-* karmadactl-darwin-arm64.tgz.sha256
-* karmadactl-linux-amd64.tgz
-* karmadactl-linux-amd64.tgz.sha256
-* karmadactl-linux-arm64.tgz
-* karmadactl-linux-arm64.tgz.sha256
-* kubectl-karmada-darwin-amd64.tgz
-* kubectl-karmada-darwin-amd64.tgz.sha256
-* kubectl-karmada-darwin-arm64.tgz
-* kubectl-karmada-darwin-arm64.tgz.sha256
-* kubectl-karmada-linux-amd64.tgz
-* kubectl-karmada-linux-amd64.tgz.sha256
-* kubectl-karmada-linux-arm64.tgz
-* kubectl-karmada-linux-arm64.tgz.sha256
-* Source code(zip)
-* Source code(tar.gz)
+- crds.tar.gz
+- karmada-chart-v\<version_number\>.tgz
+- karmadactl-darwin-amd64.tgz
+- karmadactl-darwin-amd64.tgz.sha256
+- karmadactl-darwin-arm64.tgz
+- karmadactl-darwin-arm64.tgz.sha256
+- karmadactl-linux-amd64.tgz
+- karmadactl-linux-amd64.tgz.sha256
+- karmadactl-linux-arm64.tgz
+- karmadactl-linux-arm64.tgz.sha256
+- kubectl-karmada-darwin-amd64.tgz
+- kubectl-karmada-darwin-amd64.tgz.sha256
+- kubectl-karmada-darwin-arm64.tgz
+- kubectl-karmada-darwin-arm64.tgz.sha256
+- kubectl-karmada-linux-amd64.tgz
+- kubectl-karmada-linux-amd64.tgz.sha256
+- kubectl-karmada-linux-arm64.tgz
+- kubectl-karmada-linux-arm64.tgz.sha256
+- Source code(zip)
+- Source code(tar.gz)
 
 You can visit `https://github.com/Project-HAMi/HAMi/releases/download/v<version_number>/<artifact_name>` to download the artifacts above.
 

--- a/versioned_docs/version-v2.6.0/userguide/ascend-device/enable-ascend-sharing.md
+++ b/versioned_docs/version-v2.6.0/userguide/ascend-device/enable-ascend-sharing.md
@@ -6,13 +6,13 @@ Memory slicing is supported based on virtualization template, lease available te
 
 ## Prerequisites
 
-* Ascend device type: 910B, 910A, 310P
-* driver version >= 24.1.rc1
-* Ascend docker runtime
+- Ascend device type: 910B, 910A, 310P
+- driver version >= 24.1.rc1
+- Ascend docker runtime
 
 ## Enabling Ascend-sharing support
 
-* Due to dependencies with HAMi, you need to set the arguments in the process of installing HAMi:
+- Due to dependencies with HAMi, you need to set the arguments in the process of installing HAMi:
 
   ```
   devices.ascend.enabled=true
@@ -39,15 +39,15 @@ Memory slicing is supported based on virtualization template, lease available te
         - huawei.com/Ascend310P-memory
   ```
 
-* Tag Ascend node with the following command
+- Tag Ascend node with the following command
 
   ```bash
   kubectl label node {ascend-node} ascend=on
   ```
 
-* Install [Ascend docker runtime](https://gitee.com/ascend/ascend-docker-runtime)
+- Install [Ascend docker runtime](https://gitee.com/ascend/ascend-docker-runtime)
 
-* [Download YAML for Ascend-vgpu-device-plugin](https://github.com/Project-HAMi/ascend-device-plugin/blob/master/build/ascendplugin-hami.yaml) from HAMi Project, and run the following commands to deploy
+- [Download YAML for Ascend-vgpu-device-plugin](https://github.com/Project-HAMi/ascend-device-plugin/blob/master/build/ascendplugin-hami.yaml) from HAMi Project, and run the following commands to deploy
 
   ```bash
   wge https://raw.githubusercontent.com/Project-HAMi/ascend-device-plugin/refs/heads/main/ascend-device-plugin.yaml

--- a/versioned_docs/version-v2.6.0/userguide/cambricon-device/enable-cambricon-mlu-sharing.md
+++ b/versioned_docs/version-v2.6.0/userguide/cambricon-device/enable-cambricon-mlu-sharing.md
@@ -17,14 +17,14 @@ title: Enable cambricon MLU sharing
 
 ## Prerequisites
 
-* neuware-mlu370-driver > 5.10
-* cntoolkit > 2.5.3
+- neuware-mlu370-driver > 5.10
+- cntoolkit > 2.5.3
 
 ## Enabling MLU-sharing Support
 
-* Install the chart using helm, See 'enabling vGPU support in kubernetes' section [here](https://github.com/Project-HAMi/HAMi#enabling-vgpu-support-in-kubernetes)
+- Install the chart using helm, See 'enabling vGPU support in kubernetes' section [here](https://github.com/Project-HAMi/HAMi#enabling-vgpu-support-in-kubernetes)
 
-* Activate the smlu mode for each MLUs on that node
+- Activate the smlu mode for each MLUs on that node
 
 ```sh
 cnmon set -c 0 -smlu on
@@ -32,13 +32,13 @@ cnmon set -c 1 -smlu on
 # ...
 ```
 
-* Get cambricon-device-plugin from your device provider and specify the following parameters during deployment:
+- Get cambricon-device-plugin from your device provider and specify the following parameters during deployment:
 
 `mode=dynamic-smlu`, `min-dsmlu-unit=256`
 
 These two parameters represent enabling the dynamic smlu function and setting the minimum allocable memory unit to 256 MB, respectively. You can refer to the document from device provider for more details
 
-* Deploy the cambricon-device-plugin you specified
+- Deploy the cambricon-device-plugin you specified
 
 ```
 kubectl apply -f cambricon-device-plugin-daemonset.yaml

--- a/versioned_docs/version-v2.6.0/userguide/enflame-device/enable-enflame-gcu-sharing.md
+++ b/versioned_docs/version-v2.6.0/userguide/enflame-device/enable-enflame-gcu-sharing.md
@@ -17,14 +17,14 @@ title: Enable Enflame GCU Sharing
 
 ## Prerequisites
 
-* Enflame gcushare-device-plugin >= 2.1.6 (please consult your device provider, gcushare has two components: gcushare-scheduler-plugin and gcushare-device-plugin, only gcushare-device-plugin is needed here )
-* driver version >= 1.2.3.14
-* kubernetes >= 1.24
-* enflame-container-toolkit >=2.0.50
+- Enflame gcushare-device-plugin >= 2.1.6 (please consult your device provider, gcushare has two components: gcushare-scheduler-plugin and gcushare-device-plugin, only gcushare-device-plugin is needed here )
+- driver version >= 1.2.3.14
+- kubernetes >= 1.24
+- enflame-container-toolkit >=2.0.50
 
 ## Enabling GCU-sharing Support
 
-* Deploy gcushare-device-plugin on enflame nodes (Please consult your device provider to acquire its package and document)
+- Deploy gcushare-device-plugin on enflame nodes (Please consult your device provider to acquire its package and document)
 
 :::note
 
@@ -42,7 +42,7 @@ You can customize these names by modifying `hami-scheduler-device` configMap abo
 
 :::
 
-* Set 'devices.enflame.enabled=true' when deploy HAMi
+- Set 'devices.enflame.enabled=true' when deploy HAMi
 
 ```
 helm install hami hami-charts/hami --set devices.enflame.enabled=true -n kube-system

--- a/versioned_docs/version-v2.6.0/userguide/hygon-device/enable-hygon-dcu-sharing.md
+++ b/versioned_docs/version-v2.6.0/userguide/hygon-device/enable-hygon-dcu-sharing.md
@@ -16,12 +16,12 @@ title: Enable Hygon DCU sharing
 
 ## Prerequisites
 
-* dtk driver >= 24.04
-* hy-smi v1.6.0
+- dtk driver >= 24.04
+- hy-smi v1.6.0
 
 ## Enabling DCU-sharing Support
 
-* Deploy the dcu-vgpu-device-plugin [here](https://github.com/Project-HAMi/dcu-vgpu-device-plugin)
+- Deploy the dcu-vgpu-device-plugin [here](https://github.com/Project-HAMi/dcu-vgpu-device-plugin)
 
 
 ## Running DCU jobs

--- a/versioned_docs/version-v2.6.0/userguide/iluvatar-device/enable-illuvatar-gpu-sharing.md
+++ b/versioned_docs/version-v2.6.0/userguide/iluvatar-device/enable-illuvatar-gpu-sharing.md
@@ -19,12 +19,12 @@ title: Enable Illuvatar GPU Sharing
 
 ## Prerequisites
 
-* Iluvatar gpu-manager (please consult your device provider)
-* driver version > 3.1.0
+- Iluvatar gpu-manager (please consult your device provider)
+- driver version > 3.1.0
 
 ## Enabling GPU-sharing Support
 
-* Deploy gpu-manager on iluvatar nodes (Please consult your device provider to acquire its package and document)
+- Deploy gpu-manager on iluvatar nodes (Please consult your device provider to acquire its package and document)
 
 :::note
 
@@ -32,9 +32,9 @@ Install only gpu-manager, don't install gpu-admission package.
 
 :::
 
-* Identify the resource name about core and memory usage(i.e 'iluvatar.ai/vcuda-core', 'iluvatar.ai/vcuda-memory')
+- Identify the resource name about core and memory usage(i.e 'iluvatar.ai/vcuda-core', 'iluvatar.ai/vcuda-memory')
 
-* set the 'iluvatarResourceMem' and 'iluvatarResourceCore' parameters when install hami
+- set the 'iluvatarResourceMem' and 'iluvatarResourceCore' parameters when install hami
 
 ```
 helm install hami hami-charts/hami --set scheduler.kubeScheduler.imageTag={your kubernetes version} --set iluvatarResourceMem=iluvatar.ai/vcuda-memory --set iluvatarResourceCore=iluvatar.ai/vcuda-core -n kube-system

--- a/versioned_docs/version-v2.6.0/userguide/mthreads-device/enable-mthreads-gpu-sharing.md
+++ b/versioned_docs/version-v2.6.0/userguide/mthreads-device/enable-mthreads-gpu-sharing.md
@@ -24,12 +24,12 @@ title: Enable Mthreads GPU sharing
 
 ## Prerequisites
 
-* [MT CloudNative Toolkits > 1.9.0](https://docs.mthreads.com/cloud-native/cloud-native-doc-online/)
-* driver version >= 1.2.0
+- [MT CloudNative Toolkits > 1.9.0](https://docs.mthreads.com/cloud-native/cloud-native-doc-online/)
+- driver version >= 1.2.0
 
 ## Enabling GPU-sharing Support
 
-* Deploy MT-CloudNative Toolkit on mthreads nodes (Please consult your device provider to acquire its package and document)
+- Deploy MT-CloudNative Toolkit on mthreads nodes (Please consult your device provider to acquire its package and document)
 
 :::note
 
@@ -37,7 +37,7 @@ You can remove mt-mutating-webhook and mt-gpu-scheduler after installation(optio
 
 :::
 
-* set the 'devices.mthreads.enabled = true' when installing hami
+- set the 'devices.mthreads.enabled = true' when installing hami
 
 ```
 helm install hami hami-charts/hami --set scheduler.kubeScheduler.imageTag={your kubernetes version} --set device.mthreads.enabled=true -n kube-system

--- a/versioned_docs/version-v2.7.0/contributor/governance.md
+++ b/versioned_docs/version-v2.7.0/contributor/governance.md
@@ -8,21 +8,21 @@ Heterogeneous AI Computing Virtualization Middleware (HAMi), formerly known as k
 
 The HAMi and its leadership embrace the following values:
 
-* Openness: Communication and decision-making happens in the open and is discoverable for future
+- Openness: Communication and decision-making happens in the open and is discoverable for future
   reference. As much as possible, all discussions and work take place in public
   forums and open repositories.
 
-* Fairness: All stakeholders have the opportunity to provide feedback and submit
+- Fairness: All stakeholders have the opportunity to provide feedback and submit
   contributions, which will be considered on their merits.
 
-* Community over Product or Company: Sustaining and growing the community takes
+- Community over Product or Company: Sustaining and growing the community takes
   priority over shipping code or sponsors' organizational goals. Each
   contributor participates in the project as an individual.
 
-* Inclusivity: Innovation comes from different perspectives and skill sets, and this
+- Inclusivity: Innovation comes from different perspectives and skill sets, and this
   can only be accomplished in a welcoming and respectful environment.
 
-* Participation: Responsibilities within the project are earned through
+- Participation: Responsibilities within the project are earned through
   participation, and there is a clear path up the contributor ladder into leadership
   positions.
 

--- a/versioned_docs/version-v2.7.0/contributor/ladder.md
+++ b/versioned_docs/version-v2.7.0/contributor/ladder.md
@@ -14,38 +14,38 @@ Each of the contributor roles below is organized into lists of three types of th
 
 Description: A Community Participant engages with the project and its community, contributing their time, thoughts, etc. Community participants are usually users who have stopped being anonymous and started being active in project discussions.
 
-* Responsibilities:
-  * Must follow the [CNCF CoC](https://github.com/cncf/foundation/blob/main/code-of-conduct.md)
-* How users can get involved with the community:
-  * Participating in community discussions
-  * Helping other users
-  * Submitting bug reports
-  * Commenting on issues
-  * Trying out new releases
-  * Attending community events
+- Responsibilities:
+  - Must follow the [CNCF CoC](https://github.com/cncf/foundation/blob/main/code-of-conduct.md)
+- How users can get involved with the community:
+  - Participating in community discussions
+  - Helping other users
+  - Submitting bug reports
+  - Commenting on issues
+  - Trying out new releases
+  - Attending community events
 
 ## Contributor
 
 Description: A Contributor contributes directly to the project and adds value to it. Contributions need not be code. People at the Contributor level may be new contributors, or they may only contribute occasionally.
 
-* Responsibilities include:
-  * Follow the CNCF CoC
-  * Follow the project contributing guide
-* Requirements (one or several of the below):
-  * Report and sometimes resolve issues
-  * Occasionally submit PRs
-  * Contribute to the documentation
-  * Show up at meetings, takes notes
-  * Answer questions from other community members
-  * Submit feedback on issues and PRs
-  * Test releases and patches and submit reviews
-  * Run or helps run events
-  * Promote the project in public
-  * Help run the project infrastructure
-  * [TODO: other small contributions]
-* Privileges:
-  * Invitations to contributor events
-  * Eligible to become an Organization Member
+- Responsibilities include:
+  - Follow the CNCF CoC
+  - Follow the project contributing guide
+- Requirements (one or several of the below):
+  - Report and sometimes resolve issues
+  - Occasionally submit PRs
+  - Contribute to the documentation
+  - Show up at meetings, takes notes
+  - Answer questions from other community members
+  - Submit feedback on issues and PRs
+  - Test releases and patches and submit reviews
+  - Run or helps run events
+  - Promote the project in public
+  - Help run the project infrastructure
+  - [TODO: other small contributions]
+- Privileges:
+  - Invitations to contributor events
+  - Eligible to become an Organization Member
 
 A very special thanks to the [long list of people](https://github.com/Project-HAMi/HAMi/blob/master/AUTHORS.md) who have contributed to and helped maintain the project. Thanks to everyone who contributed and helped maintain the project.
 
@@ -57,31 +57,31 @@ Description: An Organization Member is an established contributor who regularly 
 
 An Organization Member must meet the responsibilities and has the requirements of a Contributor, plus:
 
-* Responsibilities include:
-  * Continues to contribute regularly, as demonstrated by having at least 50 GitHub contributions per year
-* Requirements:
-  * Enabled [two-factor authentication] on their GitHub account
-  * Must have successful contributions to the project or community, including at least one of the following:
-    * 5 accepted PRs,
-    * Reviewed 5 PRs,
-    * Resolved and closed 3 Issues,
-    * Become responsible for a key project management area,
-    * Or some equivalent combination or contribution
-  * Must have been contributing for at least 1 months
-  * Must be actively contributing to at least one project area
-  * Must have two sponsors who are also Organization Members, at least one of whom does not work for the same employer
-  * **[Open an issue][membership request] against the Project-HAMi/HAMi repo**
-    * Ensure your sponsors are @mentioned on the issue
-    * Complete every item on the issue checklist
-    * Make sure that the list of contributions included is representative of your work on the project.
-  * Have your sponsoring reviewers reply confirmation of sponsorship: `+1`
-  * Once your sponsors have responded, your request will be handled by the `HAMi GitHub Admin team`.
+- Responsibilities include:
+  - Continues to contribute regularly, as demonstrated by having at least 50 GitHub contributions per year
+- Requirements:
+  - Enabled [two-factor authentication] on their GitHub account
+  - Must have successful contributions to the project or community, including at least one of the following:
+    - 5 accepted PRs,
+    - Reviewed 5 PRs,
+    - Resolved and closed 3 Issues,
+    - Become responsible for a key project management area,
+    - Or some equivalent combination or contribution
+  - Must have been contributing for at least 1 months
+  - Must be actively contributing to at least one project area
+  - Must have two sponsors who are also Organization Members, at least one of whom does not work for the same employer
+  - **[Open an issue][membership request] against the Project-HAMi/HAMi repo**
+    - Ensure your sponsors are @mentioned on the issue
+    - Complete every item on the issue checklist
+    - Make sure that the list of contributions included is representative of your work on the project.
+  - Have your sponsoring reviewers reply confirmation of sponsorship: `+1`
+  - Once your sponsors have responded, your request will be handled by the `HAMi GitHub Admin team`.
 
-* Privileges:
-  * May be assigned Issues and Reviews
-  * May give commands to CI/CD automation
-  * Can be added to [TODO: Repo Host] teams
-  * Can recommend other contributors to become Org Members
+- Privileges:
+  - May be assigned Issues and Reviews
+  - May give commands to CI/CD automation
+  - Can be added to [TODO: Repo Host] teams
+  - Can recommend other contributors to become Org Members
 
 The process for a Contributor to become an Organization Member is as follows:
 
@@ -96,22 +96,22 @@ Reviewers are responsible for a "specific area." This can be a specific code dir
 
 Reviewers have all the rights and responsibilities of an Organization Member, plus:
 
-* Responsibilities include:
-  * Following the reviewing guide
-  * Reviewing most Pull Requests against their specific areas of responsibility
-  * Reviewing at least 20 PRs per year
-  * Helping other contributors become reviewers
-* Requirements:
-  * Experience as a Contributor for at least 3 months
-  * Is an Organization Member
-  * Has reviewed, or helped review, at least 10 Pull Requests
-  * Has analyzed and resolved test failures in their specific area
-  * Has demonstrated an in-depth knowledge of the specific area
-  * Commits to being responsible for that specific area
-  * Is supportive of new and occasional contributors and helps get useful PRs in shape to commit
-* Additional privileges:
-  * Has GitHub or CI/CD rights to approve pull requests in specific directories
-  * Can recommend and review other contributors to become Reviewers
+- Responsibilities include:
+  - Following the reviewing guide
+  - Reviewing most Pull Requests against their specific areas of responsibility
+  - Reviewing at least 20 PRs per year
+  - Helping other contributors become reviewers
+- Requirements:
+  - Experience as a Contributor for at least 3 months
+  - Is an Organization Member
+  - Has reviewed, or helped review, at least 10 Pull Requests
+  - Has analyzed and resolved test failures in their specific area
+  - Has demonstrated an in-depth knowledge of the specific area
+  - Commits to being responsible for that specific area
+  - Is supportive of new and occasional contributors and helps get useful PRs in shape to commit
+- Additional privileges:
+  - Has GitHub or CI/CD rights to approve pull requests in specific directories
+  - Can recommend and review other contributors to become Reviewers
 
 The process of becoming a Reviewer is:
 
@@ -128,15 +128,15 @@ The current list of maintainers can be found in the [MAINTAINERS](https://github
 
 ## An active maintainer should
 
-* Actively participate in reviewing pull requests and incoming issues. There are no hard rules on what is “active enough” and this is left up to the judgement of the current group of maintainers.
+- Actively participate in reviewing pull requests and incoming issues. There are no hard rules on what is “active enough” and this is left up to the judgement of the current group of maintainers.
 
-* Actively participate in discussions about design and the future of the project.
+- Actively participate in discussions about design and the future of the project.
 
-* Take responsibility for backports to appropriate branches for PRs they approve and merge.
+- Take responsibility for backports to appropriate branches for PRs they approve and merge.
 
-* Do their best to follow all code, testing, and design conventions as determined by consensus among active maintainers.
+- Do their best to follow all code, testing, and design conventions as determined by consensus among active maintainers.
 
-* Gracefully step down from their maintainership role when they are no longer planning to actively participate in the project.
+- Gracefully step down from their maintainership role when they are no longer planning to actively participate in the project.
 
 ## How to be a maintainer
 
@@ -152,12 +152,12 @@ It is normal for maintainers to come and go based on their other responsibilitie
 
 It is important for contributors to be and stay active to set an example and show commitment to the project. Inactivity is harmful to the project as it may lead to unexpected delays, contributor attrition, and a lost of trust in the project.
 
-* Inactivity is measured by:
-  * Periods of no contributions for longer than 3 months
-  * Periods of no communication for longer than 3 months
-* Consequences of being inactive include:
-  * Involuntary removal or demotion
-  * Being asked to move to Emeritus status
+- Inactivity is measured by:
+  - Periods of no contributions for longer than 3 months
+  - Periods of no communication for longer than 3 months
+- Consequences of being inactive include:
+  - Involuntary removal or demotion
+  - Being asked to move to Emeritus status
 
 ## Involuntary Removal or Demotion
 

--- a/versioned_docs/version-v2.7.0/releases.md
+++ b/versioned_docs/version-v2.7.0/releases.md
@@ -26,14 +26,14 @@ Minor releases contain features, enhancements, and fixes that are introduced in 
 Since HAMi is a fast growing project and features continue to iterate rapidly,
 having a minor release approximately every few months helps balance speed and stability.
 
-* Roughly every 3 months
+- Roughly every 3 months
 
 ### PATCH release
 
 Patch releases are for backwards-compatible bug fixes and very minor enhancements which do not impact stability or compatibility.
 Typically only critical fixes are selected for patch releases. Usually there will be at least one patch release in a minor release cycle.
 
-* When critical fixes are required, or roughly each month
+- When critical fixes are required, or roughly each month
 
 ### Versioning
 
@@ -53,17 +53,17 @@ Critical issues, with no work-arounds, are added to the next patch release.
 
 Release branches and PRs are managed as follows:
 
-* All changes are always first committed to `master`.
-* Branches are created for each major or minor release.
-* The branch name will contain the version, for example release-1.2.
-* Patch releases are created from a release branch.
-* For critical fixes that need to be included in a patch release, PRs should always be first merged to master
+- All changes are always first committed to `master`.
+- Branches are created for each major or minor release.
+- The branch name will contain the version, for example release-1.2.
+- Patch releases are created from a release branch.
+- For critical fixes that need to be included in a patch release, PRs should always be first merged to master
   and then cherry-picked to the release branch. PRs need to be guaranteed to have a release note written and
   these descriptions will be reflected in the next patch release.
   The cherry-pick process of PRs is executed through the script. See usage [here](https://project-hami.io/docs/contributor/cherry-picks).
-* For complex changes, specially critical bugfixes, separate PRs may be required for master and release branches.
-* The milestone mark (for example v1.4) will be added to PRs which means changes in PRs are one of the contents of the corresponding release.
-* During PR review, the Assignee selection is used to indicate the reviewer.
+- For complex changes, specially critical bugfixes, separate PRs may be required for master and release branches.
+- The milestone mark (for example v1.4) will be added to PRs which means changes in PRs are one of the contents of the corresponding release.
+- During PR review, the Assignee selection is used to indicate the reviewer.
 
 ### Release Planning
 
@@ -85,26 +85,26 @@ For example, [here](https://hub.docker.com/r/karmada/karmada-controller-manager)
 
 Since v1.2.0, the following artifacts are uploaded:
 
-* crds.tar.gz
-* karmada-chart-v\<version_number\>.tgz
-* karmadactl-darwin-amd64.tgz
-* karmadactl-darwin-amd64.tgz.sha256
-* karmadactl-darwin-arm64.tgz
-* karmadactl-darwin-arm64.tgz.sha256
-* karmadactl-linux-amd64.tgz
-* karmadactl-linux-amd64.tgz.sha256
-* karmadactl-linux-arm64.tgz
-* karmadactl-linux-arm64.tgz.sha256
-* kubectl-karmada-darwin-amd64.tgz
-* kubectl-karmada-darwin-amd64.tgz.sha256
-* kubectl-karmada-darwin-arm64.tgz
-* kubectl-karmada-darwin-arm64.tgz.sha256
-* kubectl-karmada-linux-amd64.tgz
-* kubectl-karmada-linux-amd64.tgz.sha256
-* kubectl-karmada-linux-arm64.tgz
-* kubectl-karmada-linux-arm64.tgz.sha256
-* Source code(zip)
-* Source code(tar.gz)
+- crds.tar.gz
+- karmada-chart-v\<version_number\>.tgz
+- karmadactl-darwin-amd64.tgz
+- karmadactl-darwin-amd64.tgz.sha256
+- karmadactl-darwin-arm64.tgz
+- karmadactl-darwin-arm64.tgz.sha256
+- karmadactl-linux-amd64.tgz
+- karmadactl-linux-amd64.tgz.sha256
+- karmadactl-linux-arm64.tgz
+- karmadactl-linux-arm64.tgz.sha256
+- kubectl-karmada-darwin-amd64.tgz
+- kubectl-karmada-darwin-amd64.tgz.sha256
+- kubectl-karmada-darwin-arm64.tgz
+- kubectl-karmada-darwin-arm64.tgz.sha256
+- kubectl-karmada-linux-amd64.tgz
+- kubectl-karmada-linux-amd64.tgz.sha256
+- kubectl-karmada-linux-arm64.tgz
+- kubectl-karmada-linux-arm64.tgz.sha256
+- Source code(zip)
+- Source code(tar.gz)
 
 You can visit `https://github.com/Project-HAMi/HAMi/releases/download/v<version_number>/<artifact_name>` to download the artifacts above.
 

--- a/versioned_docs/version-v2.7.0/userguide/ascend-device/enable-ascend-sharing.md
+++ b/versioned_docs/version-v2.7.0/userguide/ascend-device/enable-ascend-sharing.md
@@ -6,13 +6,13 @@ Memory slicing is supported based on virtualization template, lease available te
 
 ## Prerequisites
 
-* Ascend device type: 910B, 910A, 310P
-* driver version >= 24.1.rc1
-* Ascend docker runtime
+- Ascend device type: 910B, 910A, 310P
+- driver version >= 24.1.rc1
+- Ascend docker runtime
 
 ## Enabling Ascend-sharing support
 
-* Due to dependencies with HAMi, you need to set the arguments in the process of installing HAMi:
+- Due to dependencies with HAMi, you need to set the arguments in the process of installing HAMi:
 
   ```
   devices.ascend.enabled=true
@@ -39,15 +39,15 @@ Memory slicing is supported based on virtualization template, lease available te
         - huawei.com/Ascend310P-memory
   ```
 
-* Tag Ascend node with the following command
+- Tag Ascend node with the following command
 
   ```bash
   kubectl label node {ascend-node} ascend=on
   ```
 
-* Install [Ascend docker runtime](https://gitee.com/ascend/ascend-docker-runtime)
+- Install [Ascend docker runtime](https://gitee.com/ascend/ascend-docker-runtime)
 
-* [Download YAML for Ascend-vgpu-device-plugin](https://github.com/Project-HAMi/ascend-device-plugin/blob/master/build/ascendplugin-hami.yaml) from HAMi Project, and run the following commands to deploy
+- [Download YAML for Ascend-vgpu-device-plugin](https://github.com/Project-HAMi/ascend-device-plugin/blob/master/build/ascendplugin-hami.yaml) from HAMi Project, and run the following commands to deploy
 
   ```bash
   wge https://raw.githubusercontent.com/Project-HAMi/ascend-device-plugin/refs/heads/main/ascend-device-plugin.yaml

--- a/versioned_docs/version-v2.7.0/userguide/awsneuron-device/enable-awsneuron-managing.md
+++ b/versioned_docs/version-v2.7.0/userguide/awsneuron-device/enable-awsneuron-managing.md
@@ -8,21 +8,21 @@ AWS Neuron devices are specialized hardware accelerators designed by AWS to opti
 
 HAMi now integrates with [Neuron scheduler extension](https://awsdocs-neuron.readthedocs-hosted.com/en/latest/containers/kubernetes-getting-started.html#deploy-neuron-scheduler-extension), providing the following capabilities:
 
-* **Neuron sharing**: HAMi now supports sharing on aws.amazon.com/neuron by allocating device cores(aws.amazon.com/neuroncore), each Neuron core equals to 1/2 neuron device.
+- **Neuron sharing**: HAMi now supports sharing on aws.amazon.com/neuron by allocating device cores(aws.amazon.com/neuroncore), each Neuron core equals to 1/2 neuron device.
 
-* **Topology awareness**: When allocating multiple aws-neuron devices in a container, HAMi will make sure these devices are connected with one another, so to minimize the communication cost between neuron devices. For details about how these devices are connected, refer to [Container Device Allocation On Different Instance Types](https://awsdocs-neuron.readthedocs-hosted.com/en/latest/containers/kubernetes-getting-started.html#container-device-allocation-on-different-instance-types).
+- **Topology awareness**: When allocating multiple aws-neuron devices in a container, HAMi will make sure these devices are connected with one another, so to minimize the communication cost between neuron devices. For details about how these devices are connected, refer to [Container Device Allocation On Different Instance Types](https://awsdocs-neuron.readthedocs-hosted.com/en/latest/containers/kubernetes-getting-started.html#container-device-allocation-on-different-instance-types).
 
 
 ## Prerequisites
 
-* Neuron-device-plugin
-* EC2 instance of type `Inf` or `Trn`
+- Neuron-device-plugin
+- EC2 instance of type `Inf` or `Trn`
 
 ## Enabling GCU-sharing Support
 
-* Deploy neuron-device-plugin on EC2 neuron nodes according to document the AWS document: [Neuro Device Plugin](https://awsdocs-neuron.readthedocs-hosted.com/en/latest/containers/kubernetes-getting-started.html#neuron-device-plugin)
+- Deploy neuron-device-plugin on EC2 neuron nodes according to document the AWS document: [Neuro Device Plugin](https://awsdocs-neuron.readthedocs-hosted.com/en/latest/containers/kubernetes-getting-started.html#neuron-device-plugin)
 
-* Deploy HAMi
+- Deploy HAMi
 
 ```
 helm install hami hami-charts/hami -n kube-system

--- a/versioned_docs/version-v2.7.0/userguide/cambricon-device/enable-cambricon-mlu-sharing.md
+++ b/versioned_docs/version-v2.7.0/userguide/cambricon-device/enable-cambricon-mlu-sharing.md
@@ -4,22 +4,22 @@ title: Enable Cambricon MLU Sharing
 
 **HAMi now supports `cambricon.com/mlu` by implementing most device-sharing features similar to NVIDIA GPUs**, including:
 
-* **MLU Sharing**: Tasks can request a fraction of an MLU instead of an entire MLU card.
+- **MLU Sharing**: Tasks can request a fraction of an MLU instead of an entire MLU card.
   This enables multiple tasks to share the same MLU device.
 
-* **Device Memory Control**: You can allocate MLUs with a specified memory size, with
+- **Device Memory Control**: You can allocate MLUs with a specified memory size, with
   guaranteed enforcement to ensure usage does not exceed the requested limit.
 
-* **Device Core Control**: MLUs can be assigned a specific number of compute cores,
+- **Device Core Control**: MLUs can be assigned a specific number of compute cores,
   and enforcement ensures core usage remains within bounds.
 
-* **MLU Type Selection**: You can use annotations to specify which MLU types a task *must use* or
+- **MLU Type Selection**: You can use annotations to specify which MLU types a task *must use* or
   *must avoid* by setting `cambricon.com/use-mlutype` or `cambricon.com/nouse-mlutype`.
 
 ## Prerequisites
 
-* neuware-mlu370-driver > 5.10
-* cntoolkit > 2.5.3
+- neuware-mlu370-driver > 5.10
+- cntoolkit > 2.5.3
 
 ## Enabling MLU Sharing
 
@@ -40,8 +40,8 @@ title: Enable Cambricon MLU Sharing
 
    Get the `cambricon-device-plugin` from your device provider, and configure it with the following parameters:
 
-   * `mode=dynamic-smlu`: Enables dynamic SMLU support.
-   * `min-dsmlu-unit=256`: Sets the minimum allocatable memory unit to 256 MB.
+   - `mode=dynamic-smlu`: Enables dynamic SMLU support.
+   - `min-dsmlu-unit=256`: Sets the minimum allocatable memory unit to 256 MB.
 
    Refer to your provider’s documentation for additional details.
 
@@ -55,9 +55,9 @@ title: Enable Cambricon MLU Sharing
 
 To request shared MLU resources in a container, use the following resource types:
 
-* `cambricon.com/vmlu`
-* `cambricon.com/mlu.smlu.vmemory`
-* `cambricon.com/mlu.smlu.vcore`
+- `cambricon.com/vmlu`
+- `cambricon.com/mlu.smlu.vmemory`
+- `cambricon.com/mlu.smlu.vcore`
 
 Here is an YAML example:
 

--- a/versioned_docs/version-v2.7.0/userguide/configure.md
+++ b/versioned_docs/version-v2.7.0/userguide/configure.md
@@ -45,15 +45,15 @@ HAMi allows configuring per-node behavior for device plugin. Edit
 ```sh
 kubectl -n <namespace> edit cm hami-device-plugin
 ```
-* `name`: Name of the node.
-* `operatingmode`: Operating mode of the node, can be "hami-core" or "mig", default: "hami-core".
-* `devicememoryscaling`: Overcommit ratio of device memory.
-* `devicecorescaling`: Overcommit ratio of device core.
-* `devicesplitcount`: Allowed number of tasks sharing a device.
-* `filterdevices`: Devices that are not registered to HAMi.
-  * `uuid`: UUIDs of devices to ignore
-  * `index`: Indexes of devices to ignore.
-  * A device is ignored by HAMi if it's in `uuid` or `index` list.
+- `name`: Name of the node.
+- `operatingmode`: Operating mode of the node, can be "hami-core" or "mig", default: "hami-core".
+- `devicememoryscaling`: Overcommit ratio of device memory.
+- `devicecorescaling`: Overcommit ratio of device core.
+- `devicesplitcount`: Allowed number of tasks sharing a device.
+- `filterdevices`: Devices that are not registered to HAMi.
+  - `uuid`: UUIDs of devices to ignore
+  - `index`: Indexes of devices to ignore.
+  - A device is ignored by HAMi if it's in `uuid` or `index` list.
 
 ## Chart Configs: arguments
 

--- a/versioned_docs/version-v2.7.0/userguide/enflame-device/enable-enflame-gcu-sharing.md
+++ b/versioned_docs/version-v2.7.0/userguide/enflame-device/enable-enflame-gcu-sharing.md
@@ -17,14 +17,14 @@ title: Enable Enflame GCU Sharing
 
 ## Prerequisites
 
-* Enflame gcushare-device-plugin >= 2.1.6 (please consult your device provider, gcushare has two components: gcushare-scheduler-plugin and gcushare-device-plugin, only gcushare-device-plugin is needed here )
-* driver version >= 1.2.3.14
-* kubernetes >= 1.24
-* enflame-container-toolkit >=2.0.50
+- Enflame gcushare-device-plugin >= 2.1.6 (please consult your device provider, gcushare has two components: gcushare-scheduler-plugin and gcushare-device-plugin, only gcushare-device-plugin is needed here )
+- driver version >= 1.2.3.14
+- kubernetes >= 1.24
+- enflame-container-toolkit >=2.0.50
 
 ## Enabling GCU-sharing Support
 
-* Deploy gcushare-device-plugin on enflame nodes (Please consult your device provider to acquire its package and document)
+- Deploy gcushare-device-plugin on enflame nodes (Please consult your device provider to acquire its package and document)
 
 :::note
 
@@ -42,7 +42,7 @@ You can customize these names by modifying `hami-scheduler-device` configMap abo
 
 :::
 
-* Set 'devices.enflame.enabled=true' when deploy HAMi
+- Set 'devices.enflame.enabled=true' when deploy HAMi
 
 ```
 helm install hami hami-charts/hami --set devices.enflame.enabled=true -n kube-system

--- a/versioned_docs/version-v2.7.0/userguide/hygon-device/enable-hygon-dcu-sharing.md
+++ b/versioned_docs/version-v2.7.0/userguide/hygon-device/enable-hygon-dcu-sharing.md
@@ -16,12 +16,12 @@ title: Enable Hygon DCU sharing
 
 ## Prerequisites
 
-* dtk driver >= 24.04
-* hy-smi v1.6.0
+- dtk driver >= 24.04
+- hy-smi v1.6.0
 
 ## Enabling DCU-sharing Support
 
-* Deploy the dcu-vgpu-device-plugin [here](https://github.com/Project-HAMi/dcu-vgpu-device-plugin)
+- Deploy the dcu-vgpu-device-plugin [here](https://github.com/Project-HAMi/dcu-vgpu-device-plugin)
 
 
 ## Running DCU jobs

--- a/versioned_docs/version-v2.7.0/userguide/iluvatar-device/enable-illuvatar-gpu-sharing.md
+++ b/versioned_docs/version-v2.7.0/userguide/iluvatar-device/enable-illuvatar-gpu-sharing.md
@@ -19,12 +19,12 @@ title: Enable Illuvatar GPU Sharing
 
 ## Prerequisites
 
-* Iluvatar gpu-manager (please consult your device provider)
-* driver version > 3.1.0
+- Iluvatar gpu-manager (please consult your device provider)
+- driver version > 3.1.0
 
 ## Enabling GPU-sharing Support
 
-* Deploy gpu-manager on iluvatar nodes (Please consult your device provider to acquire its package and document)
+- Deploy gpu-manager on iluvatar nodes (Please consult your device provider to acquire its package and document)
 
 :::note
 
@@ -32,9 +32,9 @@ Install only gpu-manager, don't install gpu-admission package.
 
 :::
 
-* Identify the resource name about core and memory usage(i.e 'iluvatar.ai/vcuda-core', 'iluvatar.ai/vcuda-memory')
+- Identify the resource name about core and memory usage(i.e 'iluvatar.ai/vcuda-core', 'iluvatar.ai/vcuda-memory')
 
-* set the 'iluvatarResourceMem' and 'iluvatarResourceCore' parameters when install hami
+- set the 'iluvatarResourceMem' and 'iluvatarResourceCore' parameters when install hami
 
 ```
 helm install hami hami-charts/hami --set scheduler.kubeScheduler.imageTag={your kubernetes version} --set iluvatarResourceMem=iluvatar.ai/vcuda-memory --set iluvatarResourceCore=iluvatar.ai/vcuda-core -n kube-system

--- a/versioned_docs/version-v2.7.0/userguide/kunlunxin-device/enable-kunlunxin-schedule.md
+++ b/versioned_docs/version-v2.7.0/userguide/kunlunxin-device/enable-kunlunxin-schedule.md
@@ -26,15 +26,15 @@ of the requested resources on the selected node, following these rules:
 
 ## Prerequisites
 
-* Kunlunxin driver >= v5.0.21
-* Kubernetes >= v1.23
-* kunlunxin k8s-device-plugin
+- Kunlunxin driver >= v5.0.21
+- Kubernetes >= v1.23
+- kunlunxin k8s-device-plugin
 
 ## Enabling Topology-Aware Scheduling
 
-* Deploy the Kunlunxin device plugin on P800 nodes.
+- Deploy the Kunlunxin device plugin on P800 nodes.
   (Please contact your device vendor to obtain the appropriate package and documentation.)  
-* Deploy HAMi according to the instructions in `README.md`.
+- Deploy HAMi according to the instructions in `README.md`.
 
 ## Running Kunlunxin Jobs
 

--- a/versioned_docs/version-v2.7.0/userguide/kunlunxin-device/enable-kunlunxin-vxpu.md
+++ b/versioned_docs/version-v2.7.0/userguide/kunlunxin-device/enable-kunlunxin-vxpu.md
@@ -14,13 +14,13 @@ This component supports multiplexing Kunlunxin XPU devices (P800-OAM) and provid
 
 
 ## Prerequisites
-* driver version >= 5.0.21.16
-* xpu-container-toolkit >= xpu_container_1.0.2-1
-* XPU device type: P800-OAM
+- driver version >= 5.0.21.16
+- xpu-container-toolkit >= xpu_container_1.0.2-1
+- XPU device type: P800-OAM
 
 ## Enable XPU-sharing Support
 
-* Deploy [vxpu-device-plugin]
+- Deploy [vxpu-device-plugin]
 ```yaml
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole

--- a/versioned_docs/version-v2.7.0/userguide/mthreads-device/enable-mthreads-gpu-sharing.md
+++ b/versioned_docs/version-v2.7.0/userguide/mthreads-device/enable-mthreads-gpu-sharing.md
@@ -24,12 +24,12 @@ title: Enable Mthreads GPU sharing
 
 ## Prerequisites
 
-* [MT CloudNative Toolkits > 1.9.0](https://docs.mthreads.com/cloud-native/cloud-native-doc-online/)
-* driver version >= 1.2.0
+- [MT CloudNative Toolkits > 1.9.0](https://docs.mthreads.com/cloud-native/cloud-native-doc-online/)
+- driver version >= 1.2.0
 
 ## Enabling GPU-sharing Support
 
-* Deploy MT-CloudNative Toolkit on mthreads nodes (Please consult your device provider to acquire its package and document)
+- Deploy MT-CloudNative Toolkit on mthreads nodes (Please consult your device provider to acquire its package and document)
 
 :::note
 
@@ -37,7 +37,7 @@ You can remove mt-mutating-webhook and mt-gpu-scheduler after installation(optio
 
 :::
 
-* set the 'devices.mthreads.enabled = true' when installing hami
+- set the 'devices.mthreads.enabled = true' when installing hami
 
 ```
 helm install hami hami-charts/hami --set scheduler.kubeScheduler.imageTag={your kubernetes version} --set device.mthreads.enabled=true -n kube-system

--- a/versioned_docs/version-v2.8.0/userguide/iluvatar-device/enable-illuvatar-gpu-sharing.md
+++ b/versioned_docs/version-v2.8.0/userguide/iluvatar-device/enable-illuvatar-gpu-sharing.md
@@ -18,12 +18,12 @@ title: Enable Illuvatar GPU Sharing
 
 ## Prerequisites
 
-* Iluvatar gpu-manager (please consult your device provider)
-* driver version > 3.1.0
+- Iluvatar gpu-manager (please consult your device provider)
+- driver version > 3.1.0
 
 ## Enabling GPU-sharing Support
 
-* Deploy gpu-manager on iluvatar nodes (Please consult your device provider to acquire its package and document)
+- Deploy gpu-manager on iluvatar nodes (Please consult your device provider to acquire its package and document)
 
 :::note
 
@@ -31,7 +31,7 @@ Install only gpu-manager, don't install gpu-admission package.
 
 :::
 
-* set the devices.iluvatar.enabled=true when install hami
+- set the devices.iluvatar.enabled=true when install hami
 
 ```bash
 helm install hami hami-charts/hami --set scheduler.kubeScheduler.imageTag={your kubernetes version} --set devices.iluvatar.enabled=true

--- a/versioned_docs/version-v2.8.0/userguide/nvidia-device/dynamic-resource-allocation.md
+++ b/versioned_docs/version-v2.8.0/userguide/nvidia-device/dynamic-resource-allocation.md
@@ -10,7 +10,7 @@ By installing hami-k8s-dra-driver, your cluster scheduler can discover NVIDIA GP
 
 ## Prerequisites
 
-* The underlying container runtime (e.g., containerd or CRI-O) has [CDI](https://github.com/cncf-tags/container-device-interface?tab=readme-ov-file#how-to-configure-cdi) enabled
+- The underlying container runtime (e.g., containerd or CRI-O) has [CDI](https://github.com/cncf-tags/container-device-interface?tab=readme-ov-file#how-to-configure-cdi) enabled
 
 ## Installation
 


### PR DESCRIPTION
Replace all 1,278 asterisk (`* item`) list bullets with hyphens (`- item`) across all versioned documentation (v1.3.0, v2.4.1, v2.5.0, v2.5.1, v2.6.0, v2.7.0, v2.8.0). Mirrors the same change already applied to active docs in PR #348.