### PR TITLE
docs: replace contractions with formal equivalents in blog/

### DIFF
--- a/blog/2024-12-31-post/index.md
+++ b/blog/2024-12-31-post/index.md
@@ -58,7 +58,7 @@ From the process, this error indicates the kube-apiserver failed to call the ext
   - Cross-node communication issues.
   - Extended scheduler service failure.
 - **TLS Verification Error**: Typically shows `webhook x509: certificate signed by unknown authority`.
-  During Helm chart deployment, there's a `jobs.batch` job called `hami-vgpu.admission-patch`. If it hasn't completed, this issue may occur.
+  During Helm chart deployment, there is a `jobs.batch` job called `hami-vgpu.admission-patch`. If it has not completed, this issue may occur.
 
 #### Scheduling Issues
 

--- a/blog/hami-at-kubecon-eu-2026/index.md
+++ b/blog/hami-at-kubecon-eu-2026/index.md
@@ -22,9 +22,9 @@ The discussions around GPUs are no longer limited to "device visibility" or "dri
 
 The official agenda of KubeCon Europe 2026 reflects this trend across keynotes, AI-related sessions, Project Pavilion, and co-located events.
 
-In this context, HAMi's problem space becomes clearer: it's not only about "making Kubernetes recognize GPUs," but making GPUs a resource layer capability that can be abstracted, shared, and scheduled.
+In this context, HAMi's problem space becomes clearer: it is not only about "making Kubernetes recognize GPUs," but making GPUs a resource layer capability that can be abstracted, shared, and scheduled.
 
-This is why this KubeCon is more than a project showcase for the HAMi community - it's an opportunity to engage with the broader cloud native ecosystem.
+This is why this KubeCon is more than a project showcase for the HAMi community - it is an opportunity to engage with the broader cloud native ecosystem.
 
 ## Finding HAMi at KubeCon
 
@@ -37,7 +37,7 @@ HAMi will have a booth at Project Pavilion for in-person exchanges with communit
   - **March 24 (Tuesday) 15:10–19:00**
   - **March 26 (Thursday) 12:30–14:00**
 
-If you're attending, stop by the HAMi Booth to discuss:
+If you are attending, stop by the HAMi Booth to discuss:
 
 - GPU virtualization and sharing in Kubernetes
 - Resource scheduling and utilization optimization for AI workloads
@@ -117,7 +117,7 @@ After the main conference, the AI Native Summit is also worth attention. This ev
 
 ## Beyond HAMi: Other Topics to Follow
 
-If you're attending this KubeCon, in addition to HAMi-related activities, these areas are worth following:
+If you are attending this KubeCon, in addition to HAMi-related activities, these areas are worth following:
 
 - Device Management / DRA
 - AI workload scheduling

--- a/blog/hami-webui-v1-1-0-release/index.md
+++ b/blog/hami-webui-v1-1-0-release/index.md
@@ -8,7 +8,7 @@ authors: [hami_community]
 image: /img/docs/en/userguide/webui-overview.png
 ---
 
