### PR TITLE
fix: convert blockquote Note markers to admonitions in versioned docs

### DIFF
--- a/versioned_docs/version-v2.8.0/installation/how-to-use-hami-dra.md
+++ b/versioned_docs/version-v2.8.0/installation/how-to-use-hami-dra.md
@@ -28,7 +28,11 @@ Then install with the following command:
 helm install hami hami-charts/hami --set dra.enable=true -n hami-system
 ```
 
-> **NOTICE:** *DRA mode is not compatible with traditional mode. Do not enable both at the same time.*
+:::note
+
+DRA mode is not compatible with traditional mode. Do not enable both at the same time.
+
+:::
 
 ## Supported Devices
 

--- a/versioned_docs/version-v2.8.0/userguide/iluvatar-device/examples/allocate-exclusive-bi-v150.md
+++ b/versioned_docs/version-v2.8.0/userguide/iluvatar-device/examples/allocate-exclusive-bi-v150.md
@@ -32,4 +32,8 @@ spec:
         iluvatar.ai/BI-V150-vgpu: 2
 ```
 
-> **NOTICE:** *When applying for exclusive use of a GPU, `iluvatar.ai/<card-type>-vgpu=1`, you need to set the values of `iluvatar.ai/<card-type>.vCore` and `iluvatar.ai/<card-type>.vMem` to the maximum number of GPU resources. `iluvatar.ai/<card-type>-vgpu>1` no longer supports the vGPU function, so you don't need to fill in the core and memory values*
+:::note
+
+When applying for exclusive use of a GPU, `iluvatar.ai/<card-type>-vgpu=1`, you need to set the values of `iluvatar.ai/<card-type>.vCore` and `iluvatar.ai/<card-type>.vMem` to the maximum number of GPU resources. `iluvatar.ai/<card-type>-vgpu>1` no longer supports the vGPU function, so you don't need to fill in the core and memory values
+
+:::

--- a/versioned_docs/version-v2.8.0/userguide/iluvatar-device/examples/allocate-exclusive-mr-v100.md
+++ b/versioned_docs/version-v2.8.0/userguide/iluvatar-device/examples/allocate-exclusive-mr-v100.md
@@ -32,4 +32,8 @@ spec:
         iluvatar.ai/MR-V100-vgpu: 2
 ```
 
-> **NOTICE:** *When applying for exclusive use of a GPU, `iluvatar.ai/<card-type>-vgpu=1`, you need to set the values of `iluvatar.ai/<card-type>.vCore` and `iluvatar.ai/<card-type>.vMem` to the maximum number of GPU resources. `iluvatar.ai/<card-type>-vgpu>1` no longer supports the vGPU function, so you don't need to fill in the core and memory values*
+:::note
+
+When applying for exclusive use of a GPU, `iluvatar.ai/<card-type>-vgpu=1`, you need to set the values of `iluvatar.ai/<card-type>.vCore` and `iluvatar.ai/<card-type>.vMem` to the maximum number of GPU resources. `iluvatar.ai/<card-type>-vgpu>1` no longer supports the vGPU function, so you don't need to fill in the core and memory values
+
+:::

--- a/versioned_docs/version-v2.8.0/userguide/kunlunxin-device/enable-kunlunxin-vxpu.md
+++ b/versioned_docs/version-v2.8.0/userguide/kunlunxin-device/enable-kunlunxin-vxpu.md
@@ -176,7 +176,11 @@ spec:
   # ... rest of Pod configuration
 ```
 
-> **NOTICE:** Device ID format is `{BusID}`. You can find available device IDs in the node status.
+:::note
+
+Device ID format is `{BusID}`. You can find available device IDs in the node status.
+
+:::
 
 ### Finding Device UUIDs
 

--- a/versioned_docs/version-v2.8.0/userguide/monitoring/device-allocation.md
+++ b/versioned_docs/version-v2.8.0/userguide/monitoring/device-allocation.md
@@ -33,4 +33,8 @@ If you are using [HAMi DRA](../../installation/how-to-use-hami-dra), the metrics
 | vGPUDeviceCoreAllocated | vGPU core allocated from a container | `{devicebrand="Tesla",deviceidx="0",devicename="hami-gpu-0",deviceproductname="Tesla P4",deviceuuid="GPU-82be-83fe-3068",nodeid="k8s-node01",podname="pod-0",podnamespace="default"}` 100 |
 | vGPUDeviceMemoryAllocated | vGPU memory allocated from a container | `{devicebrand="Tesla",deviceidx="0",devicename="hami-gpu-0",deviceproductname="Tesla P4",deviceuuid="GPU-82be-83fe-3068",nodeid="k8s-node01",podname="pod-0",podnamespace="default"}` 4000 |
 
-> **NOTICE:** This is the overview of device allocation, it is NOT device real-time usage metrics. For that part, see real-time device usage.
+:::note
+
+This is the overview of device allocation, it is NOT device real-time usage metrics. For that part, see real-time device usage.
+
+:::


### PR DESCRIPTION
Convert 15 informal `> **Note:**` and `> **Note**` blockquotes to Docusaurus `:::note` admonitions across versioned docs (v1.3.0, v2.4.1, v2.5.0, v2.5.1, v2.6.0, v2.7.0, v2.8.0).

Affected files: bash-auto-completion-on-linux.md, device-allocation.md, enable-kunlunxin-vxpu.md, how-to-use-hami-dra.md, and iluvatar examples.