### PR TITLE
fix: convert WARNING, NOTICE and Important blockquotes to Docusaurus admonitions

### DIFF
--- a/docs/installation/webui-installation.md
+++ b/docs/installation/webui-installation.md
@@ -42,8 +42,9 @@ To add the HAMi WebUI Helm repository and install the chart on your machine, fol
    helm install my-hami-webui hami-webui/hami-webui --set externalPrometheus.enabled=true --set externalPrometheus.address="http://prometheus-kube-prometheus-prometheus.monitoring.svc.cluster.local:9090" -n kube-system
    ```
 
-   > _**Important**_: Replace `externalPrometheus.address` with the in-cluster Prometheus URL that your environment uses.
-
+   :::caution
+   Replace `externalPrometheus.address` with the in-cluster Prometheus URL that your environment uses.
+   :::
    You can set other values from [values.yaml](https://github.com/Project-HAMi/HAMi-WebUI/blob/main/charts/hami-webui/values.yaml) during installation; see the configuration [documentation](https://github.com/Project-HAMi/HAMi-WebUI/blob/main/charts/hami-webui/README.md#values).
 
 3. Verify the installation:

--- a/docs/userguide/awsneuron-device/enable-awsneuron-managing.md
+++ b/docs/userguide/awsneuron-device/enable-awsneuron-managing.md
@@ -109,8 +109,11 @@ spec:
   # ... rest of pod spec
 ```
 
-> **NOTICE:** The device ID format is `{node-name}-AWSNeuron-{index}`. You can find the available device IDs in the node annotations.
+:::note
 
+The device ID format is `{node-name}-AWSNeuron-{index}`. You can find the available device IDs in the node annotations.
+
+:::
 ### Finding Device UUIDs
 
 You can find the UUIDs of AWS Neuron devices on a node using the following command:

--- a/i18n/zh/docusaurus-plugin-content-docs/version-v1.3.0/installation/how-to-use-volcano-vgpu.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/version-v1.3.0/installation/how-to-use-volcano-vgpu.md
@@ -115,9 +115,11 @@ EOF
 
 You can validate device memory using nvidia-smi inside container:
 
-> **WARNING:** *if you don't request GPUs when using the device plugin with NVIDIA images all
-> the GPUs on the machine will be exposed inside your container.
-> The number of vgpu used by a container can not exceed the number of gpus on that node.*
+:::warning
+
+if you don't request GPUs when using the device plugin with NVIDIA images all the GPUs on the machine will be exposed inside your container. The number of vgpu used by a container can not exceed the number of gpus on that node.
+
+:::
 
 ### Monitor
 

--- a/i18n/zh/docusaurus-plugin-content-docs/version-v1.3.0/installation/upgrade.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/version-v1.3.0/installation/upgrade.md
@@ -10,4 +10,8 @@ helm repo update
 helm install hami hami-charts/hami -n kube-system
 ```
 
-> **WARNING:** *If you upgrade HAMi without clearing your submitted tasks, it may result in segmentation fault.*
+:::warning
+
+If you upgrade HAMi without clearing your submitted tasks, it may result in segmentation fault.
+
+:::

--- a/i18n/zh/docusaurus-plugin-content-docs/version-v1.3.0/userguide/mthreads-device/enable-mthreads-gpu-sharing.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/version-v1.3.0/userguide/mthreads-device/enable-mthreads-gpu-sharing.md
@@ -31,8 +31,11 @@ title: Enable Mthreads GPU sharing
 
 * Deploy MT-CloudNative Toolkit on mthreads nodes (Please consult your device provider to acquire its package and document)
 
-> **NOTICE:** *You can remove mt-mutating-webhook and mt-gpu-scheduler after installation(optional).*
+:::note
 
+You can remove mt-mutating-webhook and mt-gpu-scheduler after installation(optional).
+
+:::
 * set the 'devices.mthreads.enabled = true' when installing hami
 
 ```

--- a/i18n/zh/docusaurus-plugin-content-docs/version-v1.3.0/userguide/volcano-vgpu/nvidia-gpu/how-to-use-volcano-vgpu.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/version-v1.3.0/userguide/volcano-vgpu/nvidia-gpu/how-to-use-volcano-vgpu.md
@@ -115,9 +115,11 @@ EOF
 
 You can validate device memory using nvidia-smi inside container:
 
-> **WARNING:** *if you don't request GPUs when using the device plugin with NVIDIA images all
-> the GPUs on the machine will be exposed inside your container.
-> The number of vgpu used by a container can not exceed the number of gpus on that node.*
+:::warning
+
+if you don't request GPUs when using the device plugin with NVIDIA images all the GPUs on the machine will be exposed inside your container. The number of vgpu used by a container can not exceed the number of gpus on that node.
+
+:::
 
 ### Monitor
 

