### PR TITLE
feat: add RSS and Atom feed options to blog plugin

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -396,6 +396,12 @@ module.exports = {
         blog: {
           showReadingTime: true,
           editUrl: "https://github.com/Project-HAMi/website/tree/master/",
+          feedOptions: {
+            type: ['rss', 'atom'],
+            title: 'HAMi Blog',
+            description: 'Latest news and updates from the HAMi project',
+            copyright: `Copyright ${new Date().getFullYear()} HAMi Authors`,
+          },
         },
         theme: {
           customCss: require.resolve("./src/css/custom.css"),


### PR DESCRIPTION
Adds explicit `feedOptions` to the blog preset in `docusaurus.config.js`.

## What changes

- `type: ['rss', 'atom']` - generates both feed formats
- `title`, `description`, `copyright` - production-ready feed metadata
- Exposes `/blog/rss.xml`, `/blog/atom.xml` for EN
- Exposes `/zh/blog/rss.xml`, `/zh/blog/atom.xml` for ZH

Both feeds verified present in build output.

Closes #147