### PR TITLE
fix: wrap bare Helm chart URL in markdown link in webui-installation docs

### DIFF
--- a/docs/installation/webui-installation.md
+++ b/docs/installation/webui-installation.md
@@ -7,8 +7,7 @@ This section describes how to deploy and run HAMi WebUI on a Kubernetes cluster 
 
 HAMi WebUI is exposed via localhost only. After deployment, you need to configure your local `~/.kube/config` file to connect to the target cluster and access the WebUI.
 
-The official repository provides the Helm chart for deploying HAMi WebUI:
-https://github.com/Project-HAMi/HAMi-WebUI/tree/main/charts/hami-webui
+The official repository provides the [Helm chart](https://github.com/Project-HAMi/HAMi-WebUI/tree/main/charts/hami-webui) for deploying HAMi WebUI.
 
 If you encounter any issues, please open an issue in the [HAMi-WebUI](https://github.com/Project-HAMi/HAMi-WebUI) repository.
 

--- a/i18n/zh/docusaurus-plugin-content-docs/current/installation/webui-installation.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/current/installation/webui-installation.md
@@ -8,8 +8,7 @@ title: 使用 Helm Charts 部署 HAMi WebUI
 
 HAMi WebUI 默认仅通过本地访问（localhost）提供服务，因此在部署完成后，需要通过配置本地 `~/.kube/config` 文件以连接目标集群并访问 WebUI。
 
-官方仓库提供了用于部署 HAMi WebUI 的 Helm Chart，详见：
-https://github.com/Project-HAMi/HAMi-WebUI/tree/main/charts/hami-webui
+官方仓库提供了用于部署 HAMi WebUI 的 [Helm Chart](https://github.com/Project-HAMi/HAMi-WebUI/tree/main/charts/hami-webui)。
 
 如在使用过程中遇到问题，可在 [HAMi-WebUI](https://github.com/Project-HAMi/HAMi-WebUI) 仓库提交 Issue 进行反馈。
 

--- a/i18n/zh/docusaurus-plugin-content-docs/version-v1.3.0/installation/webui-installation.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/version-v1.3.0/installation/webui-installation.md
@@ -8,8 +8,7 @@ title: 使用 Helm Charts 部署 HAMi WebUI
 
 HAMi WebUI 默认仅通过本地访问（localhost）提供服务，因此在部署完成后，需要通过配置本地 `~/.kube/config` 文件以连接目标集群并访问 WebUI。
 
-官方仓库提供了用于部署 HAMi WebUI 的 Helm Chart，详见：
-https://github.com/Project-HAMi/HAMi-WebUI/tree/main/charts/hami-webui
+官方仓库提供了用于部署 HAMi WebUI 的 [Helm Chart](https://github.com/Project-HAMi/HAMi-WebUI/tree/main/charts/hami-webui)。
 
 如在使用过程中遇到问题，可在 [HAMi-WebUI](https://github.com/Project-HAMi/HAMi-WebUI) 仓库提交 Issue 进行反馈。
 

--- a/i18n/zh/docusaurus-plugin-content-docs/version-v2.4.1/installation/webui-installation.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/version-v2.4.1/installation/webui-installation.md
@@ -8,8 +8,7 @@ title: 使用 Helm Charts 部署 HAMi WebUI
 
 HAMi WebUI 默认仅通过本地访问（localhost）提供服务，因此在部署完成后，需要通过配置本地 `~/.kube/config` 文件以连接目标集群并访问 WebUI。
 
-官方仓库提供了用于部署 HAMi WebUI 的 Helm Chart，详见：
-https://github.com/Project-HAMi/HAMi-WebUI/tree/main/charts/hami-webui
+官方仓库提供了用于部署 HAMi WebUI 的 [Helm Chart](https://github.com/Project-HAMi/HAMi-WebUI/tree/main/charts/hami-webui)。
 
 如在使用过程中遇到问题，可在 [HAMi-WebUI](https://github.com/Project-HAMi/HAMi-WebUI) 仓库提交 Issue 进行反馈。
 

--- a/i18n/zh/docusaurus-plugin-content-docs/version-v2.5.0/installation/webui-installation.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/version-v2.5.0/installation/webui-installation.md
@@ -8,8 +8,7 @@ title: 使用 Helm Charts 部署 HAMi WebUI
 
 HAMi WebUI 默认仅通过本地访问（localhost）提供服务，因此在部署完成后，需要通过配置本地 `~/.kube/config` 文件以连接目标集群并访问 WebUI。
 
-官方仓库提供了用于部署 HAMi WebUI 的 Helm Chart，详见：
-https://github.com/Project-HAMi/HAMi-WebUI/tree/main/charts/hami-webui
+官方仓库提供了用于部署 HAMi WebUI 的 [Helm Chart](https://github.com/Project-HAMi/HAMi-WebUI/tree/main/charts/hami-webui)。
 
 如在使用过程中遇到问题，可在 [HAMi-WebUI](https://github.com/Project-HAMi/HAMi-WebUI) 仓库提交 Issue 进行反馈。
 

--- a/i18n/zh/docusaurus-plugin-content-docs/version-v2.5.1/installation/webui-installation.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/version-v2.5.1/installation/webui-installation.md
@@ -8,8 +8,7 @@ title: 使用 Helm Charts 部署 HAMi WebUI
 
 HAMi WebUI 默认仅通过本地访问（localhost）提供服务，因此在部署完成后，需要通过配置本地 `~/.kube/config` 文件以连接目标集群并访问 WebUI。
 
-官方仓库提供了用于部署 HAMi WebUI 的 Helm Chart，详见：
-https://github.com/Project-HAMi/HAMi-WebUI/tree/main/charts/hami-webui
+官方仓库提供了用于部署 HAMi WebUI 的 [Helm Chart](https://github.com/Project-HAMi/HAMi-WebUI/tree/main/charts/hami-webui)。
 
 如在使用过程中遇到问题，可在 [HAMi-WebUI](https://github.com/Project-HAMi/HAMi-WebUI) 仓库提交 Issue 进行反馈。
 

--- a/i18n/zh/docusaurus-plugin-content-docs/version-v2.6.0/installation/webui-installation.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/version-v2.6.0/installation/webui-installation.md
@@ -8,8 +8,7 @@ title: 使用 Helm Charts 部署 HAMi WebUI
 
 HAMi WebUI 默认仅通过本地访问（localhost）提供服务，因此在部署完成后，需要通过配置本地 `~/.kube/config` 文件以连接目标集群并访问 WebUI。
 
-官方仓库提供了用于部署 HAMi WebUI 的 Helm Chart，详见：
-https://github.com/Project-HAMi/HAMi-WebUI/tree/main/charts/hami-webui
+官方仓库提供了用于部署 HAMi WebUI 的 [Helm Chart](https://github.com/Project-HAMi/HAMi-WebUI/tree/main/charts/hami-webui)。
 
 如在使用过程中遇到问题，可在 [HAMi-WebUI](https://github.com/Project-HAMi/HAMi-WebUI) 仓库提交 Issue 进行反馈。
 

--- a/i18n/zh/docusaurus-plugin-content-docs/version-v2.7.0/installation/webui-installation.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/version-v2.7.0/installation/webui-installation.md
@@ -8,8 +8,7 @@ title: 使用 Helm Charts 部署 HAMi WebUI
 
 HAMi WebUI 默认仅通过本地访问（localhost）提供服务，因此在部署完成后，需要通过配置本地 `~/.kube/config` 文件以连接目标集群并访问 WebUI。
 
-官方仓库提供了用于部署 HAMi WebUI 的 Helm Chart，详见：
-https://github.com/Project-HAMi/HAMi-WebUI/tree/main/charts/hami-webui
+官方仓库提供了用于部署 HAMi WebUI 的 [Helm Chart](https://github.com/Project-HAMi/HAMi-WebUI/tree/main/charts/hami-webui)。
 
 如在使用过程中遇到问题，可在 [HAMi-WebUI](https://github.com/Project-HAMi/HAMi-WebUI) 仓库提交 Issue 进行反馈。
 

--- a/i18n/zh/docusaurus-plugin-content-docs/version-v2.8.0/installation/webui-installation.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/version-v2.8.0/installation/webui-installation.md
@@ -8,8 +8,7 @@ title: 使用 Helm Charts 部署 HAMi WebUI
 
 HAMi WebUI 默认仅通过本地访问（localhost）提供服务，因此在部署完成后，需要通过配置本地 `~/.kube/config` 文件以连接目标集群并访问 WebUI。
 
-官方仓库提供了用于部署 HAMi WebUI 的 Helm Chart，详见：
-https://github.com/Project-HAMi/HAMi-WebUI/tree/main/charts/hami-webui
+官方仓库提供了用于部署 HAMi WebUI 的 [Helm Chart](https://github.com/Project-HAMi/HAMi-WebUI/tree/main/charts/hami-webui)。
 
 如在使用过程中遇到问题，可在 [HAMi-WebUI](https://github.com/Project-HAMi/HAMi-WebUI) 仓库提交 Issue 进行反馈。
 

--- a/versioned_docs/version-v1.3.0/installation/webui-installation.md
+++ b/versioned_docs/version-v1.3.0/installation/webui-installation.md
@@ -7,8 +7,7 @@ This section describes how to deploy and run HAMi WebUI on a Kubernetes cluster 
 
 HAMi WebUI is exposed via localhost only. After deployment, you need to configure your local `~/.kube/config` file to connect to the target cluster and access the WebUI.
 
-The official repository provides the Helm chart for deploying HAMi WebUI:
-https://github.com/Project-HAMi/HAMi-WebUI/tree/main/charts/hami-webui
+The official repository provides the [Helm chart](https://github.com/Project-HAMi/HAMi-WebUI/tree/main/charts/hami-webui) for deploying HAMi WebUI.
 
 If you encounter any issues, please open an issue in the [HAMi-WebUI](https://github.com/Project-HAMi/HAMi-WebUI) repository.
 

--- a/versioned_docs/version-v2.4.1/installation/webui-installation.md
+++ b/versioned_docs/version-v2.4.1/installation/webui-installation.md
@@ -7,8 +7,7 @@ This section describes how to deploy and run HAMi WebUI on a Kubernetes cluster 
 
 HAMi WebUI is exposed via localhost only. After deployment, you need to configure your local `~/.kube/config` file to connect to the target cluster and access the WebUI.
 
-The official repository provides the Helm chart for deploying HAMi WebUI:
-https://github.com/Project-HAMi/HAMi-WebUI/tree/main/charts/hami-webui
+The official repository provides the [Helm chart](https://github.com/Project-HAMi/HAMi-WebUI/tree/main/charts/hami-webui) for deploying HAMi WebUI.
 
 If you encounter any issues, please open an issue in the [HAMi-WebUI](https://github.com/Project-HAMi/HAMi-WebUI) repository.
 

--- a/versioned_docs/version-v2.5.0/installation/webui-installation.md
+++ b/versioned_docs/version-v2.5.0/installation/webui-installation.md
@@ -7,8 +7,7 @@ This section describes how to deploy and run HAMi WebUI on a Kubernetes cluster 
 
 HAMi WebUI is exposed via localhost only. After deployment, you need to configure your local `~/.kube/config` file to connect to the target cluster and access the WebUI.
 
-The official repository provides the Helm chart for deploying HAMi WebUI:
-https://github.com/Project-HAMi/HAMi-WebUI/tree/main/charts/hami-webui
+The official repository provides the [Helm chart](https://github.com/Project-HAMi/HAMi-WebUI/tree/main/charts/hami-webui) for deploying HAMi WebUI.
 
 If you encounter any issues, please open an issue in the [HAMi-WebUI](https://github.com/Project-HAMi/HAMi-WebUI) repository.
 

--- a/versioned_docs/version-v2.5.1/installation/webui-installation.md
+++ b/versioned_docs/version-v2.5.1/installation/webui-installation.md
@@ -7,8 +7,7 @@ This section describes how to deploy and run HAMi WebUI on a Kubernetes cluster 
 
 HAMi WebUI is exposed via localhost only. After deployment, you need to configure your local `~/.kube/config` file to connect to the target cluster and access the WebUI.
 
-The official repository provides the Helm chart for deploying HAMi WebUI:
-https://github.com/Project-HAMi/HAMi-WebUI/tree/main/charts/hami-webui
+The official repository provides the [Helm chart](https://github.com/Project-HAMi/HAMi-WebUI/tree/main/charts/hami-webui) for deploying HAMi WebUI.
 
 If you encounter any issues, please open an issue in the [HAMi-WebUI](https://github.com/Project-HAMi/HAMi-WebUI) repository.
 

--- a/versioned_docs/version-v2.6.0/installation/webui-installation.md
+++ b/versioned_docs/version-v2.6.0/installation/webui-installation.md
@@ -7,8 +7,7 @@ This section describes how to deploy and run HAMi WebUI on a Kubernetes cluster 
 
 HAMi WebUI is exposed via localhost only. After deployment, you need to configure your local `~/.kube/config` file to connect to the target cluster and access the WebUI.
 
-The official repository provides the Helm chart for deploying HAMi WebUI:
-https://github.com/Project-HAMi/HAMi-WebUI/tree/main/charts/hami-webui
+The official repository provides the [Helm chart](https://github.com/Project-HAMi/HAMi-WebUI/tree/main/charts/hami-webui) for deploying HAMi WebUI.
 
 If you encounter any issues, please open an issue in the [HAMi-WebUI](https://github.com/Project-HAMi/HAMi-WebUI) repository.
 

--- a/versioned_docs/version-v2.7.0/installation/webui-installation.md
+++ b/versioned_docs/version-v2.7.0/installation/webui-installation.md
@@ -7,8 +7,7 @@ This section describes how to deploy and run HAMi WebUI on a Kubernetes cluster 
 
 HAMi WebUI is exposed via localhost only. After deployment, you need to configure your local `~/.kube/config` file to connect to the target cluster and access the WebUI.
 
-The official repository provides the Helm chart for deploying HAMi WebUI:
-https://github.com/Project-HAMi/HAMi-WebUI/tree/main/charts/hami-webui
+The official repository provides the [Helm chart](https://github.com/Project-HAMi/HAMi-WebUI/tree/main/charts/hami-webui) for deploying HAMi WebUI.
 
 If you encounter any issues, please open an issue in the [HAMi-WebUI](https://github.com/Project-HAMi/HAMi-WebUI) repository.
 

--- a/versioned_docs/version-v2.8.0/installation/webui-installation.md
+++ b/versioned_docs/version-v2.8.0/installation/webui-installation.md
@@ -7,8 +7,7 @@ This section describes how to deploy and run HAMi WebUI on a Kubernetes cluster 
 
 HAMi WebUI is exposed via localhost only. After deployment, you need to configure your local `~/.kube/config` file to connect to the target cluster and access the WebUI.
 
-The official repository provides the Helm chart for deploying HAMi WebUI:
-https://github.com/Project-HAMi/HAMi-WebUI/tree/main/charts/hami-webui
+The official repository provides the [Helm chart](https://github.com/Project-HAMi/HAMi-WebUI/tree/main/charts/hami-webui) for deploying HAMi WebUI.
 
 If you encounter any issues, please open an issue in the [HAMi-WebUI](https://github.com/Project-HAMi/HAMi-WebUI) repository.
 


### PR DESCRIPTION
- Replaces a bare `https://github.com/Project-HAMi/HAMi-WebUI/tree/main/charts/hami-webui` URL with a proper markdown link in all `webui-installation.md` files
- Affects 8 English versioned docs and 8 Chinese i18n files (16 files total)
- No content changes
