### PR TITLE
fix: replace vague filler language in faq and release blog

### DIFF
--- a/blog/hami-v2-9-0-release/index.md
+++ b/blog/hami-v2-9-0-release/index.md
@@ -130,7 +130,7 @@ resources:
 #   vastaitech.com/nouse-va: "1"
 ```
 
-With Vastai device support, HAMi now covers over a dozen heterogeneous compute devices including **NVIDIA, Huawei Ascend, Cambricon, Hygon DCU, Biren, Enflame, MetaX, Kunlunxin, AMD, Iluvatar, Enflame, AWS Neuron, and Vastai Technologies**, making it one of the most comprehensive heterogeneous device virtualization and scheduling projects in the Kubernetes ecosystem.
+With Vastai device support, HAMi now covers over a dozen heterogeneous compute devices including **NVIDIA, Huawei Ascend, Cambricon, Hygon DCU, Biren, Enflame, MetaX, Kunlunxin, AMD, Iluvatar, Enflame, AWS Neuron, and Vastai Technologies**, making it one of the widest-supported heterogeneous device virtualization and scheduling projects in the Kubernetes ecosystem.
 
 ## Observability and Security Enhancements
 

--- a/docs/faq/faq.md
+++ b/docs/faq/faq.md
@@ -53,7 +53,7 @@ HAMi's native `nvidia.com/priority` field (0 for high, 1 for low/default) is spe
 
 Regarding the scenario where resources are insufficient, 'n' jobs are waiting, and you need to sort them for scheduling based on multiple user-submitted priorities, HAMi's two-level system isn't intended for this broader scheduling requirement.
 
-However, achieving multi-level priority scheduling **is feasible**. The recommended approach is to integrate HAMi with a more comprehensive scheduler like **Volcano**:
+However, achieving multi-level priority scheduling **is feasible**. The recommended approach is to integrate HAMi with a full-featured scheduler like **Volcano**:
 
 1. **Volcano for Multi-Level Scheduling Priority**:
     1. Volcano allows you to define multiple queues with different priority levels.

--- a/i18n/zh/docusaurus-plugin-content-docs/version-v1.3.0/faq/faq.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/version-v1.3.0/faq/faq.md
@@ -27,7 +27,7 @@ It's worth noting that not all controllers are needed by Karmada, for the recomm
 The quick answer is `yes`. In that case, you can save the effort to deploy
 [karmada-apiserver](https://github.com/karmada-io/karmada/blob/master/artifacts/deploy/karmada-apiserver.yaml) and just
 share the APIServer between Kubernetes and Karmada. In addition, the high availability capabilities in the origin clusters
-can be inherited seamlessly. We do have some users using Karmada in this way.
+can be inherited directly. We do have some users using Karmada in this way.
 
 There are some things you should consider before doing so:
 

--- a/i18n/zh/docusaurus-plugin-content-docs/version-v2.4.1/faq/faq.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/version-v2.4.1/faq/faq.md
@@ -25,7 +25,7 @@ It's worth noting that not all controllers are needed by Karmada, for the recomm
 The quick answer is `yes`. In that case, you can save the effort to deploy
 [karmada-apiserver](https://github.com/karmada-io/karmada/blob/master/artifacts/deploy/karmada-apiserver.yaml) and just
 share the APIServer between Kubernetes and Karmada. In addition, the high availability capabilities in the origin clusters
-can be inherited seamlessly. We do have some users using Karmada in this way.
+can be inherited directly. We do have some users using Karmada in this way.
 
 There are some things you should consider before doing so:
 

--- a/i18n/zh/docusaurus-plugin-content-docs/version-v2.5.0/faq/faq.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/version-v2.5.0/faq/faq.md
@@ -25,7 +25,7 @@ It's worth noting that not all controllers are needed by Karmada, for the recomm
 The quick answer is `yes`. In that case, you can save the effort to deploy
 [karmada-apiserver](https://github.com/karmada-io/karmada/blob/master/artifacts/deploy/karmada-apiserver.yaml) and just
 share the APIServer between Kubernetes and Karmada. In addition, the high availability capabilities in the origin clusters
-can be inherited seamlessly. We do have some users using Karmada in this way.
+can be inherited directly. We do have some users using Karmada in this way.
 
 There are some things you should consider before doing so:
 

--- a/versioned_docs/version-v2.6.0/faq/faq.md
+++ b/versioned_docs/version-v2.6.0/faq/faq.md
@@ -54,7 +54,7 @@ HAMi's native `nvidia.com/priority` field (0 for high, 1 for low/default) is spe
 
 Regarding the scenario where resources are insufficient, 'n' jobs are waiting, and you need to sort them for scheduling based on multiple user-submitted priorities, HAMi's two-level system isn't intended for this broader scheduling requirement.
 
-However, achieving multi-level priority scheduling **is feasible**. The recommended approach is to integrate HAMi with a more comprehensive scheduler like **Volcano**:
+However, achieving multi-level priority scheduling **is feasible**. The recommended approach is to integrate HAMi with a full-featured scheduler like **Volcano**:
 
 1. **Volcano for Multi-Level Scheduling Priority**:
     1. Volcano allows you to define multiple queues with different priority levels.

--- a/versioned_docs/version-v2.7.0/faq/faq.md
+++ b/versioned_docs/version-v2.7.0/faq/faq.md
@@ -54,7 +54,7 @@ HAMi's native `nvidia.com/priority` field (0 for high, 1 for low/default) is spe
 
 Regarding the scenario where resources are insufficient, 'n' jobs are waiting, and you need to sort them for scheduling based on multiple user-submitted priorities, HAMi's two-level system isn't intended for this broader scheduling requirement.
 
-However, achieving multi-level priority scheduling **is feasible**. The recommended approach is to integrate HAMi with a more comprehensive scheduler like **Volcano**:
+However, achieving multi-level priority scheduling **is feasible**. The recommended approach is to integrate HAMi with a full-featured scheduler like **Volcano**:
 
 1. **Volcano for Multi-Level Scheduling Priority**:
     1. Volcano allows you to define multiple queues with different priority levels.

--- a/versioned_docs/version-v2.8.0/faq/faq.md
+++ b/versioned_docs/version-v2.8.0/faq/faq.md
@@ -53,7 +53,7 @@ HAMi's native `nvidia.com/priority` field (0 for high, 1 for low/default) is spe
 
 Regarding the scenario where resources are insufficient, 'n' jobs are waiting, and you need to sort them for scheduling based on multiple user-submitted priorities, HAMi's two-level system isn't intended for this broader scheduling requirement.
 
-However, achieving multi-level priority scheduling **is feasible**. The recommended approach is to integrate HAMi with a more comprehensive scheduler like **Volcano**:
+However, achieving multi-level priority scheduling **is feasible**. The recommended approach is to integrate HAMi with a full-featured scheduler like **Volcano**:
 
 1. **Volcano for Multi-Level Scheduling Priority**:
     1. Volcano allows you to define multiple queues with different priority levels.


### PR DESCRIPTION
- Replaces "more comprehensive scheduler" with "full-featured scheduler" in `faq.md` across `docs/` and versioned docs (v2.6.0, v2.7.0, v2.8.0)
- Replaces "inherited seamlessly" with "inherited directly" in Chinese `faq.md` files (v1.3.0, v2.4.1, v2.5.0)
- Replaces "most comprehensive" with "widest-supported" in `blog/hami-v2-9-0-release/index.md`
- 8 files changed, no content meaning altered