### PR TITLE
fix: add proper link to awsneuron examples folder reference

### DIFF
--- a/docs/userguide/awsneuron-device/enable-awsneuron-managing.md
+++ b/docs/userguide/awsneuron-device/enable-awsneuron-managing.md
@@ -43,7 +43,7 @@ HAMi divides each AWS Neuron device into 2 units for resource allocation. You ca
 AWS Neuron devices can now be requested by a container
 by either using `aws.amazon.com/neuron` or `aws.amazon.com/neuroncore` resource type.
 
-More examples can be found in examples folder
+More examples can be found in the [examples/awsneuron folder](https://github.com/Project-HAMi/HAMi/tree/master/examples/awsneuron/).
 
 Allocate a whole device:
 

--- a/versioned_docs/version-v2.7.0/userguide/awsneuron-device/enable-awsneuron-managing.md
+++ b/versioned_docs/version-v2.7.0/userguide/awsneuron-device/enable-awsneuron-managing.md
@@ -44,7 +44,7 @@ HAMi divides each AWS Neuron device into 2 units for resource allocation. You co
 AWS Neuron devices can now be requested by a container
 by either using `aws.amazon.com/neuron` or `aws.amazon.com/neuroncore` resource type.
 
-More examples can be found in examples folder
+More examples can be found in the [examples/awsneuron folder](https://github.com/Project-HAMi/HAMi/tree/master/examples/awsneuron/).
 
 Allocate a whole device:
 ```yaml


### PR DESCRIPTION
Replace vague unlinked \"More examples can be found in examples folder\" with a proper link to the GitHub examples folder in the active docs and versioned docs (v2.7.0, v2.8.0).