### PR TITLE
fix: replace TODO placeholder with adopters link in versioned faq docs

### DIFF
--- a/i18n/zh/docusaurus-plugin-content-docs/version-v1.3.0/faq/faq.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/version-v1.3.0/faq/faq.md
@@ -37,4 +37,4 @@ There are some things you should consider before doing so:
   Deployment and update the status persistently, Karmada system will reconcile these changes too, so there might be
   conflicts.
 
-TODO: Link to adoption use case once it gets on board.
+See the [list of HAMi adopters](https://github.com/Project-HAMi/website/blob/master/src/pages/adopters.mdx) for organizations using HAMi in production.

--- a/i18n/zh/docusaurus-plugin-content-docs/version-v2.4.1/faq/faq.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/version-v2.4.1/faq/faq.md
@@ -35,4 +35,4 @@ There are some things you should consider before doing so:
   Deployment and update the status persistently, Karmada system will reconcile these changes too, so there might be
   conflicts.
 
-TODO: Link to adoption use case once it gets on board.
+See the [list of HAMi adopters](https://github.com/Project-HAMi/website/blob/master/src/pages/adopters.mdx) for organizations using HAMi in production.

--- a/i18n/zh/docusaurus-plugin-content-docs/version-v2.5.0/faq/faq.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/version-v2.5.0/faq/faq.md
@@ -35,4 +35,4 @@ There are some things you should consider before doing so:
   Deployment and update the status persistently, Karmada system will reconcile these changes too, so there might be
   conflicts.
 
-TODO: Link to adoption use case once it gets on board.
+See the [list of HAMi adopters](https://github.com/Project-HAMi/website/blob/master/src/pages/adopters.mdx) for organizations using HAMi in production.

--- a/versioned_docs/version-v1.3.0/faq/faq.md
+++ b/versioned_docs/version-v1.3.0/faq/faq.md
@@ -36,4 +36,4 @@ There are some things you should consider before doing so:
   Deployment and update the status persistently, Karmada system will reconcile these changes too, so there might be
   conflicts.
 
-TODO: Link to adoption use case once it gets on board.
+See the [list of HAMi adopters](https://github.com/Project-HAMi/website/blob/master/src/pages/adopters.mdx) for organizations using HAMi in production.

--- a/versioned_docs/version-v2.4.1/faq/faq.md
+++ b/versioned_docs/version-v2.4.1/faq/faq.md
@@ -36,4 +36,4 @@ There are some things you should consider before doing so:
   Deployment and update the status persistently, Karmada system will reconcile these changes too, so there might be
   conflicts.
 
-TODO: Link to adoption use case once it gets on board.
+See the [list of HAMi adopters](https://github.com/Project-HAMi/website/blob/master/src/pages/adopters.mdx) for organizations using HAMi in production.

--- a/versioned_docs/version-v2.5.0/faq/faq.md
+++ b/versioned_docs/version-v2.5.0/faq/faq.md
@@ -36,4 +36,4 @@ There are some things you should consider before doing so:
   Deployment and update the status persistently, Karmada system will reconcile these changes too, so there might be
   conflicts.
 
-TODO: Link to adoption use case once it gets on board.
+See the [list of HAMi adopters](https://github.com/Project-HAMi/website/blob/master/src/pages/adopters.mdx) for organizations using HAMi in production.


### PR DESCRIPTION
Replaces 6 stale TODO comments in faq.md (v1.3.0, v2.4.1, v2.5.0 and their ZH copies) with a link to the adopters page, which now exists at src/pages/adopters.mdx.