### PR TITLE
docs: remove casual and circular phrasing across docs and blog

### DIFF
--- a/blog/kcd-beijing-2026-dra-gpu-scheduling/index.md
+++ b/blog/kcd-beijing-2026-dra-gpu-scheduling/index.md
@@ -55,7 +55,7 @@ At the booth, the HAMi community discussed with attendees questions such as:
 
 ## GPU Scheduling Paradigm is Changing
 
-The core of this talk is not just DRA itself, but a bigger shift:
+The core of this talk extends beyond DRA itself, pointing to a broader shift:
 
 > **GPUs are evolving from "devices" to "resource objects".**
 
@@ -163,7 +163,7 @@ Output (system internal):
 
 ## DRA Driver: Real Implementation Complexity
 
-DRA driver is not just "registering resources", but full lifecycle management:
+A DRA driver encompasses more than resource registration; it provides full lifecycle management:
 
 ### Three core interfaces
 
@@ -281,7 +281,7 @@ This is the way HAMi has always insisted on:
 
 ## Summary
 
-The real value of this talk is not just introducing DRA, but answering a key question:
+The real value of this talk lies in answering a key question, beyond introducing DRA:
 
 > **How to turn a "correct but hard to use" model into a system you can use today?**
 

--- a/blog/kubecon-eu-2026-recap/index.md
+++ b/blog/kubecon-eu-2026-recap/index.md
@@ -73,7 +73,7 @@ This is why what appears to be a low-level problem has become one of the core is
 
 HAMi Maintainer Xiao Zhang's talk started from a classic, long-standing problem in the Kubernetes community: **How can multiple containers share a GPU?**
 
-While this question seems specific, it actually points to a challenge the entire AI infrastructure ecosystem faces. Once you enter inference, batch processing, online serving, and multi-tenant mixed scenarios, GPUs can no longer be allocated in an "exclusive whole-card" manner.
+While this question seems specific, it points to a challenge the entire AI infrastructure ecosystem faces. Once you enter inference, batch processing, online serving, and multi-tenant mixed scenarios, GPUs can no longer be allocated in an "exclusive whole-card" manner.
 
 The significance of this talk lies in putting HAMi's solution back into the original context of the Kubernetes community: not building an isolated solution from scratch, but addressing a long-standing upstream problem that hasn't been fully resolved.
 
@@ -192,7 +192,7 @@ HAMi sits precisely at this inflection point, offering a clear, pragmatic, and i
 
 ## Key Takeaways
 
-Looking back at KubeCon, several things stand out for the community:
+Looking back at KubeCon, several key observations stand out for the community:
 
 ### 1. Global Community Focus on AI Infra Is Rapidly Increasing
 

--- a/docs/core-concepts/gpu-virtualization.md
+++ b/docs/core-concepts/gpu-virtualization.md
@@ -88,7 +88,7 @@ The following diagram shows the three-layer architecture's component composition
 
 #### Step 1: Device Registration and Resource Reporting
 
-After `hami-device-plugin` starts, it does two things:
+After `hami-device-plugin` starts, it performs two operations:
 
 ##### ① Inflating GPU Count to Kubelet
 
@@ -158,7 +158,7 @@ hami.io/vgpu-devices-to-allocate: ;    ← Already empty, device allocation comp
 
 #### Step 3: Device Injection and Library Hijacking
 
-After the Pod is scheduled to the target node, Kubelet calls the Device Plugin's `Allocate` interface. The Device Plugin completes four things in its response:
+After the Pod is scheduled to the target node, Kubelet calls the Device Plugin's `Allocate` interface. The Device Plugin performs four operations in its response:
 
 1. **Mount device files**: Injects device files such as `/dev/nvidia*` into the container
 2. **hostPath mount libvgpu.so**: Mounts `libvgpu.so` from the host (default path `/usr/local/vgpu/libvgpu.so`) into the container at the same path via hostPath


### PR DESCRIPTION
Replace vague or informal constructions with precise, formal equivalents