### PR TITLE
fix: normalize asterisk list bullets to hyphens in 7 docs files

### DIFF
--- a/docs/userguide/iluvatar-device/enable-iluvatar-gpu-sharing.md
+++ b/docs/userguide/iluvatar-device/enable-iluvatar-gpu-sharing.md
@@ -18,8 +18,8 @@ title: Enable Iluvatar GPU Sharing
 
 ## Prerequisites
 
-* Iluvatar gpu-manager (please consult your device provider)
-* driver version > 3.1.0
+- Iluvatar gpu-manager (please consult your device provider)
+- driver version > 3.1.0
 
 ## Enabling GPU-sharing Support
 
@@ -67,15 +67,15 @@ HAMi divides each Iluvatar GPU into 100 units for resource allocation. When you 
 
 ### Memory Allocation
 
-* Each unit of `iluvatar.ai/<card-type>.vMem` represents 256MB of device memory
-* If you don't specify a memory request, the system will default to using 100% of the available memory
-* Memory allocation is enforced with hard limits to ensure tasks don't exceed their allocated memory
+- Each unit of `iluvatar.ai/<card-type>.vMem` represents 256MB of device memory
+- If you don't specify a memory request, the system will default to using 100% of the available memory
+- Memory allocation is enforced with hard limits to ensure tasks don't exceed their allocated memory
 
 ### Core Allocation
 
-* Each unit of `iluvatar.ai/<card-type>.vCore` represents 1% of the available compute cores
-* Core allocation is enforced with hard limits to ensure tasks don't exceed their allocated cores
-* When requesting multiple GPUs, the system will automatically set the core resources based on the number of GPUs requested
+- Each unit of `iluvatar.ai/<card-type>.vCore` represents 1% of the available compute cores
+- Core allocation is enforced with hard limits to ensure tasks don't exceed their allocated cores
+- When requesting multiple GPUs, the system will automatically set the core resources based on the number of GPUs requested
 
 ## Running Iluvatar jobs
 
@@ -156,7 +156,7 @@ Look for annotations containing device information in the node status.
 
 ## Notes
 
-* You need to set the following prestart command in order for the device-share to work properly
+- You need to set the following prestart command in order for the device-share to work properly
 
   ```sh
       set -ex
@@ -166,8 +166,8 @@ Look for annotations containing device information in the node status.
       source /root/.bashrc
   ```
 
-* Virtualization takes effect only for containers that apply for one GPU (i.e., iluvatar.ai/vgpu=1). When requesting multiple GPUs, the system will automatically set the core resources based on the number of GPUs requested.
+- Virtualization takes effect only for containers that apply for one GPU (i.e., iluvatar.ai/vgpu=1). When requesting multiple GPUs, the system will automatically set the core resources based on the number of GPUs requested.
 
-* The `iluvatar.ai/<card-type>.vMem` resource is only effective when `iluvatar.ai/<card-type>-vgpu=1`.
+- The `iluvatar.ai/<card-type>.vMem` resource is only effective when `iluvatar.ai/<card-type>-vgpu=1`.
 
-* Multi-device requests (`iluvatar.ai/<card-type>-vgpu= > 1`) do not support vGPU mode.
+- Multi-device requests (`iluvatar.ai/<card-type>-vgpu= > 1`) do not support vGPU mode.

--- a/versioned_docs/version-v2.5.0/userguide/metax-device/enable-metax-gpu-sharing.md
+++ b/versioned_docs/version-v2.5.0/userguide/metax-device/enable-metax-gpu-sharing.md
@@ -21,13 +21,13 @@ device-sharing features include the following:
 
 ### Prerequisites
 
-* Metax Driver >= 2.31.0
-* Metax GPU Operator >= 0.10.1
-* Kubernetes >= 1.23
+- Metax Driver >= 2.31.0
+- Metax GPU Operator >= 0.10.1
+- Kubernetes >= 1.23
 
 ### Enabling GPU-sharing Support
 
-* Deploy Metax GPU Operator on metax nodes (Please consult your device provider to acquire its package and document)
+- Deploy Metax GPU Operator on metax nodes (Please consult your device provider to acquire its package and document)
 
 - Deploy HAMi using the online installation guide
 

--- a/versioned_docs/version-v2.5.1/userguide/metax-device/enable-metax-gpu-sharing.md
+++ b/versioned_docs/version-v2.5.1/userguide/metax-device/enable-metax-gpu-sharing.md
@@ -12,13 +12,13 @@ title: Enable Metax GPU sharing
 
 ## Prerequisites
 