-Managing GPU resources in Kubernetes has long been a "blind spot" for operators. You know GPUs are being used, but answering questions like "which node has idle capacity?", "is this workload actually utilizing its allocated GPU?", or "what's the overall cluster utilization trend?" often requires piecing together `kubectl get`, Prometheus PromQL, and log output.
+Managing GPU resources in Kubernetes has long been a "blind spot" for operators. You know GPUs are being used, but answering questions like "which node has idle capacity?", "is this workload actually utilizing its allocated GPU?", or "what is the overall cluster utilization trend?" often requires piecing together `kubectl get`, Prometheus PromQL, and log output.
 
 Today, the HAMi community is introducing **[HAMi WebUI](https://github.com/Project-HAMi/HAMi-WebUI)** - an open-source GPU monitoring dashboard that puts your entire GPU cluster into a single, visual interface.
 
@@ -20,11 +20,11 @@ Together with the core HAMi scheduler, WebUI completes the full loop: **from GPU
 
 ## The Challenge of GPU Monitoring in Kubernetes
 
-[HAMi](https://github.com/Project-HAMi/HAMi), a [CNCF Sandbox project](https://www.cncf.io/projects/hami/), has long been focused on the scheduling and management layer of GPU resources in Kubernetes. The scheduler decides which GPU a workload gets - but once workloads are running, understanding what's happening at the resource level has been difficult.
+[HAMi](https://github.com/Project-HAMi/HAMi), a [CNCF Sandbox project](https://www.cncf.io/projects/hami/), has long been focused on the scheduling and management layer of GPU resources in Kubernetes. The scheduler decides which GPU a workload gets - but once workloads are running, understanding what is happening at the resource level has been difficult.
 
 Consider a typical day-to-day scenario:
 
-- A team lead wants to know if there's room to schedule another training job.
+- A team lead wants to know if there is room to schedule another training job.
 - An SRE receives an alert about high GPU memory usage and needs to pinpoint the source.
 - A cluster admin wants to compare GPU utilization across nodes to rebalance workloads.
 

--- a/blog/kcd-beijing-2026-dra-gpu-scheduling/index.md
+++ b/blog/kcd-beijing-2026-dra-gpu-scheduling/index.md
@@ -55,7 +55,7 @@ At the booth, the HAMi community discussed with attendees questions such as:
 
 ## GPU Scheduling Paradigm is Changing
 
-The core of this talk is not just DRA itself, but a bigger shift:
+The core of this talk extends beyond DRA itself, pointing to a broader shift:
 
 > **GPUs are evolving from "devices" to "resource objects".**
 
@@ -163,7 +163,7 @@ Output (system internal):
 
 ## DRA Driver: Real Implementation Complexity
 
-DRA driver is not just "registering resources", but full lifecycle management:
+A DRA driver encompasses more than resource registration; it provides full lifecycle management:
 
 ### Three core interfaces
 
@@ -281,7 +281,7 @@ This is the way HAMi has always insisted on:
 
 ## Summary
 
-The real value of this talk is not just introducing DRA, but answering a key question:
+The real value of this talk lies in answering a key question, beyond introducing DRA:
 
 > **How to turn a "correct but hard to use" model into a system you can use today?**
 

--- a/blog/kubecon-eu-2026-recap/index.md
+++ b/blog/kubecon-eu-2026-recap/index.md
@@ -73,7 +73,7 @@ This is why what appears to be a low-level problem has become one of the core is
 
 HAMi Maintainer Xiao Zhang's talk started from a classic, long-standing problem in the Kubernetes community: **How can multiple containers share a GPU?**
 
-While this question seems specific, it actually points to a challenge the entire AI infrastructure ecosystem faces. Once you enter inference, batch processing, online serving, and multi-tenant mixed scenarios, GPUs can no longer be allocated in an "exclusive whole-card" manner.
+While this question seems specific, it points to a challenge the entire AI infrastructure ecosystem faces. Once you enter inference, batch processing, online serving, and multi-tenant mixed scenarios, GPUs can no longer be allocated in an "exclusive whole-card" manner.
 
 The significance of this talk lies in putting HAMi's solution back into the original context of the Kubernetes community: not building an isolated solution from scratch, but addressing a long-standing upstream problem that hasn't been fully resolved.
 
@@ -192,7 +192,7 @@ HAMi sits precisely at this inflection point, offering a clear, pragmatic, and i
 
 ## Key Takeaways
 
-Looking back at KubeCon, several things stand out for the community:
+Looking back at KubeCon, several key observations stand out for the community:
 
 ### 1. Global Community Focus on AI Infra Is Rapidly Increasing
 

--- a/blog/kubecon-eu-2026-recap/index.md
+++ b/blog/kubecon-eu-2026-recap/index.md
@@ -59,7 +59,7 @@ Additionally, HAMi is currently applying for CNCF Incubation and participated in
 
 ### Xiao Zhang: K8s Issue #52757 - Sharing GPUs Among Multiple Containers
 
-This issue ([#52757](https://github.com/kubernetes/kubernetes/issues/52757)) is not new - it's a long-standing "unsolved problem" in the Kubernetes community.
+This issue ([#52757](https://github.com/kubernetes/kubernetes/issues/52757)) is not new - it is a long-standing "unsolved problem" in the Kubernetes community.
 
 With the explosion of AI workloads, this problem has been amplified:
 
@@ -75,7 +75,7 @@ HAMi Maintainer Xiao Zhang's talk started from a classic, long-standing problem 
 
 While this question seems specific, it points to a challenge the entire AI infrastructure ecosystem faces. Once you enter inference, batch processing, online serving, and multi-tenant mixed scenarios, GPUs can no longer be allocated in an "exclusive whole-card" manner.
 
-The significance of this talk lies in putting HAMi's solution back into the original context of the Kubernetes community: not building an isolated solution from scratch, but addressing a long-standing upstream problem that hasn't been fully resolved.
+The significance of this talk lies in putting HAMi's solution back into the original context of the Kubernetes community: not building an isolated solution from scratch, but addressing a long-standing upstream problem that has not been fully resolved.
 
 ### Mengxuan Li: Dynamic, Smart, Stable GPU-Sharing Middleware in Kubernetes
 
@@ -150,7 +150,7 @@ GPU sharing, virtualization, resource isolation, and heterogeneous scheduling we
 
 **Third, this is the result of accumulated HAMi community effort.**
 
-An open source project making it to the KubeCon main stage isn't just about "having a feature to demo." Behind it is the alignment of technical direction with industry trends, community value being recognized, and the project's position in the ecosystem becoming clearer.
+An open source project making it to the KubeCon main stage is not just about "having a feature to demo." Behind it is the alignment of technical direction with industry trends, community value being recognized, and the project's position in the ecosystem becoming clearer.
 
 This keynote demo also served as a positioning confirmation:
 
@@ -180,11 +180,11 @@ Beyond the live demo and talks, there was another important external signal from
 
 ![HAMi highlighted as a Cloud Native Landscape expansion project during Keynote](/img/kubecon-eu-2026-recap/landscape-mention.jpg)
 
-This indicates that HAMi's significance extends beyond "a project doing GPU scheduling" - it's being viewed as a representative of next-generation infrastructure problems within the broader cloud native evolution.
+This indicates that HAMi's significance extends beyond "a project doing GPU scheduling" - it is being viewed as a representative of next-generation infrastructure problems within the broader cloud native evolution.
 
 The cloud native community is realizing:
 
-- The existing resource model built around CPU / memory / network / storage isn't enough
+- The existing resource model built around CPU / memory / network / storage is not enough
 - The AI era demands new resource abstractions
 - GPUs, inference, heterogeneous devices, and workload governance are becoming key infrastructure topics for the next phase
 
@@ -215,12 +215,12 @@ HAMi is no longer just "a project that does GPU sharing." It's gradually forming
 
 ## Conclusion
 
-KubeCon EU 2026 made one thing clear: **cloud native won't be replaced by AI - it will be redefined by AI.**
+KubeCon EU 2026 made one thing clear: **cloud native will not be replaced by AI - it will be redefined by AI.**
 
 From booth exchanges to technical sessions to the main stage demo, HAMi's presence at this conference was more than just an event appearance - it was a signal:
 
 > **Cloud native infrastructure around GPUs, inference, and heterogeneous compute is entering a new phase.**
 
-If you're interested in AI infrastructure, GPU virtualization, and the evolution of Kubernetes in the AI era, join the HAMi community and help drive the next steps in this space.
+If you are interested in AI infrastructure, GPU virtualization, and the evolution of Kubernetes in the AI era, join the HAMi community and help drive the next steps in this space.
 
 ![HAMi community members and contributors group photo at KubeCon](/img/kubecon-eu-2026-recap/team-photo.jpg)

--- a/docs/core-concepts/gpu-virtualization.md
+++ b/docs/core-concepts/gpu-virtualization.md
@@ -88,7 +88,7 @@ The following diagram shows the three-layer architecture's component composition
 
 #### Step 1: Device Registration and Resource Reporting
 
-After `hami-device-plugin` starts, it does two things:
+After `hami-device-plugin` starts, it performs two operations:
 
 ##### ① Inflating GPU Count to Kubelet
 
@@ -158,7 +158,7 @@ hami.io/vgpu-devices-to-allocate: ;    ← Already empty, device allocation comp
 
 #### Step 3: Device Injection and Library Hijacking
 
-After the Pod is scheduled to the target node, Kubelet calls the Device Plugin's `Allocate` interface. The Device Plugin completes four things in its response:
+After the Pod is scheduled to the target node, Kubelet calls the Device Plugin's `Allocate` interface. The Device Plugin performs four operations in its response:
 
 1. **Mount device files**: Injects device files such as `/dev/nvidia*` into the container
 2. **hostPath mount libvgpu.so**: Mounts `libvgpu.so` from the host (default path `/usr/local/vgpu/libvgpu.so`) into the container at the same path via hostPath


### PR DESCRIPTION
Replace informal contractions across four blog posts (code block comments left unchanged)
Files: `blog/kubecon-eu-2026-recap/index.md`, `blog/hami-at-kubecon-eu-2026/index.md`, `blog/hami-webui-v1-1-0-release/index.md`, `blog/2024-12-31-post/index.md`