### PR TITLE
remove stale KubeCon India 2026 announcement bar

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -247,12 +247,6 @@ module.exports = {
     ],
   ],
   themeConfig: {
-    announcementBar: {
-      content: "kubecon_india_2026",
-      backgroundColor: "#1a1a2e",
-      textColor: "#ffffff",
-      isCloseable: true,
-    },
     image: "img/hami-graph-color.png",
     colorMode: {
       defaultMode: "dark",


### PR DESCRIPTION
KubeCon + CloudNativeCon India 2026 ended June 19. The announcement bar is no longer relevant.

Removes the `announcementBar` block from `docusaurus.config.js`.