### PR TITLE
fix: correct -set to --set in helm configuration docs

### DIFF
--- a/docs/userguide/configure.md
+++ b/docs/userguide/configure.md
@@ -59,7 +59,7 @@ kubectl -n <namespace> edit cm hami-device-plugin
 
 ## Chart Configs: arguments
 
-You can customize your vGPU support by setting the following arguments using `-set`, for example
+You can customize your vGPU support by setting the following arguments using `--set`, for example
 
 ```bash
 helm install hami hami-charts/hami --set devicePlugin.deviceMemoryScaling=5 -n kube-system

--- a/i18n/zh/docusaurus-plugin-content-docs/current/userguide/configure.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/current/userguide/configure.md
@@ -40,7 +40,7 @@ translated: true
 
 ## Chart 配置：参数
 
-你可以通过使用 `-set` 设置以下参数来自定义你的 vGPU 支持，例如
+你可以通过使用 `--set` 设置以下参数来自定义你的 vGPU 支持，例如
 
 ```bash
 helm install hami hami-charts/hami --set devicePlugin.deviceMemoryScaling=5 ...

--- a/i18n/zh/docusaurus-plugin-content-docs/version-v1.3.0/userguide/configure.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/version-v1.3.0/userguide/configure.md
@@ -48,7 +48,7 @@ You can update these configurations using one of the following methods:
 
 ## Chart Configs: parameters
 
-you can customize your vGPU support by setting the following parameters using `-set`, for example
+you can customize your vGPU support by setting the following parameters using `--set`, for example
 
 ```
 helm install hami hami-charts/hami --set devicePlugin.deviceMemoryScaling=5 ...

--- a/i18n/zh/docusaurus-plugin-content-docs/version-v2.4.1/userguide/configure.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/version-v2.4.1/userguide/configure.md
@@ -4,7 +4,7 @@ title: Configuration
 
 ## Global configuration
 
-These global configurations apply for all tasks. You can customize your HAMi installation by setting the following parameters using `-set`, for example
+These global configurations apply for all tasks. You can customize your HAMi installation by setting the following parameters using `--set`, for example
 
 ```
 helm install vgpu-charts/vgpu vgpu --set devicePlugin.deviceMemoryScaling=5 ...

--- a/i18n/zh/docusaurus-plugin-content-docs/version-v2.5.0/userguide/configure.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/version-v2.5.0/userguide/configure.md
@@ -40,7 +40,7 @@ translated: true
 
 ## Chart 配置：参数
 
-你可以通过使用 `-set` 设置以下参数来自定义你的 vGPU 支持，例如
+你可以通过使用 `--set` 设置以下参数来自定义你的 vGPU 支持，例如
 
 ```bash
 helm install hami hami-charts/hami --set devicePlugin.deviceMemoryScaling=5 ...

--- a/i18n/zh/docusaurus-plugin-content-docs/version-v2.5.1/userguide/configure.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/version-v2.5.1/userguide/configure.md
@@ -49,7 +49,7 @@ translated: true
 
 ## Chart 配置：参数
 
-你可以通过使用 `-set` 设置以下参数来自定义你的 vGPU 支持，例如
+你可以通过使用 `--set` 设置以下参数来自定义你的 vGPU 支持，例如
 
 ```bash
 helm install hami hami-charts/hami --set devicePlugin.deviceMemoryScaling=5 ...

--- a/i18n/zh/docusaurus-plugin-content-docs/version-v2.6.0/userguide/configure.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/version-v2.6.0/userguide/configure.md
@@ -46,7 +46,7 @@ translated: true
 
 ## Chart 配置：参数
 
-你可以通过使用 `-set` 设置以下参数来自定义你的 vGPU 支持，例如
+你可以通过使用 `--set` 设置以下参数来自定义你的 vGPU 支持，例如
 
 ```bash
 helm install hami hami-charts/hami --set devicePlugin.deviceMemoryScaling=5 ...

--- a/i18n/zh/docusaurus-plugin-content-docs/version-v2.7.0/userguide/configure.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/version-v2.7.0/userguide/configure.md
@@ -40,7 +40,7 @@ translated: true
 
 ## Chart 配置：参数
 
-你可以通过使用 `-set` 设置以下参数来自定义你的 vGPU 支持，例如
+你可以通过使用 `--set` 设置以下参数来自定义你的 vGPU 支持，例如
 
 ```bash
 helm install hami hami-charts/hami --set devicePlugin.deviceMemoryScaling=5 ...