--- a/i18n/zh/docusaurus-plugin-content-docs/version-v2.4.1/installation/upgrade.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/version-v2.4.1/installation/upgrade.md
@@ -10,4 +10,8 @@ helm repo update
 helm install hami hami-charts/hami -n kube-system
 ```
 
-> **WARNING:** *If you upgrade HAMi without clearing your submitted tasks, it may result in segmentation fault.*
+:::warning
+
+If you upgrade HAMi without clearing your submitted tasks, it may result in segmentation fault.
+
+:::

--- a/versioned_docs/version-v1.3.0/installation/how-to-use-volcano-vgpu.md
+++ b/versioned_docs/version-v1.3.0/installation/how-to-use-volcano-vgpu.md
@@ -117,9 +117,11 @@ EOF
 
 You can validate device memory using nvidia-smi inside container:
 
-> **WARNING:** *if you don't request GPUs when using the device plugin with NVIDIA images all
-> the GPUs on the machine will be exposed inside your container.
-> The number of vgpu used by a container can not exceed the number of gpus on that node.*
+:::warning
+
+if you don't request GPUs when using the device plugin with NVIDIA images all the GPUs on the machine will be exposed inside your container. The number of vgpu used by a container can not exceed the number of gpus on that node.
+
+:::
 
 ### Monitor
 

--- a/versioned_docs/version-v1.3.0/installation/upgrade.md
+++ b/versioned_docs/version-v1.3.0/installation/upgrade.md
@@ -10,4 +10,8 @@ helm repo update
 helm install hami hami-charts/hami -n kube-system
 ```
 
-> **WARNING:** *If you upgrade HAMi without clearing your submitted tasks, it may result in segmentation fault.*
+:::warning
+
+If you upgrade HAMi without clearing your submitted tasks, it may result in segmentation fault.
+
+:::

--- a/versioned_docs/version-v1.3.0/installation/webui-installation.md
+++ b/versioned_docs/version-v1.3.0/installation/webui-installation.md
@@ -42,8 +42,9 @@ To add the HAMi WebUI Helm repository and install the chart on your machine, fol
    helm install my-hami-webui hami-webui/hami-webui --set externalPrometheus.enabled=true --set externalPrometheus.address="http://prometheus-kube-prometheus-prometheus.monitoring.svc.cluster.local:9090" -n kube-system
    ```
 
-   > _**Important**_: Replace `externalPrometheus.address` with the in-cluster Prometheus URL that your environment uses.
-
+   :::caution
+   Replace `externalPrometheus.address` with the in-cluster Prometheus URL that your environment uses.
+   :::
    You can set other values from [values.yaml](https://github.com/Project-HAMi/HAMi-WebUI/blob/main/charts/hami-webui/values.yaml) during installation; see the configuration [documentation](https://github.com/Project-HAMi/HAMi-WebUI/blob/main/charts/hami-webui/README.md#values).
 
 3. Verify the installation:

--- a/versioned_docs/version-v1.3.0/userguide/mthreads-device/enable-mthreads-gpu-sharing.md
+++ b/versioned_docs/version-v1.3.0/userguide/mthreads-device/enable-mthreads-gpu-sharing.md
@@ -31,8 +31,11 @@ title: Enable Mthreads GPU sharing
 
 - Deploy MT-CloudNative Toolkit on mthreads nodes (Please consult your device provider to acquire its package and document)
 
-> **NOTICE:** *You can remove mt-mutating-webhook and mt-gpu-scheduler after installation(optional).*
+:::note
 
+You can remove mt-mutating-webhook and mt-gpu-scheduler after installation(optional).
+
+:::
 - set the 'devices.mthreads.enabled = true' when installing hami
 
 ```

--- a/versioned_docs/version-v1.3.0/userguide/volcano-vgpu/nvidia-gpu/how-to-use-volcano-vgpu.md
+++ b/versioned_docs/version-v1.3.0/userguide/volcano-vgpu/nvidia-gpu/how-to-use-volcano-vgpu.md
@@ -117,9 +117,11 @@ EOF
 
 You can validate device memory using nvidia-smi inside container:
 
-> **WARNING:** *if you don't request GPUs when using the device plugin with NVIDIA images all
-> the GPUs on the machine will be exposed inside your container.
-> The number of vgpu used by a container can not exceed the number of gpus on that node.*
+:::warning
+
+if you don't request GPUs when using the device plugin with NVIDIA images all the GPUs on the machine will be exposed inside your container. The number of vgpu used by a container can not exceed the number of gpus on that node.
+
+:::
 
 ### Monitor
 

--- a/versioned_docs/version-v2.4.1/installation/how-to-use-volcano-vgpu.md
+++ b/versioned_docs/version-v2.4.1/installation/how-to-use-volcano-vgpu.md
@@ -117,9 +117,11 @@ EOF
 
 You can validate device memory using nvidia-smi inside container:
 
