### PR TITLE
fix: convert indented blockquote Note markers to admonitions in MIG docs

### DIFF
--- a/i18n/zh/docusaurus-plugin-content-docs/version-v1.3.0/userguide/nvidia-device/dynamic-mig-support.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/version-v1.3.0/userguide/nvidia-device/dynamic-mig-support.md
@@ -130,9 +130,17 @@ You can customize the mig configuration by following the steps below:
               count: 1
   ```
 
-  > **Note** Helm installation and updates will be based on the configuration in this file, overwriting the built-in configuration of Helm
+  :::note
 
-  > **Note** Be aware HAMi will find and use the first MIG template suitable to the task in the order of this configMap
+  Helm installation and updates will be based on the configuration in this file, overwriting the built-in configuration of Helm.
+
+  :::
+
+  :::note
+
+  HAMi will find and use the first MIG template suitable to the task in the order of this configMap.
+
+  :::
 
 ## Running MIG jobs
 

--- a/versioned_docs/version-v1.3.0/userguide/nvidia-device/dynamic-mig-support.md
+++ b/versioned_docs/version-v1.3.0/userguide/nvidia-device/dynamic-mig-support.md
@@ -130,9 +130,17 @@ You can customize the mig configuration by following the steps below:
               count: 1
   ```
 
-  > **Note** Helm installation and updates will be based on the configuration in this file, overwriting the built-in configuration of Helm
+  :::note
 
-  > **Note** Be aware HAMi will find and use the first MIG template suitable to the task in the order of this configMap
+  Helm installation and updates will be based on the configuration in this file, overwriting the built-in configuration of Helm.
+
+  :::
+
+  :::note
+
+  HAMi will find and use the first MIG template suitable to the task in the order of this configMap.
+
+  :::
 
 ## Running MIG jobs
 

--- a/versioned_docs/version-v2.4.1/userguide/nvidia-device/dynamic-mig-support.md
+++ b/versioned_docs/version-v2.4.1/userguide/nvidia-device/dynamic-mig-support.md
@@ -130,9 +130,17 @@ You can customize the mig configuration by following the steps below:
               count: 1
   ```
 
-  > **Note** Helm installation and updates will be based on the configuration in this file, overwriting the built-in configuration of Helm
+  :::note
 
-  > **Note** Be aware HAMi will find and use the first MIG template suitable to the task in the order of this configMap
+  Helm installation and updates will be based on the configuration in this file, overwriting the built-in configuration of Helm.
+
+  :::
+
+  :::note
+
+  HAMi will find and use the first MIG template suitable to the task in the order of this configMap.
+
+  :::
 
 ## Running MIG jobs
 

--- a/versioned_docs/version-v2.5.0/userguide/nvidia-device/dynamic-mig-support.md
+++ b/versioned_docs/version-v2.5.0/userguide/nvidia-device/dynamic-mig-support.md
@@ -130,9 +130,17 @@ You can customize the mig configuration by following the steps below:
               count: 1
   ```
 
-  > **Note** Helm installation and updates will be based on the configuration in this file, overwriting the built-in configuration of Helm
+  :::note
 
-  > **Note** Be aware HAMi will find and use the first MIG template suitable to the task in the order of this configMap
+  Helm installation and updates will be based on the configuration in this file, overwriting the built-in configuration of Helm.
+
+  :::
+
+  :::note
+
+  HAMi will find and use the first MIG template suitable to the task in the order of this configMap.
+
+  :::
 
 ## Running MIG jobs
 


### PR DESCRIPTION
Converts 8 remaining `> **Note**` blockquotes inside list items in `dynamic-mig-support.md` to Docusaurus `:::note` admonitions across versioned docs (v1.3.0, v2.4.1, v2.5.0) and the ZH i18n copy (v1.3.0). No content changes.