### PR TITLE
docs: rename nvidia.defaultMem to nvidia.defaultMemory in configure docs

### DIFF
--- a/docs/userguide/configure.md
+++ b/docs/userguide/configure.md
@@ -25,7 +25,7 @@ You can update these configurations using one of the following methods:
    | `nvidia.deviceSplitCount` | Integer | Maximum jobs assigned to a single GPU device. | `10` |
    | `nvidia.migstrategy` | String | "none" for ignoring MIG features, "mixed" for allocating MIG devices by separate resources. | `"none"` |
    | `nvidia.disablecorelimit` | String | "true" to disable core limit, "false" to enable core limit. | `"false"` |
-   | `nvidia.defaultMem` | Integer | The default device memory of the current job, in MB. '0' means using 100% of the device memory. | `0` |
+   | `nvidia.defaultMemory` | Integer | The default device memory of the current job, in MB. '0' means using 100% of the device memory. | `0` |
    | `nvidia.defaultCores` | Integer | Percentage of GPU cores reserved for the current job. `0` allows any GPU with enough memory; `100` reserves the entire GPU exclusively. | `0` |
    | `nvidia.defaultGPUNum` | Integer | Default number of GPUs. If set to `0`, it will be filtered out. If `nvidia.com/gpu` is not set in the pod resource, the webhook checks `nvidia.com/gpumem`, `resource-mem-percentage`, and `nvidia.com/gpucores`, adding `nvidia.com/gpu` with this default value if any of them are set. | `1` |
    | `nvidia.memoryFactor` | Integer | During resource requests, the actual value of `nvidia.com/gpumem` will be multiplied by this factor. If `mock-device-plugin` is deployed, the actual value `nvidia.com/gpumem` in `node.status.capacity` will also be amplified by the corresponding multiple. | `1` |

--- a/i18n/zh/docusaurus-plugin-content-docs/current/userguide/configure.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/current/userguide/configure.md
@@ -26,7 +26,7 @@ translated: true
 | `nvidia.deviceSplitCount` | 整数 | 单块 GPU 可分配的最大任务数。 | `10` |
 | `nvidia.migstrategy` | 字符串 | 设置为 `"none"` 表示忽略 MIG 功能，设置为 `"mixed"` 表示以独立资源方式分配 MIG 设备。 | `"none"` |
 | `nvidia.disablecorelimit` | 字符串 | 设置为 `"true"` 表示禁用算力限制，设置为 `"false"` 表示启用算力限制。 | `"false"` |
-| `nvidia.defaultMem` | 整数 | 当前任务默认使用的设备显存（MB）。若为 `0`，则表示使用设备 100% 显存。 | `0` |
+| `nvidia.defaultMemory` | 整数 | 当前任务默认使用的设备显存（MB）。若为 `0`，则表示使用设备 100% 显存。 | `0` |
 | `nvidia.defaultCores` | 整数 | 当前任务默认预留的 GPU 算力百分比。`0` 表示只要显存够就可用任何 GPU；`100` 表示独占整块 GPU。 | `0` |
 | `nvidia.defaultGPUNum` | 整数 | 默认分配的 GPU 数量。若设为 `0`，则会被过滤。如果 Pod 的资源未显式设置 `nvidia.com/gpu`，则 Webhook 会检查是否设置了 `nvidia.com/gpumem`、`resource-mem-percentage` 或 `nvidia.com/gpucores`，若设置了其中任一项，则自动添加默认值的 `nvidia.com/gpu`。 | `1` |
 | `nvidia.memoryFactor` | 整数 | 在资源申请时 `nvidia.com/gpumem` 的真实值会放大相应的倍数。如果部署了 `mock-device-plugin`，在 `node.status.capacity` 的真实值也会放大对应的倍数。 | `1` |

--- a/i18n/zh/docusaurus-plugin-content-docs/version-v2.8.0/userguide/configure.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/version-v2.8.0/userguide/configure.md
@@ -28,7 +28,7 @@ translated: true
 | `nvidia.deviceSplitCount` | 整数 | 单块 GPU 可分配的最大任务数。 | `10` |
 | `nvidia.migstrategy` | 字符串 | 设置为 `"none"` 表示忽略 MIG 功能，设置为 `"mixed"` 表示以独立资源方式分配 MIG 设备。 | `"none"` |
 | `nvidia.disablecorelimit` | 字符串 | 设置为 `"true"` 表示禁用核心限制，设置为 `"false"` 表示启用核心限制。 | `"false"` |