-> **WARNING:** *if you don't request GPUs when using the device plugin with NVIDIA images all
-> the GPUs on the machine will be exposed inside your container.
-> The number of vgpu used by a container can not exceed the number of gpus on that node.*
+:::warning
+
+if you don't request GPUs when using the device plugin with NVIDIA images all the GPUs on the machine will be exposed inside your container. The number of vgpu used by a container can not exceed the number of gpus on that node.
+
+:::
 
 ### Monitor
 

--- a/versioned_docs/version-v2.4.1/installation/upgrade.md
+++ b/versioned_docs/version-v2.4.1/installation/upgrade.md
@@ -10,4 +10,8 @@ helm repo update
 helm install hami hami-charts/hami -n kube-system
 ```
 
-> **WARNING:** *If you upgrade HAMi without clearing your submitted tasks, it may result in segmentation fault.*
+:::warning
+
+If you upgrade HAMi without clearing your submitted tasks, it may result in segmentation fault.
+
+:::

--- a/versioned_docs/version-v2.4.1/installation/webui-installation.md
+++ b/versioned_docs/version-v2.4.1/installation/webui-installation.md
@@ -42,8 +42,9 @@ To add the HAMi WebUI Helm repository and install the chart on your machine, fol
    helm install my-hami-webui hami-webui/hami-webui --set externalPrometheus.enabled=true --set externalPrometheus.address="http://prometheus-kube-prometheus-prometheus.monitoring.svc.cluster.local:9090" -n kube-system
    ```
 