--- a/i18n/zh/docusaurus-plugin-content-docs/version-v2.8.0/userguide/configure.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/version-v2.8.0/userguide/configure.md
@@ -39,7 +39,7 @@ translated: true
 
 ## Chart 配置：参数
 
-你可以通过使用 `-set` 设置以下参数来自定义你的 vGPU 支持，例如
+你可以通过使用 `--set` 设置以下参数来自定义你的 vGPU 支持，例如
 
 ```bash
 helm install hami hami-charts/hami --set devicePlugin.deviceMemoryScaling=5 ...

--- a/versioned_docs/version-v1.3.0/userguide/configure.md
+++ b/versioned_docs/version-v1.3.0/userguide/configure.md
@@ -48,7 +48,7 @@ You can update these configurations using one of the following methods:
 
 ## Chart Configs: parameters
 
-you can customize your vGPU support by setting the following parameters using `-set`, for example
+you can customize your vGPU support by setting the following parameters using `--set`, for example
 
 ```
 helm install hami hami-charts/hami --set devicePlugin.deviceMemoryScaling=5 ...

--- a/versioned_docs/version-v2.4.1/userguide/configure.md
+++ b/versioned_docs/version-v2.4.1/userguide/configure.md
@@ -48,7 +48,7 @@ You can update these configurations using one of the following methods:
 
 ## Chart Configs: parameters
 
-you can customize your vGPU support by setting the following parameters using `-set`, for example
+you can customize your vGPU support by setting the following parameters using `--set`, for example
 
 ```
 helm install hami hami-charts/hami --set devicePlugin.deviceMemoryScaling=5 ...

--- a/versioned_docs/version-v2.5.0/userguide/configure.md
+++ b/versioned_docs/version-v2.5.0/userguide/configure.md
@@ -48,7 +48,7 @@ You can update these configurations using one of the following methods:
 
 ## Chart Configs: parameters
 
-you can customize your vGPU support by setting the following parameters using `-set`, for example
+you can customize your vGPU support by setting the following parameters using `--set`, for example
 
 ```
 helm install hami hami-charts/hami --set devicePlugin.deviceMemoryScaling=5 ...

--- a/versioned_docs/version-v2.5.1/userguide/configure.md
+++ b/versioned_docs/version-v2.5.1/userguide/configure.md
@@ -42,7 +42,7 @@ You can update these configurations using one of the following methods:
 
 ## Chart Configs: arguments
 
-You can customize your vGPU support by setting the following arguments using `-set`, for example
+You can customize your vGPU support by setting the following arguments using `--set`, for example
 
 ```bash
 helm install hami hami-charts/hami --set devicePlugin.deviceMemoryScaling=5 ...

--- a/versioned_docs/version-v2.6.0/userguide/configure.md
+++ b/versioned_docs/version-v2.6.0/userguide/configure.md
@@ -42,7 +42,7 @@ You can update these configurations using one of the following methods:
 
 ## Chart Configs: arguments
 
-You can customize your vGPU support by setting the following arguments using `-set`, for example
+You can customize your vGPU support by setting the following arguments using `--set`, for example
 
 ```bash
 helm install hami hami-charts/hami --set devicePlugin.deviceMemoryScaling=5 ...

--- a/versioned_docs/version-v2.7.0/userguide/configure.md
+++ b/versioned_docs/version-v2.7.0/userguide/configure.md
@@ -57,7 +57,7 @@ kubectl -n <namespace> edit cm hami-device-plugin
 
 ## Chart Configs: arguments
 
-You can customize your vGPU support by setting the following arguments using `-set`, for example
+You can customize your vGPU support by setting the following arguments using `--set`, for example
 
 ```bash
 helm install hami hami-charts/hami --set devicePlugin.deviceMemoryScaling=5 ...

--- a/versioned_docs/version-v2.8.0/userguide/configure.md
+++ b/versioned_docs/version-v2.8.0/userguide/configure.md
@@ -59,7 +59,7 @@ kubectl -n <namespace> edit cm hami-device-plugin
 
 ## Chart Configs: arguments
 
-You can customize your vGPU support by setting the following arguments using `-set`, for example
+You can customize your vGPU support by setting the following arguments using `--set`, for example
 
 ```bash
 helm install hami hami-charts/hami --set devicePlugin.deviceMemoryScaling=5 -n kube-system


### PR DESCRIPTION
Fixes a typo in 16 configure.md files across all versions and ZH translations where the helm flag was written as `-set` instead of the correct `--set`.