### PR TITLE
docs: fix grammar and informal language in device sharing guides

### DIFF
--- a/docs/userguide/enflame-device/enable-enflame-gcu-sharing.md
+++ b/docs/userguide/enflame-device/enable-enflame-gcu-sharing.md
@@ -47,14 +47,14 @@ helm install hami hami-charts/hami --set devices.enflame.enabled=true -n kube-sy
 
 ## Device Granularity
 
-HAMi divides each Enflame GCU into 100 units for resource allocation. When you request a portion of a GCU, you're actually requesting a certain number of these units.
+HAMi divides each Enflame GCU into 100 units for resource allocation. Requesting a portion of a GCU corresponds to requesting a specific number of these units.
 
 ### GCU Slice Allocation
 
 - Each unit of `enflame.com/vgcu-percentage` represents 1% device memory and 1% core
-- If you don't specify a memory request, the system will default to using 100% of the available memory
-- Memory allocation is enforced with hard limits to ensure tasks don't exceed their allocated memory
-- Core allocation is enforced with hard limits to ensure tasks don't exceed their allocated cores
+- If no memory request is specified, the system defaults to using 100% of the available memory
+- Memory allocation is enforced with hard limits to ensure tasks do not exceed their allocated memory
+- Core allocation is enforced with hard limits to ensure tasks do not exceed their allocated cores
 
 ## Running Enflame jobs
 

--- a/docs/userguide/iluvatar-device/enable-iluvatar-gpu-sharing.md
+++ b/docs/userguide/iluvatar-device/enable-iluvatar-gpu-sharing.md
@@ -63,19 +63,19 @@ The currently supported GPU models and resource names are defined in [device-con
 
 ## Device Granularity
 
-HAMi divides each Iluvatar GPU into 100 units for resource allocation. When you request a portion of a GPU, you're actually requesting a certain number of these units.
+HAMi divides each Iluvatar GPU into 100 units for resource allocation. Requesting a portion of a GPU corresponds to requesting a specific number of these units.
 
 ### Memory Allocation
 
-- Each unit of `iluvatar.ai/<card-type>.vMem` represents 256MB of device memory
-- If you don't specify a memory request, the system will default to using 100% of the available memory
-- Memory allocation is enforced with hard limits to ensure tasks don't exceed their allocated memory
+* Each unit of `iluvatar.ai/<card-type>.vMem` represents 256MB of device memory
+* If no memory request is specified, the system defaults to using 100% of the available memory
+* Memory allocation is enforced with hard limits to ensure tasks do not exceed their allocated memory
 
 ### Core Allocation
 
-- Each unit of `iluvatar.ai/<card-type>.vCore` represents 1% of the available compute cores
-- Core allocation is enforced with hard limits to ensure tasks don't exceed their allocated cores
-- When requesting multiple GPUs, the system will automatically set the core resources based on the number of GPUs requested
+* Each unit of `iluvatar.ai/<card-type>.vCore` represents 1% of the available compute cores
+* Core allocation is enforced with hard limits to ensure tasks do not exceed their allocated cores
+* When requesting multiple GPUs, the system will automatically set the core resources based on the number of GPUs requested
 
 ## Running Iluvatar jobs
 

--- a/docs/userguide/iluvatar-device/examples/allocate-exclusive-bi-v150.md
+++ b/docs/userguide/iluvatar-device/examples/allocate-exclusive-bi-v150.md
@@ -34,6 +34,6 @@ spec:
 
 :::note
 
-When applying for exclusive use of a GPU, `iluvatar.ai/<card-type>-vgpu=1`, you need to set the values of `iluvatar.ai/<card-type>.vCore` and `iluvatar.ai/<card-type>.vMem` to the maximum number of GPU resources. `iluvatar.ai/<card-type>-vgpu>1` no longer supports the vGPU function, so you don't need to fill in the core and memory values
+When applying for exclusive use of a GPU with `iluvatar.ai/<card-type>-vgpu=1`, set `iluvatar.ai/<card-type>.vCore` and `iluvatar.ai/<card-type>.vMem` to the maximum GPU resource values. When `iluvatar.ai/<card-type>-vgpu>1`, the vGPU function is not supported and core and memory values do not need to be specified.
 
 :::

--- a/docs/userguide/iluvatar-device/examples/allocate-exclusive-mr-v100.md
+++ b/docs/userguide/iluvatar-device/examples/allocate-exclusive-mr-v100.md
@@ -34,6 +34,6 @@ spec:
 
 :::note
 
-When applying for exclusive use of a GPU, `iluvatar.ai/<card-type>-vgpu=1`, you need to set the values of `iluvatar.ai/<card-type>.vCore` and `iluvatar.ai/<card-type>.vMem` to the maximum number of GPU resources. `iluvatar.ai/<card-type>-vgpu>1` no longer supports the vGPU function, so you don't need to fill in the core and memory values
+When applying for exclusive use of a GPU with `iluvatar.ai/<card-type>-vgpu=1`, set `iluvatar.ai/<card-type>.vCore` and `iluvatar.ai/<card-type>.vMem` to the maximum GPU resource values. When `iluvatar.ai/<card-type>-vgpu>1`, the vGPU function is not supported and core and memory values do not need to be specified.
 
 :::

--- a/docs/userguide/vastai/enable-vastai-sharing.md
+++ b/docs/userguide/vastai/enable-vastai-sharing.md
@@ -4,9 +4,9 @@ title: Enable Vastai Sharing
 
 ## Introduction
 
-HAMi now supports sharing `vastaitech.com/va` (Vastaitech) devices and provide the following capabilities:
+HAMi now supports sharing `vastaitech.com/va` (Vastaitech) devices and provides the following capabilities:
 
-**Supports both Full-Card mode and Die mode**: Only Full-Card mode and Die mode are supported currently.
+**Supports both Full-Card mode and Die mode**: The scheduler supports Full-Card mode, where the entire device is allocated to a single workload, and Die mode, where the device is partitioned into sub-units for multiple workloads.
 
 **Die-mode topology awareness**: When multiple resources are requested in die mode, the scheduler will try to allocate them on the same AIC whenever possible.
 


### PR DESCRIPTION
- Fix subject-verb agreement in Vastai guide: `provide` -> `provides`
- Rewrite redundant Vastai capability bullet to be informative rather than circular
- Remove casual phrasing (`you're actually requesting`) from Enflame and Iluvatar device granularity sections
- Replace contractions (`don't`, `you're`) with formal equivalents across affected files
- Rephrase `fill in the core and memory values` to `specify` in Iluvatar exclusive-use notes (two example files)