-   > _**Important**_: Replace `externalPrometheus.address` with the in-cluster Prometheus URL that your environment uses.
-
+   :::caution
+   Replace `externalPrometheus.address` with the in-cluster Prometheus URL that your environment uses.
+   :::
    You can set other values from [values.yaml](https://github.com/Project-HAMi/HAMi-WebUI/blob/main/charts/hami-webui/values.yaml) during installation; see the configuration [documentation](https://github.com/Project-HAMi/HAMi-WebUI/blob/main/charts/hami-webui/README.md#values).
 
 3. Verify the installation:

--- a/versioned_docs/version-v2.4.1/userguide/mthreads-device/enable-mthreads-gpu-sharing.md
+++ b/versioned_docs/version-v2.4.1/userguide/mthreads-device/enable-mthreads-gpu-sharing.md
@@ -31,8 +31,11 @@ title: Enable Mthreads GPU sharing
 
 - Deploy MT-CloudNative Toolkit on mthreads nodes (Please consult your device provider to acquire its package and document)
 
-> **NOTICE:** *You can remove mt-mutating-webhook and mt-gpu-scheduler after installation(optional).*
+:::note
 
+You can remove mt-mutating-webhook and mt-gpu-scheduler after installation(optional).
+
+:::
 - set the 'devices.mthreads.enabled = true' when installing hami
 
 ```

--- a/versioned_docs/version-v2.4.1/userguide/volcano-vgpu/nvidia-gpu/how-to-use-volcano-vgpu.md
+++ b/versioned_docs/version-v2.4.1/userguide/volcano-vgpu/nvidia-gpu/how-to-use-volcano-vgpu.md
@@ -117,9 +117,11 @@ EOF
 
 You can validate device memory using nvidia-smi inside container:
 
-> **WARNING:** *if you don't request GPUs when using the device plugin with NVIDIA images all
-> the GPUs on the machine will be exposed inside your container.
-> The number of vgpu used by a container can not exceed the number of gpus on that node.*
+:::warning
+
+if you don't request GPUs when using the device plugin with NVIDIA images all the GPUs on the machine will be exposed inside your container. The number of vgpu used by a container can not exceed the number of gpus on that node.
+
+:::
 
 ### Monitor
 

--- a/versioned_docs/version-v2.5.0/installation/how-to-use-volcano-vgpu.md
+++ b/versioned_docs/version-v2.5.0/installation/how-to-use-volcano-vgpu.md
@@ -117,9 +117,11 @@ EOF
 
 You can validate device memory using nvidia-smi inside container:
 
-> **WARNING:** *if you don't request GPUs when using the device plugin with NVIDIA images all
-> the GPUs on the machine will be exposed inside your container.
-> The number of vgpu used by a container can not exceed the number of gpus on that node.*
+:::warning
+
+if you don't request GPUs when using the device plugin with NVIDIA images all the GPUs on the machine will be exposed inside your container. The number of vgpu used by a container can not exceed the number of gpus on that node.
+
+:::
 
 ### Monitor
 

--- a/versioned_docs/version-v2.5.0/installation/upgrade.md
+++ b/versioned_docs/version-v2.5.0/installation/upgrade.md
@@ -10,4 +10,8 @@ helm repo update
 helm install hami hami-charts/hami -n kube-system
 ```
 
-> **WARNING:** *If you upgrade HAMi without clearing your submitted tasks, it may result in segmentation fault.*
+:::warning
+
+If you upgrade HAMi without clearing your submitted tasks, it may result in segmentation fault.
+
+:::

--- a/versioned_docs/version-v2.5.0/installation/webui-installation.md
+++ b/versioned_docs/version-v2.5.0/installation/webui-installation.md
@@ -42,8 +42,9 @@ To add the HAMi WebUI Helm repository and install the chart on your machine, fol
    helm install my-hami-webui hami-webui/hami-webui --set externalPrometheus.enabled=true --set externalPrometheus.address="http://prometheus-kube-prometheus-prometheus.monitoring.svc.cluster.local:9090" -n kube-system
    ```
 
-   > _**Important**_: Replace `externalPrometheus.address` with the in-cluster Prometheus URL that your environment uses.
-
+   :::caution
+   Replace `externalPrometheus.address` with the in-cluster Prometheus URL that your environment uses.
+   :::
    You can set other values from [values.yaml](https://github.com/Project-HAMi/HAMi-WebUI/blob/main/charts/hami-webui/values.yaml) during installation; see the configuration [documentation](https://github.com/Project-HAMi/HAMi-WebUI/blob/main/charts/hami-webui/README.md#values).
 
 3. Verify the installation:

--- a/versioned_docs/version-v2.5.0/userguide/iluvatar-device/enable-iluvatar-gpu-sharing.md
+++ b/versioned_docs/version-v2.5.0/userguide/iluvatar-device/enable-iluvatar-gpu-sharing.md
@@ -25,8 +25,11 @@ title: Enable Iluvatar GCU sharing
 
 - Deploy gpu-manager on iluvatar nodes (Please consult your device provider to acquire its package and document)
 
-> **NOTICE:** *Install only gpu-manager, don't install gpu-admission package.*
+:::note
 
+Install only gpu-manager, don't install gpu-admission package.
+
+:::
 - Identify the resource name about core and memory usage(i.e 'iluvatar.ai/vcuda-core', 'iluvatar.ai/vcuda-memory')
 
 - set the 'iluvatarResourceMem' and 'iluvatarResourceCore' parameters when install hami

--- a/versioned_docs/version-v2.5.0/userguide/mthreads-device/enable-mthreads-gpu-sharing.md
+++ b/versioned_docs/version-v2.5.0/userguide/mthreads-device/enable-mthreads-gpu-sharing.md
@@ -31,8 +31,11 @@ title: Enable Mthreads GPU sharing
 
 - Deploy MT-CloudNative Toolkit on mthreads nodes (Please consult your device provider to acquire its package and document)
 
-> **NOTICE:** *You can remove mt-mutating-webhook and mt-gpu-scheduler after installation(optional).*
+:::note
 
+You can remove mt-mutating-webhook and mt-gpu-scheduler after installation(optional).
+
+:::
 - set the 'devices.mthreads.enabled = true' when installing hami
 
 ```

--- a/versioned_docs/version-v2.5.0/userguide/volcano-vgpu/nvidia-gpu/how-to-use-volcano-vgpu.md
+++ b/versioned_docs/version-v2.5.0/userguide/volcano-vgpu/nvidia-gpu/how-to-use-volcano-vgpu.md
@@ -117,9 +117,11 @@ EOF
 
 You can validate device memory using nvidia-smi inside container:
 
-> **WARNING:** *if you don't request GPUs when using the device plugin with NVIDIA images all
-> the GPUs on the machine will be exposed inside your container.
-> The number of vgpu used by a container can not exceed the number of gpus on that node.*
+:::warning
+
+if you don't request GPUs when using the device plugin with NVIDIA images all the GPUs on the machine will be exposed inside your container. The number of vgpu used by a container can not exceed the number of gpus on that node.
+
+:::
 
 ### Monitor
 

--- a/versioned_docs/version-v2.5.1/installation/upgrade.md
+++ b/versioned_docs/version-v2.5.1/installation/upgrade.md
@@ -10,4 +10,8 @@ helm repo update
 helm install hami hami-charts/hami -n kube-system
 ```
 
-> **WARNING:** *If you upgrade HAMi without clearing your submitted tasks, it may result in segmentation fault.*
+:::warning
+
+If you upgrade HAMi without clearing your submitted tasks, it may result in segmentation fault.
+
+:::

--- a/versioned_docs/version-v2.5.1/installation/webui-installation.md
+++ b/versioned_docs/version-v2.5.1/installation/webui-installation.md
@@ -42,8 +42,9 @@ To add the HAMi WebUI Helm repository and install the chart on your machine, fol
    helm install my-hami-webui hami-webui/hami-webui --set externalPrometheus.enabled=true --set externalPrometheus.address="http://prometheus-kube-prometheus-prometheus.monitoring.svc.cluster.local:9090" -n kube-system
    ```
 
-   > _**Important**_: Replace `externalPrometheus.address` with the in-cluster Prometheus URL that your environment uses.
-
+   :::caution
+   Replace `externalPrometheus.address` with the in-cluster Prometheus URL that your environment uses.
+   :::
    You can set other values from [values.yaml](https://github.com/Project-HAMi/HAMi-WebUI/blob/main/charts/hami-webui/values.yaml) during installation; see the configuration [documentation](https://github.com/Project-HAMi/HAMi-WebUI/blob/main/charts/hami-webui/README.md#values).
 
 3. Verify the installation:

--- a/versioned_docs/version-v2.5.1/userguide/mthreads-device/enable-mthreads-gpu-sharing.md
+++ b/versioned_docs/version-v2.5.1/userguide/mthreads-device/enable-mthreads-gpu-sharing.md
@@ -31,8 +31,11 @@ title: Enable Mthreads GPU sharing
 
 - Deploy MT-CloudNative Toolkit on mthreads nodes (Please consult your device provider to acquire its package and document)
 
-> **NOTICE:** *You can remove mt-mutating-webhook and mt-gpu-scheduler after installation(optional).*
+:::note
 
+You can remove mt-mutating-webhook and mt-gpu-scheduler after installation(optional).
+
+:::
 - set the 'devices.mthreads.enabled = true' when installing hami
 
 ```

--- a/versioned_docs/version-v2.6.0/installation/upgrade.md
+++ b/versioned_docs/version-v2.6.0/installation/upgrade.md
@@ -10,4 +10,8 @@ helm repo update
 helm install hami hami-charts/hami -n kube-system
 ```
 
-> **WARNING:** *If you upgrade HAMi without clearing your submitted tasks, it may result in segmentation fault.*
+:::warning
+
+If you upgrade HAMi without clearing your submitted tasks, it may result in segmentation fault.
+
+:::

--- a/versioned_docs/version-v2.6.0/installation/webui-installation.md
+++ b/versioned_docs/version-v2.6.0/installation/webui-installation.md
@@ -42,8 +42,9 @@ To add the HAMi WebUI Helm repository and install the chart on your machine, fol
    helm install my-hami-webui hami-webui/hami-webui --set externalPrometheus.enabled=true --set externalPrometheus.address="http://prometheus-kube-prometheus-prometheus.monitoring.svc.cluster.local:9090" -n kube-system
    ```
 
-   > _**Important**_: Replace `externalPrometheus.address` with the in-cluster Prometheus URL that your environment uses.
-
+   :::caution
+   Replace `externalPrometheus.address` with the in-cluster Prometheus URL that your environment uses.
+   :::
    You can set other values from [values.yaml](https://github.com/Project-HAMi/HAMi-WebUI/blob/main/charts/hami-webui/values.yaml) during installation; see the configuration [documentation](https://github.com/Project-HAMi/HAMi-WebUI/blob/main/charts/hami-webui/README.md#values).
 
 3. Verify the installation:

--- a/versioned_docs/version-v2.7.0/installation/upgrade.md
+++ b/versioned_docs/version-v2.7.0/installation/upgrade.md
@@ -10,4 +10,8 @@ helm repo update
 helm install hami hami-charts/hami -n kube-system
 ```
 
-> **WARNING:** *If you upgrade HAMi without clearing your submitted tasks, it may result in segmentation fault.*
+:::warning
+
+If you upgrade HAMi without clearing your submitted tasks, it may result in segmentation fault.
+
+:::

--- a/versioned_docs/version-v2.7.0/installation/webui-installation.md
+++ b/versioned_docs/version-v2.7.0/installation/webui-installation.md
@@ -42,8 +42,9 @@ To add the HAMi WebUI Helm repository and install the chart on your machine, fol
    helm install my-hami-webui hami-webui/hami-webui --set externalPrometheus.enabled=true --set externalPrometheus.address="http://prometheus-kube-prometheus-prometheus.monitoring.svc.cluster.local:9090" -n kube-system
    ```
 
-   > _**Important**_: Replace `externalPrometheus.address` with the in-cluster Prometheus URL that your environment uses.
-
+   :::caution
+   Replace `externalPrometheus.address` with the in-cluster Prometheus URL that your environment uses.
+   :::
    You can set other values from [values.yaml](https://github.com/Project-HAMi/HAMi-WebUI/blob/main/charts/hami-webui/values.yaml) during installation; see the configuration [documentation](https://github.com/Project-HAMi/HAMi-WebUI/blob/main/charts/hami-webui/README.md#values).
 
 3. Verify the installation:

--- a/versioned_docs/version-v2.8.0/installation/webui-installation.md
+++ b/versioned_docs/version-v2.8.0/installation/webui-installation.md
@@ -42,8 +42,9 @@ To add the HAMi WebUI Helm repository and install the chart on your machine, fol
    helm install my-hami-webui hami-webui/hami-webui --set externalPrometheus.enabled=true --set externalPrometheus.address="http://prometheus-kube-prometheus-prometheus.monitoring.svc.cluster.local:9090" -n kube-system
    ```
 
-   > _**Important**_: Replace `externalPrometheus.address` with the in-cluster Prometheus URL that your environment uses.
-
+   :::caution
+   Replace `externalPrometheus.address` with the in-cluster Prometheus URL that your environment uses.
+   :::
    You can set other values from [values.yaml](https://github.com/Project-HAMi/HAMi-WebUI/blob/main/charts/hami-webui/values.yaml) during installation; see the configuration [documentation](https://github.com/Project-HAMi/HAMi-WebUI/blob/main/charts/hami-webui/README.md#values).
 
 3. Verify the installation:

--- a/versioned_docs/version-v2.8.0/userguide/ascend-device/examples/allocate-310p.md
+++ b/versioned_docs/version-v2.8.0/userguide/ascend-device/examples/allocate-310p.md
@@ -21,8 +21,11 @@ spec:
           huawei.com/Ascend310P-memory: 2000 # requesting 2000m device memory
 ```
 
-> **NOTICE:** *Compute resource of Ascend310P is also limited with `huawei.com/Ascend310P-memory`, equal to the percentage of device memory allocated.*
+:::note
 
+Compute resource of Ascend310P is also limited with `huawei.com/Ascend310P-memory`, equal to the percentage of device memory allocated.
+
+:::
 ## Select Device by UUID
 
 You can specify which Ascend devices a pod uses or excludes by using annotations:

--- a/versioned_docs/version-v2.8.0/userguide/ascend-device/examples/allocate-910b.md
+++ b/versioned_docs/version-v2.8.0/userguide/ascend-device/examples/allocate-910b.md
@@ -21,8 +21,11 @@ spec:
           huawei.com/Ascend910B-memory: 2000 # requesting 2000m device memory
 ```
 
-> **NOTICE:** *Compute resource of Ascend910B is also limited with `huawei.com/Ascend910B-memory`, equal to the percentage of device memory allocated.*
+:::note
 
+Compute resource of Ascend910B is also limited with `huawei.com/Ascend910B-memory`, equal to the percentage of device memory allocated.
+
+:::
 ## Select Device by UUID
 
 You can specify which Ascend devices a pod uses or excludes by using annotations:

--- a/versioned_docs/version-v2.8.0/userguide/awsneuron-device/enable-awsneuron-managing.md
+++ b/versioned_docs/version-v2.8.0/userguide/awsneuron-device/enable-awsneuron-managing.md
@@ -109,8 +109,11 @@ spec:
   # ... rest of pod spec
 ```
 
-> **NOTICE:** The device ID format is `{node-name}-AWSNeuron-{index}`. You can find the available device IDs in the node annotations.
+:::note
 
+The device ID format is `{node-name}-AWSNeuron-{index}`. You can find the available device IDs in the node annotations.
+
+:::
 ### Finding Device UUIDs
 
 You can find the UUIDs of AWS Neuron devices on a node using the following command:

--- a/versioned_docs/version-v2.8.0/userguide/enflame-device/enable-enflame-gcu-sharing.md
+++ b/versioned_docs/version-v2.8.0/userguide/enflame-device/enable-enflame-gcu-sharing.md
@@ -26,13 +26,21 @@ title: Enable Enflame GPU Sharing
 
 * Deploy gcushare-device-plugin on enflame nodes (Please consult your device provider to acquire its package and document)
 
-> **NOTICE:** *Install only gpushare-device-plugin, don't install gpu-scheduler-plugin package.*
-> **NOTICE:** The default resource names are:
->
-> * `enflame.com/vgcu` for GCU count, only support 1 now.
-> * `enflame.com/vgcu-percentage` for the percentage of memory and cores in a gcu slice.
->
-> You can customize these names by modifying `hami-scheduler-device` configMap above.
+:::note
+
+Install only gpushare-device-plugin, don't install gpu-scheduler-plugin package.
+
+:::
+:::note
+
+The default resource names are:
+
+- `enflame.com/vgcu` for GCU count, only support 1 now.
+- `enflame.com/vgcu-percentage` for the percentage of memory and cores in a gcu slice.
+
+You can customize these names by modifying `hami-scheduler-device` configMap above.
+
+:::
 
 * Set 'devices.enflame.enabled=true' when deploy HAMi
 
@@ -78,8 +86,11 @@ spec:
           enflame.com/vgcu-percentage: 22
 ```
 
-> **NOTICE:** *You can find more examples in [examples/enflame folder](https://github.com/Project-HAMi/HAMi/tree/master/examples/enflame/)*
+:::note
 
+You can find more examples in [examples/enflame folder](https://github.com/Project-HAMi/HAMi/tree/master/examples/enflame/)
+
+:::
 ## Device UUID Selection
 
 You can specify which GPU devices to use or exclude using annotations:
@@ -98,8 +109,11 @@ spec:
   # ... rest of pod spec
 ```
 
-> **NOTICE:** The device ID format is `{node-name}-enflame-{index}`. You can find the available device IDs in the node status.
+:::note
 
+The device ID format is `{node-name}-enflame-{index}`. You can find the available device IDs in the node status.
+
+:::
 ### Finding Device UUIDs
 
 You can find the UUIDs of Enflame GCUs on a node using the following command:

--- a/versioned_docs/version-v2.8.0/userguide/iluvatar-device/examples/allocate-bi-v150.md
+++ b/versioned_docs/version-v2.8.0/userguide/iluvatar-device/examples/allocate-bi-v150.md
@@ -36,4 +36,8 @@ spec:
         iluvatar.ai/BI-V150.vMem: 64
 ```
 
-> **NOTICE:** *Each `iluvatar.ai/<card-type>.vCore` unit represents 1% of an available compute core, and each `iluvatar.ai/<card-type>.vMem` unit represents 256MB of device memory*
+:::note
+
+Each `iluvatar.ai/<card-type>.vCore` unit represents 1% of an available compute core, and each `iluvatar.ai/<card-type>.vMem` unit represents 256MB of device memory
+
+:::

--- a/versioned_docs/version-v2.8.0/userguide/iluvatar-device/examples/allocate-mr-v100.md
+++ b/versioned_docs/version-v2.8.0/userguide/iluvatar-device/examples/allocate-mr-v100.md
@@ -37,4 +37,8 @@ spec:
         iluvatar.ai/MR-V100.vMem: 64
 ```
 
-> **NOTICE:** *Each `iluvatar.ai/<card-type>.vCore` unit represents 1% of an available compute core, and each `iluvatar.ai/<card-type>.vMem` unit represents 256MB of device memory*
+:::note
+
+Each `iluvatar.ai/<card-type>.vCore` unit represents 1% of an available compute core, and each `iluvatar.ai/<card-type>.vMem` unit represents 256MB of device memory
+
+:::

--- a/versioned_docs/version-v2.8.0/userguide/metax-device/metax-gpu/enable-metax-gpu-schedule.md
+++ b/versioned_docs/version-v2.8.0/userguide/metax-device/metax-gpu/enable-metax-gpu-schedule.md
@@ -67,4 +67,8 @@ spec:
           metax-tech.com/gpu: 1 # requesting 1 GPU
 ```
 
-> **NOTICE:** *You can find more examples in [examples/metax folder](https://github.com/Project-HAMi/HAMi/tree/master/examples/metax/gpu)*
+:::note
+
+You can find more examples in [examples/metax folder](https://github.com/Project-HAMi/HAMi/tree/master/examples/metax/gpu)
+
+:::

--- a/versioned_docs/version-v2.8.0/userguide/metax-device/metax-sgpu/enable-metax-gpu-sharing.md
+++ b/versioned_docs/version-v2.8.0/userguide/metax-device/metax-sgpu/enable-metax-gpu-sharing.md
@@ -46,4 +46,8 @@ spec:
           metax-tech.com/vmemory: 4 # each GPU require 4 GiB device memory
 ```
 
-> **NOTICE:** *You can find more examples in [examples/metax folder](https://github.com/Project-HAMi/HAMi/tree/master/examples/metax/sgpu)*
+:::note
+
+You can find more examples in [examples/metax folder](https://github.com/Project-HAMi/HAMi/tree/master/examples/metax/sgpu)
+
+:::

--- a/versioned_docs/version-v2.8.0/userguide/metax-device/metax-sgpu/examples/default-use.md
+++ b/versioned_docs/version-v2.8.0/userguide/metax-device/metax-sgpu/examples/default-use.md
@@ -23,4 +23,8 @@ spec:
           metax-tech.com/vmemory: 4 # each GPU require 4 GiB device memory
 ```
 
-> **NOTICE:** *When a `metax-tech.com/vcore` or `metax-tech.com/vmemory` resource is not applied for, it indicates that the quota for the corresponding resource is full*
+:::note
+
+When a `metax-tech.com/vcore` or `metax-tech.com/vmemory` resource is not applied for, it indicates that the quota for the corresponding resource is full
+
+:::

--- a/versioned_docs/version-v2.8.0/userguide/mthreads-device/enable-mthreads-gpu-sharing.md
+++ b/versioned_docs/version-v2.8.0/userguide/mthreads-device/enable-mthreads-gpu-sharing.md
@@ -31,8 +31,11 @@ title: Enable Mthreads GPU sharing
 
 * Deploy MT-CloudNative Toolkit on mthreads nodes (Please consult your device provider to acquire its package and document)
 
-> **NOTICE:** *You can remove mt-mutating-webhook and mt-gpu-scheduler after installation(optional).*
+:::note
 
+You can remove mt-mutating-webhook and mt-gpu-scheduler after installation(optional).
+
+:::
 * set the 'devices.mthreads.enabled = true' when installing hami
 
 ```bash

--- a/versioned_docs/version-v2.8.0/userguide/nvidia-device/examples/allocate-device-core.md
+++ b/versioned_docs/version-v2.8.0/userguide/nvidia-device/examples/allocate-device-core.md
@@ -21,4 +21,8 @@ spec:
           nvidia.com/gpucores: 50 # requesting 50% of each vGPU's core resources
 ```
 
-> **NOTICE:** *HAMi implements `nvidia.com/gpucores` using time-slice, Therefore, when the core utilization is queried through the nvidia-smi command, there will be fluctuations*
+:::note
+
+HAMi implements `nvidia.com/gpucores` using time-slice, Therefore, when the core utilization is queried through the nvidia-smi command, there will be fluctuations
+
+:::

--- a/versioned_docs/version-v2.8.0/userguide/nvidia-device/examples/allocate-device-memory.md
+++ b/versioned_docs/version-v2.8.0/userguide/nvidia-device/examples/allocate-device-memory.md
@@ -21,4 +21,8 @@ spec:
           nvidia.com/gpumem: 3000 # each vGPU requests 3G device memory
 ```
 
-> **NOTICE:** *`nvidia.com/gpumem` can't be used together with `nvidia.com/gpumem-percentage`*
+:::note
+
+`nvidia.com/gpumem` can't be used together with `nvidia.com/gpumem-percentage`
+
+:::

--- a/versioned_docs/version-v2.8.0/userguide/nvidia-device/examples/allocate-device-memory2.md
+++ b/versioned_docs/version-v2.8.0/userguide/nvidia-device/examples/allocate-device-memory2.md
@@ -21,4 +21,8 @@ spec:
           nvidia.com/gpumem-percentage: 50 # each vGPU requests 50% of device memory
 ```
 
-> **NOTICE:** *`nvidia.com/gpumem` can't be used together with `nvidia.com/gpumem-percentage`*
+:::note
+
+`nvidia.com/gpumem` can't be used together with `nvidia.com/gpumem-percentage`
+
+:::

--- a/versioned_docs/version-v2.8.0/userguide/nvidia-device/examples/specify-card-type-to-use.md
+++ b/versioned_docs/version-v2.8.0/userguide/nvidia-device/examples/specify-card-type-to-use.md
@@ -22,4 +22,8 @@ spec:
           nvidia.com/gpu: 2 # requesting 2 vGPUs
 ```
 
-> **NOTICE:** *You can assign this task to multiple GPU types, use comma to separate. In this example, the job runs on A100 or V100.*
+:::note
+
+You can assign this task to multiple GPU types, use comma to separate. In this example, the job runs on A100 or V100.
+
+:::

--- a/versioned_docs/version-v2.8.0/userguide/nvidia-device/specify-device-core-usage.md
+++ b/versioned_docs/version-v2.8.0/userguide/nvidia-device/specify-device-core-usage.md
@@ -13,4 +13,8 @@ Optional, each unit of `nvidia.com/gpucores` equals 1% of device cores.
           nvidia.com/gpucores: 50 # Each GPU allocates 50% device cores.
 ```
 
-> **NOTICE:** *HAMi-core uses time-slice to limit device core usage. Therefore, there will be fluctuations when looking at GPU utilization through nvidia-smi*
+:::note
+
+HAMi-core uses time-slice to limit device core usage. Therefore, there will be fluctuations when looking at GPU utilization through nvidia-smi
+
+:::

--- a/versioned_docs/version-v2.8.0/userguide/nvidia-device/specify-device-memory-usage.md
+++ b/versioned_docs/version-v2.8.0/userguide/nvidia-device/specify-device-memory-usage.md
@@ -23,4 +23,8 @@ Optional, each unit of `nvidia.com/gpumem-percentage` equals 1% of device memory
           nvidia.com/gpumem-percentage: 50 # Each GPU contains 50% device memory
 ```
 
-> **NOTICE:** *`nvidia.com/gpumem` and `nvidia.com/gpumem-percentage` can't be assigned together*
+:::note
+
+`nvidia.com/gpumem` and `nvidia.com/gpumem-percentage` can't be assigned together
+
+:::

--- a/versioned_docs/version-v2.8.0/userguide/nvidia-device/specify-device-uuid-to-use.md
+++ b/versioned_docs/version-v2.8.0/userguide/nvidia-device/specify-device-uuid-to-use.md
@@ -13,4 +13,8 @@ metadata:
     nvidia.com/use-gpuuuid: "GPU-123456"
 ```
 
-> **NOTICE:** *Each GPU UUID is unique in a cluster, so assign a certain UUID means assigning this task to certain node with that GPU*
+:::note
+
+Each GPU UUID is unique in a cluster, so assign a certain UUID means assigning this task to certain node with that GPU
+
+:::


### PR DESCRIPTION
Converts 48 remaining informal blockquotes to Docusaurus admonitions across docs/, versioned_docs/, and i18n/. WARNING blocks become :::warning, NOTICE blocks become :::note, and Important blocks become :::caution. No content changes.