### PR TITLE
fix: correct Illuvatar to Iluvatar in page titles

### DIFF
--- a/versioned_docs/version-v2.6.0/userguide/iluvatar-device/enable-illuvatar-gpu-sharing.md
+++ b/versioned_docs/version-v2.6.0/userguide/iluvatar-device/enable-illuvatar-gpu-sharing.md
@@ -1,5 +1,5 @@
 ---
-title: Enable Illuvatar GPU Sharing
+title: Enable Iluvatar GPU Sharing
 ---
 
 

--- a/versioned_docs/version-v2.7.0/userguide/iluvatar-device/enable-illuvatar-gpu-sharing.md
+++ b/versioned_docs/version-v2.7.0/userguide/iluvatar-device/enable-illuvatar-gpu-sharing.md
@@ -1,5 +1,5 @@
 ---
-title: Enable Illuvatar GPU Sharing
+title: Enable Iluvatar GPU Sharing
 ---
 
 

--- a/versioned_docs/version-v2.8.0/userguide/iluvatar-device/enable-illuvatar-gpu-sharing.md
+++ b/versioned_docs/version-v2.8.0/userguide/iluvatar-device/enable-illuvatar-gpu-sharing.md
@@ -1,5 +1,5 @@
 ---
-title: Enable Illuvatar GPU Sharing
+title: Enable Iluvatar GPU Sharing
 ---
 
 ## Introduction


### PR DESCRIPTION
Fixes a spelling error in the title field of enable-illuvatar-gpu-sharing.md across v2.6.0, v2.7.0, and v2.8.0. The correct brand name is Iluvatar (one l), not Illuvatar (double l).