### PR TITLE
fix: apply consistent title case to value card headings

### DIFF
--- a/src/data/home/valueCards.js
+++ b/src/data/home/valueCards.js
@@ -27,7 +27,7 @@ const valueCards = [
     id: 'advanced-scheduling',
     icon: 'gauge-high',
     title: {
-      en: 'Advanced scheduling',
+      en: 'Advanced Scheduling',
       zh: '动态控制与调度',
     },
     description: {
@@ -39,7 +39,7 @@ const valueCards = [
     id: 'standards',
     icon: 'kubernetes',
     title: {
-      en: 'Kubernetes native',
+      en: 'Kubernetes Native',
       zh: 'Kubernetes 原生',
     },
     description: {


### PR DESCRIPTION
- `'Advanced scheduling'` and `'Kubernetes native'` in `src/data/home/valueCards.js` were missing title case
- Every other value card on the homepage uses title case (e.g. `'Hard Isolation'`, `'Unified Monitoring'`)
- This PR corrects the two outliers for visual consistency