### PR TITLE
fix: convert numbered NOTICE and 注意 markers to admonitions in Chinese i18n docs

### DIFF
--- a/i18n/zh/docusaurus-plugin-content-docs/current/installation/how-to-use-volcano-ascend.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/current/installation/how-to-use-volcano-ascend.md
@@ -81,7 +81,7 @@ data:
 
  你可能会注意到 `volcano-vgpu` 有自己的 `GeometriesCMName` 和 `KnownGeometriesCMNamespace`，这意味着如果要在同一个 Volcano 集群中同时使用 vNPU 和 vGPU，你需要合并两边的 configMap。
 
- :::
+:::
 
 ## 使用方法
 

--- a/i18n/zh/docusaurus-plugin-content-docs/current/userguide/mthreads-device/enable-mthreads-gpu-sharing.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/current/userguide/mthreads-device/enable-mthreads-gpu-sharing.md
@@ -65,6 +65,14 @@ spec:
           mthreads.com/sgpu-core: 8
 ```
 
-> **注意1:** *每一单位的sgpu-memory代表512M的显存.*
+:::note
 
-> **注意2:** *查看更多的[用例](https://github.com/Project-HAMi/HAMi/tree/release-v2.6/examples/mthreads/).*
+每一单位的sgpu-memory代表512M的显存.
+
+:::
+
+:::note
+
+查看更多的[用例](https://github.com/Project-HAMi/HAMi/tree/release-v2.6/examples/mthreads/).
+
+:::

--- a/i18n/zh/docusaurus-plugin-content-docs/version-v1.3.0/userguide/metax-device/enable-metax-gpu-schedule.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/version-v1.3.0/userguide/metax-device/enable-metax-gpu-schedule.md
@@ -63,4 +63,8 @@ spec:
           metax-tech.com/gpu: 1 # requesting 1 vGPUs
 ```
 
-> **NOTICE2:** *You can find more examples in examples folder
+:::note
+
+You can find more examples in the [examples folder](https://github.com/Project-HAMi/HAMi/tree/master/examples)
+
+:::

--- a/i18n/zh/docusaurus-plugin-content-docs/version-v1.3.0/userguide/mthreads-device/enable-mthreads-gpu-sharing.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/version-v1.3.0/userguide/mthreads-device/enable-mthreads-gpu-sharing.md
@@ -64,8 +64,16 @@ spec:
           mthreads.com/sgpu-core: 8
 ```
 
-> **NOTICE1:** *Each unit of sgpu-memory indicates 512M device memory*
+:::note
 
-> **NOTICE2:** *You can find more examples in examples folder*
+Each unit of sgpu-memory indicates 512M device memory
+
+:::
+
+:::note
+
+You can find more examples in the [examples folder](https://github.com/Project-HAMi/HAMi/tree/master/examples)
+
+:::
 
     

--- a/i18n/zh/docusaurus-plugin-content-docs/version-v2.6.0/userguide/mthreads-device/enable-mthreads-gpu-sharing.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/version-v2.6.0/userguide/mthreads-device/enable-mthreads-gpu-sharing.md
@@ -64,6 +64,14 @@ spec:
           mthreads.com/sgpu-core: 8
 ```
 
-> **注意1:** *每一单位的sgpu-memory代表512M的显存.*
+:::note
 
-> **注意2:** *查看更多的[用例](https://github.com/Project-HAMi/HAMi/tree/release-v2.6/examples/mthreads/).*
+每一单位的sgpu-memory代表512M的显存.
+
+:::
+
+:::note
+
+查看更多的[用例](https://github.com/Project-HAMi/HAMi/tree/release-v2.6/examples/mthreads/).
+
+:::

--- a/i18n/zh/docusaurus-plugin-content-docs/version-v2.7.0/userguide/mthreads-device/enable-mthreads-gpu-sharing.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/version-v2.7.0/userguide/mthreads-device/enable-mthreads-gpu-sharing.md
@@ -64,6 +64,14 @@ spec:
           mthreads.com/sgpu-core: 8
 ```
 
-> **注意1:** *每一单位的sgpu-memory代表512M的显存.*
+:::note
 
-> **注意2:** *查看更多的[用例](https://github.com/Project-HAMi/HAMi/tree/release-v2.6/examples/mthreads/).*
+每一单位的sgpu-memory代表512M的显存.
+
+:::
+
+:::note
+
+查看更多的[用例](https://github.com/Project-HAMi/HAMi/tree/release-v2.6/examples/mthreads/).
+
+:::

--- a/i18n/zh/docusaurus-plugin-content-docs/version-v2.8.0/installation/how-to-use-volcano-ascend.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/version-v2.8.0/installation/how-to-use-volcano-ascend.md
@@ -80,7 +80,7 @@ data:
 
  你可能会注意到 `volcano-vgpu` 有自己的 `GeometriesCMName` 和 `KnownGeometriesCMNamespace`，这意味着如果要在同一个 Volcano 集群中同时使用 vNPU 和 vGPU，你需要合并两边的 configMap。
 
- :::
+:::
 
 ## 使用方法
 

--- a/i18n/zh/docusaurus-plugin-content-docs/version-v2.8.0/userguide/mthreads-device/enable-mthreads-gpu-sharing.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/version-v2.8.0/userguide/mthreads-device/enable-mthreads-gpu-sharing.md
@@ -65,6 +65,14 @@ spec:
           mthreads.com/sgpu-core: 8
 ```
 
-> **注意1:** *每一单位的sgpu-memory代表512M的显存.*
+:::note
 
-> **注意2:** *查看更多的[用例](https://github.com/Project-HAMi/HAMi/tree/release-v2.6/examples/mthreads/).*
+每一单位的sgpu-memory代表512M的显存.
+
+:::
+
+:::note
+
+查看更多的[用例](https://github.com/Project-HAMi/HAMi/tree/release-v2.6/examples/mthreads/).
+
+:::


### PR DESCRIPTION
Convert NOTICE1/NOTICE2 and 注意1/注意2 numbered blockquotes to Docusaurus :::note admonitions across Chinese i18n documentation (current, v1.3.0, v2.6.0, v2.7.0, v2.8.0).

Also re-applies the fix for leading-space admonition closing markers in how-to-use-volcano-ascend.md (current and v2.8.0).