### PR TITLE
fix: convert plain Note: to admonition and remove weak note phrasing

### DIFF
--- a/blog/hami-v2-9-0-release/index.md
+++ b/blog/hami-v2-9-0-release/index.md
@@ -64,7 +64,7 @@ Core capabilities include:
 
 To enable this feature, set `ascend.hamiVnpuCore` to `true` in the Helm values. It can also be enabled in the `ascend-device-plugin` node configuration. The cluster supports mixed mode where some nodes have it enabled and others do not.
 
-Note that in v2.9, user Pods must explicitly declare `huawei.com/vnpu-mode: 'hami-core'` in annotations to use this feature. Pods without this declaration will continue to use the template-based vNPU partitioning from the previous version, and may result in pending tasks if no compatible nodes are available.
+In v2.9, user Pods must explicitly declare `huawei.com/vnpu-mode: 'hami-core'` in annotations to use this feature. Pods without this declaration will continue to use the template-based vNPU partitioning from the previous version, and may result in pending tasks if no compatible nodes are available.
 
 > This feature has been validated in China Merchants Bank's production environment. Based on the HAMi-vNPU-Core software partitioning solution, China Merchants Bank achieved 100% resource pooling of Ascend 910C compute and high-performance communication for large models, significantly improving domestic compute resource utilization.
 

--- a/docs/get-started/verify-hami.md
+++ b/docs/get-started/verify-hami.md
@@ -81,7 +81,9 @@ kubectl wait --for=condition=Succeeded pod/cuda-test --timeout=60s
 kubectl logs cuda-test
 ```
 
-Note: You must see the standard `nvidia-smi` output. Do not proceed if this fails.
+:::note
+You must see the standard `nvidia-smi` output. Do not proceed if this fails.
+:::
 
 ## Step 2: Verify HAMi Installation
 


### PR DESCRIPTION
- `docs/get-started/verify-hami.md`: convert bare `Note:` prefix to `:::note` Docusaurus admonition
- `blog/hami-v2-9-0-release/index.md`: remove weak "Note that" sentence opener