### PR TITLE
docs: fix capitalization of HAMi and MIG in dynamic-mig.md

### DIFF
--- a/docs/developers/dynamic-mig.md
+++ b/docs/developers/dynamic-mig.md
@@ -104,7 +104,7 @@ data:
 
 ## Examples
 
-Dynamic mig is compatible with hami tasks, as the example below:
+Dynamic MIG is compatible with HAMi tasks, as shown in the example below:
 Set `nvidia.com/gpu` and `nvidia.com/gpumem`.
 
 ```yaml


### PR DESCRIPTION
Correct inconsistent capitalization in prose text:

- `Dynamic mig is compatible with hami tasks` → `Dynamic MIG is compatible with HAMi tasks`
- `as the example below:` → `as shown in the example below:`

File: `docs/developers/dynamic-mig.md`