### PR TITLE
fix: replace GPU terminology with Neuron in awsneuron docs

### DIFF
--- a/docs/userguide/awsneuron-device/enable-awsneuron-managing.md
+++ b/docs/userguide/awsneuron-device/enable-awsneuron-managing.md
@@ -93,7 +93,7 @@ spec:
 
 ## Selecting by Device UUID
 
-You can specify which GPU devices to use or exclude using annotations:
+You can specify which Neuron devices to use or exclude using annotations:
 
 ```yaml
 apiVersion: v1
@@ -101,9 +101,9 @@ kind: Pod
 metadata:
   name: poddemo
   annotations:
-    # Use specific GPU devices (comma-separated list)
+    # Use specific Neuron devices (comma-separated list)
     aws.amazon.com/use-gpuuuid: "node1-AWSNeuron-0,node1-AWSNeuron-1"
-    # Or exclude specific GPU devices (comma-separated list)
+    # Or exclude specific Neuron devices (comma-separated list)
     aws.amazon.com/nouse-gpuuuid: "node1-AWSNeuron-2,node1-AWSNeuron-3"
 spec:
   # ... rest of pod spec

--- a/i18n/zh/docusaurus-plugin-content-docs/current/userguide/awsneuron-device/enable-awsneuron-managing.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/current/userguide/awsneuron-device/enable-awsneuron-managing.md
@@ -92,7 +92,7 @@ spec:
 
 ## 按设备 UUID 选择
 
-可通过注解指定使用或排除特定 GPU 设备：
+可通过注解指定使用或排除特定 Neuron 设备：
 
 ```yaml
 apiVersion: v1
@@ -100,9 +100,9 @@ kind: Pod
 metadata:
   name: poddemo
   annotations:
-    # 指定使用的 GPU 设备 (逗号分隔列表)
+    # 指定使用的 Neuron 设备 (逗号分隔列表)
     aws.amazon.com/use-gpuuuid: "node1-AWSNeuron-0,node1-AWSNeuron-1"
-    # 或排除特定 GPU 设备 (逗号分隔列表)
+    # 或排除特定 Neuron 设备 (逗号分隔列表)
     aws.amazon.com/nouse-gpuuuid: "node1-AWSNeuron-2,node1-AWSNeuron-3"
 spec:
   # ... 其他 pod 配置

--- a/i18n/zh/docusaurus-plugin-content-docs/version-v2.7.0/userguide/awsneuron-device/enable-awsneuron-managing.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/version-v2.7.0/userguide/awsneuron-device/enable-awsneuron-managing.md
@@ -93,7 +93,7 @@ spec:
 
 ## 按设备 UUID 选择
 
-可通过注解指定使用或排除特定 GPU 设备：
+可通过注解指定使用或排除特定 Neuron 设备：
 
 ```yaml
 apiVersion: v1
@@ -101,9 +101,9 @@ kind: Pod
 metadata:
   name: poddemo
   annotations:
-    # 指定使用的 GPU 设备 (逗号分隔列表)
+    # 指定使用的 Neuron 设备 (逗号分隔列表)
     aws.amazon.com/use-gpuuuid: "node1-AWSNeuron-0,node1-AWSNeuron-1"
-    # 或排除特定 GPU 设备 (逗号分隔列表)
+    # 或排除特定 Neuron 设备 (逗号分隔列表)
     aws.amazon.com/nouse-gpuuuid: "node1-AWSNeuron-2,node1-AWSNeuron-3"
 spec:
   # ... 其他 pod 配置

--- a/versioned_docs/version-v2.7.0/userguide/awsneuron-device/enable-awsneuron-managing.md
+++ b/versioned_docs/version-v2.7.0/userguide/awsneuron-device/enable-awsneuron-managing.md
@@ -92,7 +92,7 @@ spec:
 
 ## Selecting by Device UUID
 
-You can specify which GPU devices to use or exclude using annotations:
+You can specify which Neuron devices to use or exclude using annotations:
 
 ```yaml
 apiVersion: v1
@@ -100,9 +100,9 @@ kind: Pod
 metadata:
   name: poddemo
   annotations:
-    # Use specific GPU devices (comma-separated list)
+    # Use specific Neuron devices (comma-separated list)
     aws.amazon.com/use-gpuuuid: "node1-AWSNeuron-0,node1-AWSNeuron-1"
-    # Or exclude specific GPU devices (comma-separated list)
+    # Or exclude specific Neuron devices (comma-separated list)
     aws.amazon.com/nouse-gpuuuid: "node1-AWSNeuron-2,node1-AWSNeuron-3"
 spec:
   # ... rest of pod spec


### PR DESCRIPTION
Replace incorrect \"GPU devices\" terminology with \"Neuron devices\" in awsneuron device documentation and annotation comments, covering versioned docs (v2.7.0, v2.8.0) and Chinese i18n (current, v2.7.0). Mirrors the fix already applied to active English docs in PR #349.