### PR TITLE
fix: correct Enflame GPU to GCU in titles and annotation comments

### DIFF
--- a/docs/userguide/enflame-device/enable-enflame-gcu-sharing.md
+++ b/docs/userguide/enflame-device/enable-enflame-gcu-sharing.md
@@ -1,5 +1,5 @@
 ---
-title: Enable Enflame GPU Sharing
+title: Enable Enflame GCU Sharing
 ---
 
 
@@ -82,7 +82,7 @@ spec:
 
 ## Device UUID Selection
 
-You can specify which GPU devices to use or exclude using annotations:
+You can specify which GCU devices to use or exclude using annotations:
 
 ```yaml
 apiVersion: v1
@@ -90,9 +90,9 @@ kind: Pod
 metadata:
   name: poddemo
   annotations:
-    # Use specific GPU devices (comma-separated list)
+    # Use specific GCU devices (comma-separated list)
     enflame.com/use-gpuuuid: "node1-enflame-0,node1-enflame-1"
-    # Or exclude specific GPU devices (comma-separated list)
+    # Or exclude specific GCU devices (comma-separated list)
     enflame.com/nouse-gpuuuid: "node1-enflame-2,node1-enflame-3"
 spec:
   # ... rest of pod spec

--- a/versioned_docs/version-v2.5.0/userguide/enflame-device/enable-enflame-gpu-sharing.md
+++ b/versioned_docs/version-v2.5.0/userguide/enflame-device/enable-enflame-gpu-sharing.md
@@ -89,9 +89,9 @@ kind: Pod
 metadata:
   name: poddemo
   annotations:
-    # Use specific GPU devices (comma-separated list)
+    # Use specific GCU devices (comma-separated list)
     enflame.com/use-gpuuuid: "node1-enflame-0,node1-enflame-1"
-    # Or exclude specific GPU devices (comma-separated list)
+    # Or exclude specific GCU devices (comma-separated list)
     enflame.com/nouse-gpuuuid: "node1-enflame-2,node1-enflame-3"
 spec:
   # ... rest of pod spec

--- a/versioned_docs/version-v2.6.0/userguide/enflame-device/enable-enflame-gcu-sharing.md
+++ b/versioned_docs/version-v2.6.0/userguide/enflame-device/enable-enflame-gcu-sharing.md
@@ -1,5 +1,5 @@
 ---
-title: Enable Enflame GPU Sharing
+title: Enable Enflame GCU Sharing
 ---
 
 
@@ -82,7 +82,7 @@ spec:
 
 ## Device UUID Selection
 
-You can specify which GPU devices to use or exclude using annotations:
+You can specify which GCU devices to use or exclude using annotations:
 
 ```yaml
 apiVersion: v1
@@ -90,9 +90,9 @@ kind: Pod
 metadata:
   name: poddemo
   annotations:
-    # Use specific GPU devices (comma-separated list)
+    # Use specific GCU devices (comma-separated list)
     enflame.com/use-gpuuuid: "node1-enflame-0,node1-enflame-1"
-    # Or exclude specific GPU devices (comma-separated list)
+    # Or exclude specific GCU devices (comma-separated list)
     enflame.com/nouse-gpuuuid: "node1-enflame-2,node1-enflame-3"
 spec:
   # ... rest of pod spec

--- a/versioned_docs/version-v2.7.0/userguide/enflame-device/enable-enflame-gcu-sharing.md
+++ b/versioned_docs/version-v2.7.0/userguide/enflame-device/enable-enflame-gcu-sharing.md
@@ -1,5 +1,5 @@
 ---
-title: Enable Enflame GPU Sharing
+title: Enable Enflame GCU Sharing
 ---
 
 
@@ -82,7 +82,7 @@ spec:
 
 ## Device UUID Selection
 
-You can specify which GPU devices to use or exclude using annotations:
+You can specify which GCU devices to use or exclude using annotations:
 
 ```yaml
 apiVersion: v1
@@ -90,9 +90,9 @@ kind: Pod
 metadata:
   name: poddemo
   annotations:
-    # Use specific GPU devices (comma-separated list)
+    # Use specific GCU devices (comma-separated list)
     enflame.com/use-gpuuuid: "node1-enflame-0,node1-enflame-1"
-    # Or exclude specific GPU devices (comma-separated list)
+    # Or exclude specific GCU devices (comma-separated list)
     enflame.com/nouse-gpuuuid: "node1-enflame-2,node1-enflame-3"
 spec:
   # ... rest of pod spec


### PR DESCRIPTION
Fix remaining GPU terminology in Enflame documentation that should use GCU.
