### PR TITLE
docs: remove conjunction sentence starters across docs and blog

### DIFF
--- a/blog/kcd-beijing-2026-dra-gpu-scheduling/index.md
+++ b/blog/kcd-beijing-2026-dra-gpu-scheduling/index.md
@@ -105,7 +105,7 @@ spec:
             count: 1
 ```
 
-And you also need to write a CEL selector:
+You also need to write a CEL selector:
 
 ```yaml
 device.attributes["gpu.hami.io"].type == "hami-gpu"

--- a/docs/contributor/adopters.md
+++ b/docs/contributor/adopters.md
@@ -4,7 +4,7 @@ title: HAMi Adopters
 
 # HAMi Adopters
 
-So you and your organisation are using HAMi? That's great. Reach out and let the community know.
+Using HAMi in your organisation? Reach out and let the community know.
 
 ## Adding yourself
 

--- a/docs/installation/prerequisites.md
+++ b/docs/installation/prerequisites.md
@@ -41,7 +41,7 @@ When running Kubernetes with Docker, use the `nvidia-ctk` tool to automatically 
 sudo nvidia-ctk runtime configure --runtime=docker
 ```
 
-And then restart Docker:
+Then restart Docker:
 
 ```bash
 sudo systemctl daemon-reload && sudo systemctl restart docker
@@ -55,7 +55,7 @@ When running Kubernetes with containerd, use the `nvidia-ctk` tool to automatica
 sudo nvidia-ctk runtime configure --runtime=containerd
 ```
 
-And then restart containerd:
+Then restart containerd:
 
 ```bash
 sudo systemctl daemon-reload && sudo systemctl restart containerd


### PR DESCRIPTION
Replace sentences starting with conjunctions with direct phrasing.

Files: `docs/installation/prerequisites.md`, `docs/contributor/adopters.md`, `blog/kcd-beijing-2026-dra-gpu-scheduling/index.md`