### PR TITLE
fix: remove the expired param --short for it has been removed from k8s v1.28

### DIFF
--- a/docs/installation/online-installation.md
+++ b/docs/installation/online-installation.md
@@ -18,7 +18,7 @@ helm repo add hami-charts https://project-hami.github.io/HAMi/
 A Kubernetes version is required for proper installation. You can retrieve your Kubernetes server version with:
 
 ```bash
-kubectl version --short
+kubectl version
 ```
 
 ## Installation


### PR DESCRIPTION
## Summary
fix: remove the expired param --short for it has been removed from k8s v1.28

## Changes Made
- Removed：`--short` in `kubectl version --short`，The command option `--short` in docs cannot be execute in k8s after v1.28