### PR TITLE
fix: update configmap URL from personal fork to official Project-HAMi repo

### DIFF
--- a/docs/userguide/configure.md
+++ b/docs/userguide/configure.md
@@ -21,7 +21,7 @@ You can update these configurations using one of the following methods:
    After making changes, restart the related HAMi components to apply the updated configurations.
 
 2. Modify Helm Chart: Update the corresponding values in the
-   [ConfigMap](https://raw.githubusercontent.com/archlitchi/HAMi/refs/heads/master/charts/hami/templates/scheduler/device-configmap.yaml),
+   [ConfigMap](https://raw.githubusercontent.com/Project-HAMi/HAMi/refs/heads/master/charts/hami/templates/scheduler/device-configmap.yaml),
    then reapply the Helm Chart to regenerate the ConfigMap.
 
    | Argument | Type | Description | Default |

--- a/i18n/zh/docusaurus-plugin-content-docs/current/userguide/configure.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/current/userguide/configure.md
@@ -20,7 +20,7 @@ translated: true
 
    更改后，重启相关的 HAMi 组件以应用更新的配置。
 
-2. 修改 Helm Chart：更新 [ConfigMap](https://raw.githubusercontent.com/archlitchi/HAMi/refs/heads/master/charts/hami/templates/scheduler/device-configmap.yaml) 中的相应值，然后重新应用 Helm Chart 以重新生成 ConfigMap。
+2. 修改 Helm Chart：更新 [ConfigMap](https://raw.githubusercontent.com/Project-HAMi/HAMi/refs/heads/master/charts/hami/templates/scheduler/device-configmap.yaml) 中的相应值，然后重新应用 Helm Chart 以重新生成 ConfigMap。
 
 | 参数 | 类型 | 描述 | 默认值 |
 | --- | ---- | --- | ----- |

--- a/i18n/zh/docusaurus-plugin-content-docs/version-v1.3.0/userguide/configure.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/version-v1.3.0/userguide/configure.md
@@ -19,7 +19,7 @@ You can update these configurations using one of the following methods:
     kubectl edit configmap hami-scheduler-device -n <namespace>
     ```
     After making changes, restart the related HAMi components to apply the updated configurations.
-2. Modify Helm Chart: Update the corresponding values in the [ConfigMap](https://raw.githubusercontent.com/archlitchi/HAMi/refs/heads/master/charts/hami/templates/scheduler/device-configmap.yaml), then reapply the Helm Chart to regenerate the ConfigMap.
+2. Modify Helm Chart: Update the corresponding values in the [ConfigMap](https://raw.githubusercontent.com/Project-HAMi/HAMi/refs/heads/master/charts/hami/templates/scheduler/device-configmap.yaml), then reapply the Helm Chart to regenerate the ConfigMap.
 
 - `nvidia.deviceMemoryScaling:` 
   Float type, by default: 1. The ratio for NVIDIA device memory scaling, can be greater than 1 (enable virtual device memory, experimental feature). For NVIDIA GPU with *M* memory, if `nvidia.deviceMemoryScaling` is set argument to *S*, vGPUs split by this GPU will totally get `S * M` memory in Kubernetes with the HAMi device plugin.

--- a/i18n/zh/docusaurus-plugin-content-docs/version-v2.5.0/userguide/configure.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/version-v2.5.0/userguide/configure.md
@@ -20,7 +20,7 @@ translated: true
    更改后，重启相关的 HAMi 组件以应用更新的配置。
 
 2. 修改 Helm Chart：更新
-   [ConfigMap](https://raw.githubusercontent.com/archlitchi/HAMi/refs/heads/master/charts/hami/templates/scheduler/device-configmap.yaml)
+   [ConfigMap](https://raw.githubusercontent.com/Project-HAMi/HAMi/refs/heads/master/charts/hami/templates/scheduler/device-configmap.yaml)
    中的相应值，然后重新应用 Helm Chart 以重新生成 ConfigMap。
 
    | 参数名 | 类型 | 描述 | 默认值 |

--- a/i18n/zh/docusaurus-plugin-content-docs/version-v2.5.1/userguide/configure.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/version-v2.5.1/userguide/configure.md
@@ -19,7 +19,7 @@ translated: true
   
     更改后，重启相关的 HAMi 组件以应用更新的配置。
   
-2. 修改 Helm Chart：更新 [ConfigMap](https://raw.githubusercontent.com/archlitchi/HAMi/refs/heads/master/charts/hami/templates/scheduler/device-configmap.yaml)
+2. 修改 Helm Chart：更新 [ConfigMap](https://raw.githubusercontent.com/Project-HAMi/HAMi/refs/heads/master/charts/hami/templates/scheduler/device-configmap.yaml)
    中的相应值，然后重新应用 Helm Chart 以重新生成 ConfigMap。
 
 - `nvidia.deviceMemoryScaling`：

--- a/i18n/zh/docusaurus-plugin-content-docs/version-v2.6.0/userguide/configure.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/version-v2.6.0/userguide/configure.md
@@ -17,7 +17,7 @@ translated: true
 
     更改后，重启相关的 HAMi 组件以应用更新的配置。
 
-2. 修改 Helm Chart：更新 [ConfigMap](https://raw.githubusercontent.com/archlitchi/HAMi/refs/heads/master/charts/hami/templates/scheduler/device-configmap.yaml) 中的相应值，然后重新应用 Helm Chart 以重新生成 ConfigMap。
+2. 修改 Helm Chart：更新 [ConfigMap](https://raw.githubusercontent.com/Project-HAMi/HAMi/refs/heads/master/charts/hami/templates/scheduler/device-configmap.yaml) 中的相应值，然后重新应用 Helm Chart 以重新生成 ConfigMap。
 
 - `nvidia.deviceMemoryScaling`：
   浮点类型，默认值：1。NVIDIA 设备显存缩放比例，可以大于 1（启用虚拟设备显存，实验性功能）。对于具有 *M* 内存的 NVIDIA GPU，如果我们将 `nvidia.deviceMemoryScaling` 参数设置为 *S*，则通过此 GPU 分割的 vGPU 在 Kubernetes 中将总共获得 `S * M` 内存。

--- a/i18n/zh/docusaurus-plugin-content-docs/version-v2.7.0/userguide/configure.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/version-v2.7.0/userguide/configure.md
@@ -21,7 +21,7 @@ translated: true
 
    更改后，重启相关的 HAMi 组件以应用更新的配置。
 
-2. 修改 Helm Chart：更新 [ConfigMap](https://raw.githubusercontent.com/archlitchi/HAMi/refs/heads/master/charts/hami/templates/scheduler/device-configmap.yaml) 中的相应值，然后重新应用 Helm Chart 以重新生成 ConfigMap。
+2. 修改 Helm Chart：更新 [ConfigMap](https://raw.githubusercontent.com/Project-HAMi/HAMi/refs/heads/master/charts/hami/templates/scheduler/device-configmap.yaml) 中的相应值，然后重新应用 Helm Chart 以重新生成 ConfigMap。
 
 | 参数 | 类型 | 描述 | 默认值 |
 | --- | ---- | --- | ----- |

--- a/i18n/zh/docusaurus-plugin-content-docs/version-v2.8.0/userguide/configure.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/version-v2.8.0/userguide/configure.md
@@ -20,7 +20,7 @@ translated: true
 
    更改后，重启相关的 HAMi 组件以应用更新的配置。
 
-2. 修改 Helm Chart：更新 [ConfigMap](https://raw.githubusercontent.com/archlitchi/HAMi/refs/heads/master/charts/hami/templates/scheduler/device-configmap.yaml) 中的相应值，然后重新应用 Helm Chart 以重新生成 ConfigMap。
+2. 修改 Helm Chart：更新 [ConfigMap](https://raw.githubusercontent.com/Project-HAMi/HAMi/refs/heads/master/charts/hami/templates/scheduler/device-configmap.yaml) 中的相应值，然后重新应用 Helm Chart 以重新生成 ConfigMap。
 
 | 参数 | 类型 | 描述 | 默认值 |
 | --- | ---- | --- | ----- |

--- a/versioned_docs/version-v1.3.0/userguide/configure.md
+++ b/versioned_docs/version-v1.3.0/userguide/configure.md
@@ -19,7 +19,7 @@ You can update these configurations using one of the following methods:
     kubectl edit configmap hami-scheduler-device -n <namespace>
     ```
     After making changes, restart the related HAMi components to apply the updated configurations.
-2. Modify Helm Chart: Update the corresponding values in the [ConfigMap](https://raw.githubusercontent.com/archlitchi/HAMi/refs/heads/master/charts/hami/templates/scheduler/device-configmap.yaml), then reapply the Helm Chart to regenerate the ConfigMap.
+2. Modify Helm Chart: Update the corresponding values in the [ConfigMap](https://raw.githubusercontent.com/Project-HAMi/HAMi/refs/heads/master/charts/hami/templates/scheduler/device-configmap.yaml), then reapply the Helm Chart to regenerate the ConfigMap.
 
 - `nvidia.deviceMemoryScaling:` 
   Float type, by default: 1. The ratio for NVIDIA device memory scaling, can be greater than 1 (enable virtual device memory, experimental feature). For NVIDIA GPU with *M* memory, if `nvidia.deviceMemoryScaling` is set argument to *S*, vGPUs split by this GPU will totally get `S * M` memory in Kubernetes with the HAMi device plugin.

--- a/versioned_docs/version-v2.4.1/userguide/configure.md
+++ b/versioned_docs/version-v2.4.1/userguide/configure.md
@@ -19,7 +19,7 @@ You can update these configurations using one of the following methods:
     kubectl edit configmap hami-scheduler-device -n <namespace>
     ```
     After making changes, restart the related HAMi components to apply the updated configurations.
-2. Modify Helm Chart: Update the corresponding values in the [ConfigMap](https://raw.githubusercontent.com/archlitchi/HAMi/refs/heads/master/charts/hami/templates/scheduler/device-configmap.yaml), then reapply the Helm Chart to regenerate the ConfigMap.
+2. Modify Helm Chart: Update the corresponding values in the [ConfigMap](https://raw.githubusercontent.com/Project-HAMi/HAMi/refs/heads/master/charts/hami/templates/scheduler/device-configmap.yaml), then reapply the Helm Chart to regenerate the ConfigMap.
 
 - `nvidia.deviceMemoryScaling:` 
   Float type, by default: 1. The ratio for NVIDIA device memory scaling, can be greater than 1 (enable virtual device memory, experimental feature). For NVIDIA GPU with *M* memory, if `nvidia.deviceMemoryScaling` is set argument to *S*, vGPUs split by this GPU will totally get `S * M` memory in Kubernetes with the HAMi device plugin.

--- a/versioned_docs/version-v2.5.0/userguide/configure.md
+++ b/versioned_docs/version-v2.5.0/userguide/configure.md
@@ -19,7 +19,7 @@ You can update these configurations using one of the following methods:
     kubectl edit configmap hami-scheduler-device -n <namespace>
     ```
     After making changes, restart the related HAMi components to apply the updated configurations.
-2. Modify Helm Chart: Update the corresponding values in the [ConfigMap](https://raw.githubusercontent.com/archlitchi/HAMi/refs/heads/master/charts/hami/templates/scheduler/device-configmap.yaml), then reapply the Helm Chart to regenerate the ConfigMap.
+2. Modify Helm Chart: Update the corresponding values in the [ConfigMap](https://raw.githubusercontent.com/Project-HAMi/HAMi/refs/heads/master/charts/hami/templates/scheduler/device-configmap.yaml), then reapply the Helm Chart to regenerate the ConfigMap.
 
 - `nvidia.deviceMemoryScaling:` 
   Float type, by default: 1. The ratio for NVIDIA device memory scaling, can be greater than 1 (enable virtual device memory, experimental feature). For NVIDIA GPU with *M* memory, if `nvidia.deviceMemoryScaling` is set argument to *S*, vGPUs split by this GPU will totally get `S * M` memory in Kubernetes with the HAMi device plugin.

--- a/versioned_docs/version-v2.5.1/userguide/configure.md
+++ b/versioned_docs/version-v2.5.1/userguide/configure.md
@@ -22,7 +22,7 @@ You can update these configurations using one of the following methods:
    After making changes, restart the related HAMi components to apply the updated configurations.
 
 2. Modify Helm Chart: Update the corresponding values in the
-   [ConfigMap](https://raw.githubusercontent.com/archlitchi/HAMi/refs/heads/master/charts/hami/templates/scheduler/device-configmap.yaml),
+   [ConfigMap](https://raw.githubusercontent.com/Project-HAMi/HAMi/refs/heads/master/charts/hami/templates/scheduler/device-configmap.yaml),
    then reapply the Helm Chart to regenerate the ConfigMap.
 
    | Argument | Type | Description | Default |

--- a/versioned_docs/version-v2.6.0/userguide/configure.md
+++ b/versioned_docs/version-v2.6.0/userguide/configure.md
@@ -22,7 +22,7 @@ You can update these configurations using one of the following methods:
    After making changes, restart the related HAMi components to apply the updated configurations.
 
 2. Modify Helm Chart: Update the corresponding values in the
-   [ConfigMap](https://raw.githubusercontent.com/archlitchi/HAMi/refs/heads/master/charts/hami/templates/scheduler/device-configmap.yaml),
+   [ConfigMap](https://raw.githubusercontent.com/Project-HAMi/HAMi/refs/heads/master/charts/hami/templates/scheduler/device-configmap.yaml),
    then reapply the Helm Chart to regenerate the ConfigMap.
 
    | Argument | Type | Description | Default |

--- a/versioned_docs/version-v2.7.0/userguide/configure.md
+++ b/versioned_docs/version-v2.7.0/userguide/configure.md
@@ -22,7 +22,7 @@ You can update these configurations using one of the following methods:
    After making changes, restart the related HAMi components to apply the updated configurations.
 
 2. Modify Helm Chart: Update the corresponding values in the
-   [ConfigMap](https://raw.githubusercontent.com/archlitchi/HAMi/refs/heads/master/charts/hami/templates/scheduler/device-configmap.yaml),
+   [ConfigMap](https://raw.githubusercontent.com/Project-HAMi/HAMi/refs/heads/master/charts/hami/templates/scheduler/device-configmap.yaml),
    then reapply the Helm Chart to regenerate the ConfigMap.
 
    | Argument | Type | Description | Default |

--- a/versioned_docs/version-v2.8.0/userguide/configure.md
+++ b/versioned_docs/version-v2.8.0/userguide/configure.md
@@ -21,7 +21,7 @@ You can update these configurations using one of the following methods:
    After making changes, restart the related HAMi components to apply the updated configurations.
 
 2. Modify Helm Chart: Update the corresponding values in the
-   [ConfigMap](https://raw.githubusercontent.com/archlitchi/HAMi/refs/heads/master/charts/hami/templates/scheduler/device-configmap.yaml),
+   [ConfigMap](https://raw.githubusercontent.com/Project-HAMi/HAMi/refs/heads/master/charts/hami/templates/scheduler/device-configmap.yaml),
    then reapply the Helm Chart to regenerate the ConfigMap.
 
    | Argument | Type | Description | Default |


### PR DESCRIPTION
Replaces 15 stale links pointing to archlitchi/HAMi (a personal fork) with the official Project-HAMi/HAMi URL in configure.md across all versions and ZH translations. The file exists at the official URL and returns HTTP 200.