### PR TITLE
docs: replace vague etc./and more with explicit enumerations

### DIFF
--- a/blog/2024-12-31-post/index.md
+++ b/blog/2024-12-31-post/index.md
@@ -25,7 +25,7 @@ The official documentation provides a clear overview before looking at the code:
 
 The process can be broken down into three phases:
 
-- **Preparation Phase**: The diagram shows the prerequisites: a Mutating Webhook, device-plugin, etc.
+- **Preparation Phase**: The diagram shows the prerequisites: a Mutating Webhook, device-plugin, and scheduler.
   This phase primarily analyzes the preparation of dependencies, which are only needed during the initial service startup.
 
   ![Preparation before Pod creation](https://github.com/elrondwong/elrond.wang/raw/master/img/posts/Hami-GPU-Pod-Scheduler/%E5%87%86%E5%A4%87%E5%B7%A5%E4%BD%9C.png)
@@ -1377,7 +1377,7 @@ func main() {
 
 #### Starting the Plugin
 
-The plugin here is designed to implement different methods for devices from different vendors. The plugin controller defines operations such as start, restart, exit, etc.
+The plugin here is designed to implement different methods for devices from different vendors. The plugin controller defines operations such as start, restart, and exit.
 The main focus here is on `plugins, restartPlugins, err := startPlugins(c, flags, restarting)`.
 
 `cmd/device-plugin/nvidia/main.go:156`

--- a/blog/hami-v2-8-0-release/index.md
+++ b/blog/hami-v2-8-0-release/index.md
@@ -16,7 +16,7 @@ This article provides a detailed overview of the major updates in v2.8.0.
 
 ## Core Features and Capability Updates
 
-This section introduces the core features and capability updates in HAMi v2.8.0, covering standard interface support, high availability mechanisms, device compatibility, and more.
+This section introduces the core features and capability updates in HAMi v2.8.0, covering standard interface support, high availability mechanisms, and device compatibility.
 
 ### Official Support for Kubernetes Device Resource Assignment (DRA)
 

--- a/docs/core-concepts/introduction.md
+++ b/docs/core-concepts/introduction.md
@@ -11,7 +11,7 @@ HAMi is a [Cloud Native Computing Foundation](https://cncf.io/) [Sandbox project
 
 ### Device Sharing
 
-- **Multi-device Support**: Compatible with various heterogeneous AI computing devices (GPUs, NPUs, etc.)
+- **Multi-device Support**: Compatible with various heterogeneous AI computing devices (GPUs, NPUs, and other accelerators)
 - **Shared Access**: Multiple containers can simultaneously share devices for improved resource utilization
 
 ### Memory Management

--- a/docs/developers/hami-webui-development-guide.md
+++ b/docs/developers/hami-webui-development-guide.md
@@ -67,16 +67,16 @@ The architecture includes frontend UI, backend services, and underlying cluster 
 
 1. **Common foundation layer** (`packages/web/src/`)
    - `layout/`: global layout (Sidebar / TopBar / AppMain)
-   - `components/`: common components (BackHeader / BlockBox / Echarts-plus / Message / Confirm, etc.)
+   - `components/`: common components (BackHeader, BlockBox, Echarts-plus, Message, Confirm, and others)
    - `hooks/`: common hooks (for example, `useFetchList`)
    - `utils/`: utility helpers (for example, `request.js` and calculation helpers)
    - `icons/` and `components/SvgIcon/`: SVG icon registration and rendering
 2. **Business module layer** (`packages/web/projects/vgpu/`)
    - `router.js`: module routes
-   - `views/`: page components (monitoring, nodes, cards, tasks, etc.)
+   - `views/`: page components (monitoring, nodes, cards, and tasks)
    - `api/`: API wrappers (`apiPrefix = '/api/vgpu'`)
    - `hooks/`: business hooks
-   - `components/`: business components (charts/dashboards, etc.)
+   - `components/`: business components (charts and dashboards)
 
 ### Routing and menu conventions
 

--- a/docs/userguide/hami-webui-user-guide.md
+++ b/docs/userguide/hami-webui-user-guide.md
@@ -14,7 +14,7 @@ HAMi WebUI focuses on GPU resource management and observability, and provides th
 
 On the cluster overview page, you can quickly understand the overall running status of the current cluster, including:
 
-- GPU resource usage (utilization, allocation, etc.)
+- GPU resource usage (utilization, allocation, and consumption trends)
 - Node resource status
 - Key metric trends
 - Time range filtering and trend display


### PR DESCRIPTION
Replace trailing `etc.` and `and more` 
Files: `docs/core-concepts/introduction.md`, `docs/userguide/hami-webui-user-guide.md`, `docs/developers/hami-webui-development-guide.md`, `blog/hami-v2-8-0-release/index.md`, `blog/2024-12-31-post/index.md`