### PR TITLE
fix: replace my-scheduler placeholder link text in awsneuron docs

### DIFF
--- a/docs/userguide/awsneuron-device/enable-awsneuron-managing.md
+++ b/docs/userguide/awsneuron-device/enable-awsneuron-managing.md
@@ -6,7 +6,7 @@ title: Enable AWS-Neuron device Sharing
 
 AWS Neuron devices are specialized hardware accelerators designed by AWS to optimize machine learning workloads, particularly for deep learning inference and training. They are part of the AWS Inferentia and Trainium families, which provide high performance, cost-effective, and scalable solutions for AI applications on AWS.
 
-HAMi now integrates with [my-scheduler](https://awsdocs-neuron.readthedocs-hosted.com/en/latest/containers/kubernetes-getting-started.html#deploy-neuron-scheduler-extension), providing the following capabilities:
+HAMi now integrates with [Neuron scheduler extension](https://awsdocs-neuron.readthedocs-hosted.com/en/latest/containers/kubernetes-getting-started.html#deploy-neuron-scheduler-extension), providing the following capabilities:
 
 * **Neuron sharing**: HAMi now supports sharing on aws.amazon.com/neuron by allocating device cores(aws.amazon.com/neuroncore), each Neuron core equals 1/2 of a neuron device.
 

--- a/i18n/zh/docusaurus-plugin-content-docs/current/userguide/awsneuron-device/enable-awsneuron-managing.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/current/userguide/awsneuron-device/enable-awsneuron-managing.md
@@ -5,7 +5,7 @@ linktitle: AWS-Neuron 共享
 
 AWS Neuron 设备是 AWS 专为机器学习工作负载设计的硬件加速器，特别针对深度学习推理和训练场景进行了优化。这些设备属于 AWS Inferentia 和 Trainium 产品家族，可在 AWS 云上为 AI 应用提供高性能、高性价比且可扩展的解决方案。
 
-HAMi 现已集成[my-scheduler](https://awsdocs-neuron.readthedocs-hosted.com/en/latest/containers/kubernetes-getting-started.html#deploy-neuron-scheduler-extension)，提供以下核心功能：
+HAMi 现已集成[Neuron scheduler extension](https://awsdocs-neuron.readthedocs-hosted.com/en/latest/containers/kubernetes-getting-started.html#deploy-neuron-scheduler-extension)，提供以下核心功能：
 
 * **Neuron 共享机制**：HAMi 支持通过分配设备核心 (aws.amazon.com/neuroncore) 实现 AWS Neuron 设备共享，每个 Neuron 核心对应 1/2 个物理设备。
 

--- a/i18n/zh/docusaurus-plugin-content-docs/version-v2.7.0/userguide/awsneuron-device/enable-awsneuron-managing.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/version-v2.7.0/userguide/awsneuron-device/enable-awsneuron-managing.md
@@ -6,7 +6,7 @@ title: 启用 AWS-Neuron 设备共享
 
 AWS Neuron 设备是 AWS 专为机器学习工作负载设计的硬件加速器，特别针对深度学习推理和训练场景进行了优化。这些设备属于 AWS Inferentia 和 Trainium 产品家族，可在 AWS 云上为 AI 应用提供高性能、高性价比且可扩展的解决方案。
 
-HAMi 现已集成[my-scheduler](https://awsdocs-neuron.readthedocs-hosted.com/en/latest/containers/kubernetes-getting-started.html#deploy-neuron-scheduler-extension)，提供以下核心功能：
+HAMi 现已集成[Neuron scheduler extension](https://awsdocs-neuron.readthedocs-hosted.com/en/latest/containers/kubernetes-getting-started.html#deploy-neuron-scheduler-extension)，提供以下核心功能：
 
 * **Neuron 共享机制**：HAMi 支持通过分配设备核心 (aws.amazon.com/neuroncore) 实现 AWS Neuron 设备共享，每个 Neuron 核心对应 1/2 个物理设备。
 

--- a/versioned_docs/version-v2.7.0/userguide/awsneuron-device/enable-awsneuron-managing.md
+++ b/versioned_docs/version-v2.7.0/userguide/awsneuron-device/enable-awsneuron-managing.md
@@ -6,7 +6,7 @@ title: Enable AWS-Neuron device Sharing
 
 AWS Neuron devices are specialized hardware accelerators designed by AWS to optimize machine learning workloads, particularly for deep learning inference and training. They are part of the AWS Inferentia and Trainium families, which provide high performance, cost-effective, and scalable solutions for AI applications on AWS.
 
-HAMi now integrates with [my-scheduler](https://awsdocs-neuron.readthedocs-hosted.com/en/latest/containers/kubernetes-getting-started.html#deploy-neuron-scheduler-extension), providing the following capabilities:
+HAMi now integrates with [Neuron scheduler extension](https://awsdocs-neuron.readthedocs-hosted.com/en/latest/containers/kubernetes-getting-started.html#deploy-neuron-scheduler-extension), providing the following capabilities:
 
 * **Neuron sharing**: HAMi now supports sharing on aws.amazon.com/neuron by allocating device cores(aws.amazon.com/neuroncore), each Neuron core equals to 1/2 neuron device.
 


### PR DESCRIPTION
Replace placeholder `[my-scheduler]` link text with the correct `[Neuron scheduler extension]` in versioned docs (v2.7.0, v2.8.0) and Chinese i18n docs (current, v2.7.0). Mirrors the fix already applied to active docs in PR #349.