### PR TITLE
fix: remove duplicate truncate marker from kubecon-eu-2026-recap blog post

### DIFF
--- a/blog/kubecon-eu-2026-recap/index.md
+++ b/blog/kubecon-eu-2026-recap/index.md
@@ -55,8 +55,6 @@ Additionally, HAMi is currently applying for CNCF Incubation and participated in
 
 ![TAG Workshop discussing CNCF project governance](/img/kubecon-eu-2026-recap/tag-workshop.jpg)
 
-<!-- truncate -->
-
 ## Two Technical Sessions: From Community Problems to Engineering Solutions
 
 ### Xiao Zhang: K8s Issue #52757 - Sharing GPUs Among Multiple Containers


### PR DESCRIPTION
The `kubecon-eu-2026-recap` blog post had two `<!-- truncate -->` markers -
one at line 13 (correct, after the intro paragraph) and a second at line 58
(mid-article, inside the body). Both the English and Chinese versions were affected.