### PR TITLE
fix: convert upgrade-notes blockquotes to admonitions in v2.9.0 release blog

### DIFF
--- a/blog/hami-v2-9-0-release/index.md
+++ b/blog/hami-v2-9-0-release/index.md
@@ -205,11 +205,11 @@ helm upgrade hami hami-charts/hami -n hami-system
 
 For complete installation documentation, refer to: [https://project-hami.io/docs/installation/online-installation](https://project-hami.io/docs/installation/online-installation)
 
-> **Upgrade notes:**
->
-> - If using Volcano vGPU mode, please note CDI-related configuration changes
-> - If using Ascend devices and wish to enable HAMi-core mode, refer to the Ascend configuration section in the latest documentation
-> - It is recommended to verify compatibility in a test environment before upgrading
+:::warning Upgrade notes
+- If using Volcano vGPU mode, please note CDI-related configuration changes
+- If using Ascend devices and wish to enable HAMi-core mode, refer to the Ascend configuration section in the latest documentation
+- It is recommended to verify compatibility in a test environment before upgrading
+:::
 
 ## Community Updates
 

--- a/i18n/zh/docusaurus-plugin-content-blog/hami-v2-9-0-release/index.md
+++ b/i18n/zh/docusaurus-plugin-content-blog/hami-v2-9-0-release/index.md
@@ -205,11 +205,11 @@ helm upgrade hami hami-charts/hami -n hami-system
 
 完整安装文档请参考：[https://project-hami.io/zh/docs/installation/online-installation](https://project-hami.io/zh/docs/installation/online-installation)
 
-> **升级注意事项：**
->
-> - 如使用 Volcano vGPU 模式，请注意 CDI 相关配置变更
-> - 如使用昇腾设备并希望启用 HAMi-core 模式，请参考最新文档中的 Ascend 配置章节
-> - 建议在升级前在测试环境验证兼容性
+:::warning 升级注意事项
+- 如使用 Volcano vGPU 模式，请注意 CDI 相关配置变更
+- 如使用昇腾设备并希望启用 HAMi-core 模式，请参考最新文档中的 Ascend 配置章节
+- 建议在升级前在测试环境验证兼容性
+:::
 
 ## 社区动态
 


### PR DESCRIPTION
Follow-up to #359.

The upgrade notes sections in both the English and Chinese v2.9.0 release blog posts used raw `> **...**` blockquotes. This site uses Docusaurus admonitions (`:::warning`) for callout content.

Changed in `blog/hami-v2-9-0-release/index.md` and `i18n/zh/docusaurus-plugin-content-blog/hami-v2-9-0-release/index.md`:

```markdown
# Before
> **Upgrade notes:**
>
> - ...

# After
:::warning Upgrade notes
- ...
:::
```