### PR TITLE
docs: replace weak There-is/are constructions with direct phrasing

### DIFF
--- a/docs/contributor/contribute-docs.md
+++ b/docs/contributor/contribute-docs.md
@@ -196,7 +196,7 @@ Fixes to existing versioned docs are handled by maintainers through cherry-picks
 
 ## Chinese Translation Workflow
 
-There are two cases:
+Two cases apply:
 
 **Translating an existing English doc:**
 

--- a/docs/contributor/contributing.md
+++ b/docs/contributor/contributing.md
@@ -297,7 +297,7 @@ When reviewing others' PRs:
 
 ## AI Usage
 
-AI tools may be used to assist with writing code, documentation, or commit messages. There is one hard rule:
+AI tools may be used to assist with writing code, documentation, or commit messages. One hard rule applies:
 
 **Do not submit AI-generated text directly as your PR description, issue body, or commit message.**
 

--- a/docs/contributor/ladder.md
+++ b/docs/contributor/ladder.md
@@ -115,7 +115,7 @@ The current list of maintainers is in [MAINTAINERS](https://github.com/Project-H
 
 **An active maintainer:**
 
-- Actively reviews pull requests and incoming issues. There are no hard rules on what counts as active - this is left to the judgement of the current maintainer group.
+- Actively reviews pull requests and incoming issues. No hard rules define what counts as active - this is left to the judgement of the current maintainer group.
 - Participates in discussions about design and the future of the project.
 - Takes responsibility for backports to appropriate branches for PRs they approve and merge.
 - Follows code, testing, and design conventions as determined by consensus among active maintainers.

--- a/docs/faq/faq.md
+++ b/docs/faq/faq.md
@@ -129,7 +129,7 @@ These three Device Plugins all manage GPU resources but differ in usage scenario
 ### Coexistence
 
 - **HAMi Device Plugin and NVIDIA Official Device Plugin**: Should not coexist to avoid resource conflicts.
-- **HAMi Device Plugin and Volcano vGPU Device Plugin**: Can theoretically coexist, but using only one is recommended.
+- **HAMi Device Plugin and Volcano vGPU Device Plugin**: Can theoretically coexist; use only one to avoid conflicts.
 - **NVIDIA Official Device Plugin and Volcano vGPU Device Plugin**: Can theoretically coexist, but mixed usage is not advised.
 
 ## Why do Node Capacity and Allocatable show only `nvidia.com/gpu` and not `nvidia.com/gpucores` or `nvidia.com/gpumem`?


### PR DESCRIPTION
Replace filler sentence openers and passive recommendation phrasing.
Files: `docs/faq/faq.md`, `docs/contributor/contribute-docs.md`, `docs/contributor/contributing.md`, `docs/contributor/ladder.md`