### PR TITLE
docs: replace contractions with formal equivalents in docs/

### DIFF
--- a/docs/core-concepts/gpu-virtualization.md
+++ b/docs/core-concepts/gpu-virtualization.md
@@ -5,7 +5,7 @@ linktitle: GPU Virtualization
 
 In AI inference scenarios, a common dilemma is that GPUs are expensive, but mostly idle.
 
-A typical inference service often only uses 20%~40% of the GPU's compute and a small amount of VRAM, leaving the rest idle. Kubernetes' default GPU scheduling model is exclusive: `nvidia.com/gpu: 1` means the entire card is yours, and all other Pods must wait. Want to share a single GPU across multiple inference services? The standard Device Plugin can't do it, because it can only report device counts (integers) to the scheduler - there is no concept of "VRAM quota."
+A typical inference service often only uses 20%~40% of the GPU's compute and a small amount of VRAM, leaving the rest idle. Kubernetes' default GPU scheduling model is exclusive: `nvidia.com/gpu: 1` means the entire card is yours, and all other Pods must wait. Want to share a single GPU across multiple inference services? The standard Device Plugin cannot do it, because it can only report device counts (integers) to the scheduler - there is no concept of "VRAM quota."
 
 This led to various GPU sharing solutions. NVIDIA's official Time-Slicing allows multiple Pods to be scheduled concurrently, but provides no VRAM isolation - a Pod OOM can crash all tasks on the card. MIG hardware partitioning offers true isolation, but only datacenter-grade cards like A100 and H100 support it.
 

--- a/docs/faq/faq.md
+++ b/docs/faq/faq.md
@@ -15,7 +15,7 @@ title: FAQ
 | Mthreads | MTT S4000 | Core 1 core group, Memory 512M | Supported, but splitting is not supported when `gpu > 1`. The entire card is exclusively allocated. |
 | Metax | MXC500 | Does not support splitting, only whole card allocation is possible. | Supported, but all allocations are for whole cards. |
 
-## What is vGPU? Why can't I allocate two vGPUs on the same card despite seeing 10 vGPUs?
+## What is vGPU? Why cannot I allocate two vGPUs on the same card despite seeing 10 vGPUs?
 
 **TL;DR**
 
@@ -27,7 +27,7 @@ vGPU increases GPU utilization by enabling multiple tasks to share one GPU throu
 
 A vGPU is a logical instance of a physical GPU created using virtualization, allowing multiple tasks to share the same physical GPU. For example, setting `deviceSplitCount: 10` means a physical GPU can allocate resources to up to 10 tasks. This allocation does not increase physical resources; it only defines logical visibility.
 
-**Why can't I allocate two vGPUs on the same card?**
+**Why cannot I allocate two vGPUs on the same card?**
 
 1. **Significance of vGPU**
    vGPU represents different task views of the same physical GPU. It is not a separate partition of physical resources. When a task requests `nvidia.com/gpu: 2`, it is interpreted as requiring two physical GPUs, not two vGPUs from the same GPU.
@@ -51,7 +51,7 @@ HAMi's built-in two-level priority is for runtime preemption on a single GPU (e.
 
 HAMi's native `nvidia.com/priority` field (0 for high, 1 for low/default) is specifically designed for **runtime preemption on a single GPU**. The typical scenario it addresses is when a low-priority task (e.g., training) is running, and a high-priority task (e.g., inference) needs immediate access to that same GPU. In this case, the high-priority task will cause the low-priority task to pause, effectively ceding compute resources. Once the high-priority task completes, the low-priority task resumes. This mechanism is focused on immediate resource contention on a specific device, rather than for sorting a queue of many pending jobs with multiple priority levels for initial scheduling.
 
-Regarding the scenario where resources are insufficient, 'n' jobs are waiting, and you need to sort them for scheduling based on multiple user-submitted priorities, HAMi's two-level system isn't intended for this broader scheduling requirement.
+Regarding the scenario where resources are insufficient, 'n' jobs are waiting, and you need to sort them for scheduling based on multiple user-submitted priorities, HAMi's two-level system is not intended for this broader scheduling requirement.
 
 However, achieving multi-level priority scheduling **is feasible**. The recommended approach is to integrate HAMi with a full-featured scheduler like **Volcano**:
 

--- a/docs/installation/how-to-use-volcano-vgpu.md
+++ b/docs/installation/how-to-use-volcano-vgpu.md
@@ -121,7 +121,7 @@ You can validate device memory using nvidia-smi inside container:
 
 :::warning
 
-If you don't request GPUs when using the device plugin with NVIDIA images, all
+If you do not request GPUs when using the device plugin with NVIDIA images, all
 the GPUs on the machine will be exposed inside your container.
 The number of vGPUs used by a container can not exceed the number of GPUs on that node.
 

--- a/docs/installation/uninstall.md
+++ b/docs/installation/uninstall.md
@@ -28,7 +28,7 @@ This command will remove all HAMi resources, including:
 
 :::warning
 
-Uninstalling HAMi won't automatically stop or kill running GPU tasks. Container processes will continue to use GPU resources even after HAMi components are removed.
+Uninstalling HAMi does not automatically stop or kill running GPU tasks. Container processes will continue to use GPU resources even after HAMi components are removed.
 
 :::
 

--- a/docs/installation/upgrade.md
+++ b/docs/installation/upgrade.md
@@ -94,7 +94,7 @@ helm upgrade hami hami-charts/hami -n kube-system -f current-values.yaml
 
 ### In-Place Upgrade (If Using Existing Installation)
 
-If you don't have a custom values file, you can upgrade directly:
+If you do not have a custom values file, you can upgrade directly:
 
 ```bash
 helm repo update hami-charts
@@ -261,7 +261,7 @@ helm rollback hami <revision-number> -n kube-system
 
 ### Manual Rollback
 
-If helm rollback doesn't work:
+If helm rollback does not work:
 
 ```bash
 # Get previous HAMi version from backup

--- a/docs/troubleshooting/troubleshooting.md
+++ b/docs/troubleshooting/troubleshooting.md
@@ -7,7 +7,7 @@ title: Troubleshooting
 - Tasks with the "nodeName" field cannot be scheduled at the moment; please use "nodeSelector" instead.
 - Only computing tasks are currently supported; video codec processing is not supported.
 - Since v2.3.10, HAMi has changed the `device-plugin` environment variable name from `NodeName` to `NODE_NAME`.
-  If you're using an image version earlier than v2.3.10, the `device-plugin` may fail to start.
+  If you are using an image version earlier than v2.3.10, the `device-plugin` may fail to start.
 
   To resolve this issue, you have two options:
 


### PR DESCRIPTION
Replace informal contractions with their full forms across documentation files

Files changed: `docs/faq/faq.md`, `docs/installation/uninstall.md`, `docs/installation/upgrade.md`, `docs/installation/how-to-use-volcano-vgpu.md`, `docs/troubleshooting/troubleshooting.md`, `docs/core-concepts/gpu-virtualization.md`