### PR TITLE
fix: convert numbered NOTICE markers and fix vague example references in versioned docs

### DIFF
--- a/versioned_docs/version-v1.3.0/userguide/metax-device/enable-metax-gpu-schedule.md
+++ b/versioned_docs/version-v1.3.0/userguide/metax-device/enable-metax-gpu-schedule.md
@@ -39,7 +39,7 @@ Equipped with MetaXLink interconnected resources.
 
 * Deploy Metax GPU Extensions on metax nodes (Please consult your device provider to acquire its package and document)
 
-- Deploy HAMi using the [online installation guide](../../installation/online-installation.md)
+* Deploy HAMi according to README.md
 
 ## Running Metax jobs
 
@@ -65,6 +65,6 @@ spec:
 
 :::note
 
-You can find more examples in examples folder
+You can find more examples in the [examples/metax/gpu folder](https://github.com/Project-HAMi/HAMi/tree/master/examples/metax/gpu)
 
 :::

--- a/versioned_docs/version-v1.3.0/userguide/mthreads-device/enable-mthreads-gpu-sharing.md
+++ b/versioned_docs/version-v1.3.0/userguide/mthreads-device/enable-mthreads-gpu-sharing.md
@@ -31,11 +31,7 @@ title: Enable Mthreads GPU sharing
 
 * Deploy MT-CloudNative Toolkit on mthreads nodes (Please consult your device provider to acquire its package and document)
 
-:::note
-
-You can remove mt-mutating-webhook and mt-gpu-scheduler after installation(optional).
-
-:::
+> **NOTICE:** *You can remove mt-mutating-webhook and mt-gpu-scheduler after installation(optional).*
 
 * set the 'devices.mthreads.enabled = true' when installing hami
 
@@ -76,7 +72,7 @@ Each unit of sgpu-memory indicates 512M device memory
 
 :::note
 
-You can find more examples in examples folder
+You can find more examples in the [examples/mthreads folder](https://github.com/Project-HAMi/HAMi/tree/master/examples/mthreads)
 
 :::
 

--- a/versioned_docs/version-v2.4.1/userguide/metax-device/enable-metax-gpu-schedule.md
+++ b/versioned_docs/version-v2.4.1/userguide/metax-device/enable-metax-gpu-schedule.md
@@ -38,7 +38,7 @@ Equipped with MetaXLink interconnected resources.
 
 * Deploy Metax GPU Extensions on metax nodes (Please consult your device provider to acquire its package and document)
 
-- Deploy HAMi using the online installation guide
+* Deploy HAMi according to README.md
 
 ## Running Metax jobs
 
@@ -64,7 +64,7 @@ spec:
 
 :::note
 
-You can find more examples in examples folder
+You can find more examples in the [examples/metax/gpu folder](https://github.com/Project-HAMi/HAMi/tree/master/examples/metax/gpu)
 
 :::
 

--- a/versioned_docs/version-v2.4.1/userguide/mthreads-device/enable-mthreads-gpu-sharing.md
+++ b/versioned_docs/version-v2.4.1/userguide/mthreads-device/enable-mthreads-gpu-sharing.md
@@ -31,11 +31,7 @@ title: Enable Mthreads GPU sharing
 
 * Deploy MT-CloudNative Toolkit on mthreads nodes (Please consult your device provider to acquire its package and document)
 
-:::note
-
-You can remove mt-mutating-webhook and mt-gpu-scheduler after installation(optional).
-
-:::
+> **NOTICE:** *You can remove mt-mutating-webhook and mt-gpu-scheduler after installation(optional).*
 
 * set the 'devices.mthreads.enabled = true' when installing hami
 
@@ -76,7 +72,7 @@ Each unit of sgpu-memory indicates 512M device memory
 
 :::note
 
-You can find more examples in examples folder
+You can find more examples in the [examples/mthreads folder](https://github.com/Project-HAMi/HAMi/tree/master/examples/mthreads)
 
 :::
 

--- a/versioned_docs/version-v2.5.0/userguide/iluvatar-device/enable-iluvatar-gpu-sharing.md
+++ b/versioned_docs/version-v2.5.0/userguide/iluvatar-device/enable-iluvatar-gpu-sharing.md
@@ -25,11 +25,7 @@ title: Enable Iluvatar GCU sharing
 
 * Deploy gpu-manager on iluvatar nodes (Please consult your device provider to acquire its package and document)
 
-:::note
-
-Install only gpu-manager, don't install gpu-admission package.
-
-:::
+> **NOTICE:** *Install only gpu-manager, don't install gpu-admission package.*
 
 * Identify the resource name about core and memory usage(i.e 'iluvatar.ai/vcuda-core', 'iluvatar.ai/vcuda-memory')
 
@@ -107,7 +103,7 @@ Each unit of vcuda-memory indicates 256M device memory
 
 :::note
 
-You can find more examples in examples folder
+You can find more examples in the [examples/iluvatar folder](https://github.com/Project-HAMi/HAMi/tree/master/examples/iluvatar)
 
 :::
 

--- a/versioned_docs/version-v2.5.0/userguide/metax-device/enable-metax-gpu-schedule.md
+++ b/versioned_docs/version-v2.5.0/userguide/metax-device/enable-metax-gpu-schedule.md
@@ -38,7 +38,7 @@ Equipped with MetaXLink interconnected resources.
 
 * Deploy Metax GPU Extensions on metax nodes (Please consult your device provider to acquire its package and document)
 
-- Deploy HAMi using the [online installation guide](../../installation/online-installation.md)
+* Deploy HAMi according to README.md
 
 ## Running Metax jobs
 
@@ -64,7 +64,7 @@ spec:
 
 :::note
 
-You can find more examples in examples folder
+You can find more examples in the [examples/metax/gpu folder](https://github.com/Project-HAMi/HAMi/tree/master/examples/metax/gpu)
 
 :::
 

--- a/versioned_docs/version-v2.5.0/userguide/mthreads-device/enable-mthreads-gpu-sharing.md
+++ b/versioned_docs/version-v2.5.0/userguide/mthreads-device/enable-mthreads-gpu-sharing.md
@@ -31,11 +31,7 @@ title: Enable Mthreads GPU sharing
 
 * Deploy MT-CloudNative Toolkit on mthreads nodes (Please consult your device provider to acquire its package and document)
 
-:::note
-
-You can remove mt-mutating-webhook and mt-gpu-scheduler after installation(optional).
-
-:::
+> **NOTICE:** *You can remove mt-mutating-webhook and mt-gpu-scheduler after installation(optional).*
 
 * set the 'devices.mthreads.enabled = true' when installing hami
 
@@ -76,7 +72,7 @@ Each unit of sgpu-memory indicates 512M device memory
 
 :::note
 
-You can find more examples in examples folder
+You can find more examples in the [examples/mthreads folder](https://github.com/Project-HAMi/HAMi/tree/master/examples/mthreads)
 
 :::
 

--- a/versioned_docs/version-v2.5.1/userguide/metax-device/enable-metax-gpu-schedule.md
+++ b/versioned_docs/version-v2.5.1/userguide/metax-device/enable-metax-gpu-schedule.md
@@ -38,7 +38,7 @@ Equipped with MetaXLink interconnected resources.
 
 * Deploy Metax GPU Extensions on metax nodes (Please consult your device provider to acquire its package and document)
 
-- Deploy HAMi using the [online installation guide](../../installation/online-installation.md)
+* Deploy HAMi according to README.md
 
 ## Running Metax jobs
 
@@ -64,7 +64,7 @@ spec:
 
 :::note
 
-You can find more examples in examples folder
+You can find more examples in the [examples/metax/gpu folder](https://github.com/Project-HAMi/HAMi/tree/master/examples/metax/gpu)
 
 :::
 

--- a/versioned_docs/version-v2.5.1/userguide/mthreads-device/enable-mthreads-gpu-sharing.md
+++ b/versioned_docs/version-v2.5.1/userguide/mthreads-device/enable-mthreads-gpu-sharing.md
@@ -31,11 +31,7 @@ title: Enable Mthreads GPU sharing
 
 * Deploy MT-CloudNative Toolkit on mthreads nodes (Please consult your device provider to acquire its package and document)
 
-:::note
-
-You can remove mt-mutating-webhook and mt-gpu-scheduler after installation(optional).
-
-:::
+> **NOTICE:** *You can remove mt-mutating-webhook and mt-gpu-scheduler after installation(optional).*
 
 * set the 'devices.mthreads.enabled = true' when installing hami
 
@@ -76,7 +72,7 @@ Each unit of sgpu-memory indicates 512M device memory
 
 :::note
 
-You can find more examples in examples folder
+You can find more examples in the [examples/mthreads folder](https://github.com/Project-HAMi/HAMi/tree/master/examples/mthreads)
 
 :::
 

--- a/versioned_docs/version-v2.8.0/userguide/awsneuron-device/enable-awsneuron-managing.md
+++ b/versioned_docs/version-v2.8.0/userguide/awsneuron-device/enable-awsneuron-managing.md
@@ -43,7 +43,7 @@ HAMi divides each AWS Neuron device into 2 units for resource allocation. You ca
 AWS Neuron devices can now be requested by a container
 by either using `aws.amazon.com/neuron` or `aws.amazon.com/neuroncore` resource type.
 
-More examples can be found in examples folder
+More examples can be found in the [examples/awsneuron folder](https://github.com/Project-HAMi/HAMi/tree/master/examples/awsneuron/).
 
 Allocate a whole device:
 

--- a/versioned_docs/version-v2.8.0/userguide/mthreads-device/enable-mthreads-gpu-sharing.md
+++ b/versioned_docs/version-v2.8.0/userguide/mthreads-device/enable-mthreads-gpu-sharing.md
@@ -8,17 +8,17 @@ title: Enable Mthreads GPU sharing
 
 **GPU sharing**: Each task can allocate a portion of GPU instead of a whole GPU card, thus GPU can be shared among multiple tasks.
 
-**Device Memory Control**: GPUs can be allocated with a specific device memory size on certain types (e.g., MTT S4000), with hard limits enforced to prevent exceeding the allocation.
+**Device Memory Control**: GPUs can be allocated with certain device memory size on certain type(i.e MTT S4000) and have made it that it does not exceed the boundary.
 
-**Device Core Control**: GPUs can be allocated with limited compute cores on certain types (e.g., MTT S4000), with hard limits enforced to prevent exceeding the allocation.
+**Device Core Control**: GPUs can be allocated with limited compute cores on certain type(i.e MTT S4000) and have made it that it does not exceed the boundary.
 
 ## Important Notes
 
 1. Device sharing for multi-cards is not supported.
 
-2. Only one Mthreads device can be shared in a pod (even if there are multiple containers).
+2. Only one mthreads device can be shared in a pod(even there are multiple containers).
 
-3. Support allocating exclusive Mthreads GPU by specifying mthreads.com/vgpu only.
+3. Support allocating exclusive mthreads GPU by specifying mthreads.com/vgpu only.
 
 4. These features are tested on MTT S4000
 
@@ -29,20 +29,20 @@ title: Enable Mthreads GPU sharing
 
 ## Enabling GPU-sharing Support
 
-* Deploy MT-CloudNative Toolkit on Mthreads nodes (Please consult your device provider to acquire its package and document)
+* Deploy MT-CloudNative Toolkit on mthreads nodes (Please consult your device provider to acquire its package and document)
 
 > **NOTICE:** *You can remove mt-mutating-webhook and mt-gpu-scheduler after installation(optional).*
 
 * set the 'devices.mthreads.enabled = true' when installing hami
 
 ```bash
-helm install hami hami-charts/hami --set scheduler.kubeScheduler.imageTag={your kubernetes version} --set devices.mthreads.enabled=true -n kube-system
+helm install hami hami-charts/hami --set scheduler.kubeScheduler.imageTag={your kubernetes version} --set device.mthreads.enabled=true -n kube-system
 ```
 
 ## Running Mthreads jobs
 
 Mthreads GPUs can now be requested by a container
-using the `mthreads.com/vgpu`, `mthreads.com/sgpu-memory` and `mthreads.com/sgpu-core` resource type:
+using the `mthreads.com/vgpu`, `mthreads.com/sgpu-memory` and `mthreads.com/sgpu-core`  resource type:
 
 ```yaml
 apiVersion: v1
@@ -64,5 +64,13 @@ spec:
           mthreads.com/sgpu-core: 8
 ```
 
-> **NOTICE:** *Each unit of sgpu-memory indicates 512M device memory*
-> **NOTICE:** *You can find more examples in [examples/mthreads folder](https://github.com/Project-HAMi/HAMi/tree/master/examples/mthreads/)*
+:::note
+
+Each unit of sgpu-memory indicates 512M device memory
+
+:::
+:::note
+
+You can find more examples in [examples/mthreads folder](https://github.com/Project-HAMi/HAMi/tree/release-v2.6/examples/mthreads/)
+
+:::


### PR DESCRIPTION
Convert NOTICE1/NOTICE2 numbered blockquotes to :::note admonitions and replace vague \"examples folder\" references with proper GitHub links across versioned docs (v1.3.0, v2.4.1, v2.5.0, v2.5.1, v2.6.0, v2.7.0, v2.8.0).

Affected files: mthreads, metax, iluvatar, and awsneuron device docs.