-* Metax Driver >= 2.31.0
-* Metax GPU Operator >= 0.10.1
-* Kubernetes >= 1.23
+- Metax Driver >= 2.31.0
+- Metax GPU Operator >= 0.10.1
+- Kubernetes >= 1.23
 
 ## Enabling GPU-sharing Support
 
-* Deploy Metax GPU Operator on metax nodes (Please consult your device provider to acquire its package and document)
+- Deploy Metax GPU Operator on metax nodes (Please consult your device provider to acquire its package and document)
 
 - Deploy HAMi using the online installation guide
 

--- a/versioned_docs/version-v2.6.0/userguide/metax-device/metax-gpu/enable-metax-gpu-schedule.md
+++ b/versioned_docs/version-v2.6.0/userguide/metax-device/metax-gpu/enable-metax-gpu-schedule.md
@@ -33,12 +33,12 @@ Equipped with MetaXLink interconnected resources.
 
 ## Prerequisites
 
-* Metax GPU extensions >= 0.8.0
-* Kubernetes >= 1.23
+- Metax GPU extensions >= 0.8.0
+- Kubernetes >= 1.23
 
 ## Enabling topo-awareness scheduling
 
-* Deploy Metax GPU Extensions on metax nodes (Please consult your device provider to acquire its package and document)
+- Deploy Metax GPU Extensions on metax nodes (Please consult your device provider to acquire its package and document)
 
 - Deploy HAMi using the [online installation guide](../../../installation/online-installation.md)
 

--- a/versioned_docs/version-v2.6.0/userguide/metax-device/metax-sgpu/enable-metax-gpu-sharing.md
+++ b/versioned_docs/version-v2.6.0/userguide/metax-device/metax-sgpu/enable-metax-gpu-sharing.md
@@ -15,13 +15,13 @@ translated: true
 
 ### Prerequisites
 
-* Metax Driver >= 2.32.0
-* Metax GPU Operator >= 0.10.2
-* Kubernetes >= 1.23
+- Metax Driver >= 2.32.0
+- Metax GPU Operator >= 0.10.2
+- Kubernetes >= 1.23
 
 ### Enabling GPU-sharing Support
 
-* Deploy Metax GPU Operator on metax nodes (Please consult your device provider to acquire its package and document)
+- Deploy Metax GPU Operator on metax nodes (Please consult your device provider to acquire its package and document)
 
 - Deploy HAMi using the [online installation guide](../../../installation/online-installation.md)
 

--- a/versioned_docs/version-v2.7.0/userguide/metax-device/metax-gpu/enable-metax-gpu-schedule.md
+++ b/versioned_docs/version-v2.7.0/userguide/metax-device/metax-gpu/enable-metax-gpu-schedule.md
@@ -35,12 +35,12 @@ the GPU device plugin (gpu-device) handles fine-grained allocation based on the 
 
 ## Prerequisites
 
-* Metax GPU extensions >= 0.8.0
-* Kubernetes >= 1.23
+- Metax GPU extensions >= 0.8.0
+- Kubernetes >= 1.23
 
 ## Enabling topo-awareness scheduling
 
-* Deploy Metax GPU Extensions on metax nodes (Please consult your device provider to acquire its package and document)
+- Deploy Metax GPU Extensions on metax nodes (Please consult your device provider to acquire its package and document)
 
 - Deploy HAMi using the [online installation guide](../../../installation/online-installation.md)
 

--- a/versioned_docs/version-v2.7.0/userguide/metax-device/metax-sgpu/enable-metax-gpu-sharing.md
+++ b/versioned_docs/version-v2.7.0/userguide/metax-device/metax-sgpu/enable-metax-gpu-sharing.md
@@ -13,13 +13,13 @@ translated: true
 
 ## Prerequisites
 
-* Metax Driver >= 2.32.0
-* Metax GPU Operator >= 0.10.2
-* Kubernetes >= 1.23
+- Metax Driver >= 2.32.0
+- Metax GPU Operator >= 0.10.2
+- Kubernetes >= 1.23
 
 ## Enabling GPU-sharing support
 
-* Deploy Metax GPU Operator on metax nodes (Please consult your device provider to obtain the installation package and documentation)
+- Deploy Metax GPU Operator on metax nodes (Please consult your device provider to obtain the installation package and documentation)
 
 - Deploy HAMi using the [online installation guide](../../../installation/online-installation.md)
 


### PR DESCRIPTION
- Replaces `*` list markers with `-` for consistency in files that mixed both styles
- Affected files: `iluvatar-device` in `docs/`, and `metax-device` in versioned docs (v2.5.0, v2.5.1, v2.6.0, v2.7.0)
- 7 files changed, no content changes