-| `nvidia.defaultMem` | 整数 | 当前任务默认使用的设备显存（MB）。若为 `0`，则表示使用设备 100% 显存。 | `0` |
+| `nvidia.defaultMemory` | 整数 | 当前任务默认使用的设备显存（MB）。若为 `0`，则表示使用设备 100% 显存。 | `0` |
 | `nvidia.defaultCores` | 整数 | 当前任务默认预留的 GPU 核心百分比。`0` 表示只要显存够就可用任何 GPU；`100` 表示独占整块 GPU。 | `0` |
 | `nvidia.defaultGPUNum` | 整数 | 默认分配的 GPU 数量。若设为 `0`，则会被过滤。如果 Pod 的资源未显式设置 `nvidia.com/gpu`，则 webhook 会检查是否设置了 `nvidia.com/gpumem`、`resource-mem-percentage` 或 `nvidia.com/gpucores`，若设置了其中任一项，则自动添加默认值的 `nvidia.com/gpu`。 | `1` |
 | `nvidia.resourceCountName` | 字符串 | vGPU 数量的资源名。 | `"nvidia.com/gpu"` |

--- a/versioned_docs/version-v2.8.0/userguide/configure.md
+++ b/versioned_docs/version-v2.8.0/userguide/configure.md
@@ -30,7 +30,7 @@ You can update these configurations using one of the following methods:
    | `nvidia.deviceSplitCount` | Integer | Maximum jobs assigned to a single GPU device. | `10` |
    | `nvidia.migstrategy` | String | "none" for ignoring MIG features, "mixed" for allocating MIG devices by separate resources. | `"none"` |
    | `nvidia.disablecorelimit` | String | "true" to disable core limit, "false" to enable core limit. | `"false"` |
-   | `nvidia.defaultMem` | Integer | The default device memory of the current job, in MB. '0' means using 100% of the device memory. | `0` |
+   | `nvidia.defaultMemory` | Integer | The default device memory of the current job, in MB. '0' means using 100% of the device memory. | `0` |
    | `nvidia.defaultCores` | Integer | Percentage of GPU cores reserved for the current job. `0` allows any GPU with enough memory; `100` reserves the entire GPU exclusively. | `0` |
    | `nvidia.defaultGPUNum` | Integer | Default number of GPUs. If set to `0`, it will be filtered out. If `nvidia.com/gpu` is not set in the pod resource, the webhook checks `nvidia.com/gpumem`, `resource-mem-percentage`, and `nvidia.com/gpucores`, adding `nvidia.com/gpu` with this default value if any of them are set. | `1` |
    | `nvidia.memoryFactor` | Integer | During resource requests, the actual value of `nvidia.com/gpumem` will be multiplied by this factor. If `mock-device-plugin` is deployed, the actual value `nvidia.com/gpumem` in `node.status.capacity` will also be amplified by the corresponding multiple. | `1` |


### PR DESCRIPTION
## What this PR does

The device configuration table in the user guide lists the default memory option as `nvidia.defaultMem`, but the actual ConfigMap field is `defaultMemory` (Go struct tag `yaml:"defaultMemory"` in `pkg/device/nvidia/device.go`).

`defaultMem` was the name of the original CLI flag (`--default-mem`, default `5000`), introduced back in 2021. That flag was later superseded by the ConfigMap-based `defaultMemory` field and has since been removed from the scheduler. The docs were never updated, so users following them set a key that has no effect.

This PR renames `nvidia.defaultMem` -> `nvidia.defaultMemory` in:

- `docs/userguide/configure.md` (current, EN)
- `i18n/zh/docusaurus-plugin-content-docs/current/userguide/configure.md` (current, ZH)
- `versioned_docs/version-v2.8.0/userguide/configure.md` (v2.8.0, EN)
- `i18n/zh/docusaurus-plugin-content-docs/version-v2.8.0/userguide/configure.md` (v2.8.0, ZH)

Older versioned snapshots are intentionally left untouched.

## AI assistance disclosure

This change was prepared with AI assistance (Claude Code).