### PR TITLE
fix wrong Slack channel ID in v2.9.0 release blog

### DIFF
--- a/blog/hami-v2-9-0-release/index.md
+++ b/blog/hami-v2-9-0-release/index.md
@@ -265,4 +265,4 @@ We sincerely welcome more developers, users, and ecosystem partners to join the 
 - Volcano vGPU Device Plugin: [https://github.com/Project-HAMi/volcano-vgpu-device-plugin](https://github.com/Project-HAMi/volcano-vgpu-device-plugin)
 - Documentation: [https://project-hami.io](https://project-hami.io)
 - Community Discord (recommended): [https://discord.gg/Amhy7XmbNq](https://discord.gg/Amhy7XmbNq)
-- Community CNCF Slack: [https://cloud-native.slack.com/archives/C08844T5WBQ](https://cloud-native.slack.com/archives/C08844T5WBQ)
+- Community CNCF Slack: [https://cloud-native.slack.com/archives/C07T10BU4R2](https://cloud-native.slack.com/archives/C07T10BU4R2)

--- a/i18n/zh/docusaurus-plugin-content-blog/hami-v2-9-0-release/index.md
+++ b/i18n/zh/docusaurus-plugin-content-blog/hami-v2-9-0-release/index.md
@@ -265,4 +265,4 @@ HAMi v2.9.0 是一次面向异构设备虚拟化深度、Kubernetes 原生标准
 - Volcano vGPU Device Plugin：[https://github.com/Project-HAMi/volcano-vgpu-device-plugin](https://github.com/Project-HAMi/volcano-vgpu-device-plugin)
 - 项目文档：[https://project-hami.io](https://project-hami.io)
 - 社区 Discord（推荐）：[https://discord.gg/Amhy7XmbNq](https://discord.gg/Amhy7XmbNq)
-- 社区 CNCF Slack：[https://cloud-native.slack.com/archives/C08844T5WBQ](https://cloud-native.slack.com/archives/C08844T5WBQ)
+- 社区 CNCF Slack：[https://cloud-native.slack.com/archives/C07T10BU4R2](https://cloud-native.slack.com/archives/C07T10BU4R2)


### PR DESCRIPTION
The v2.9.0 release blog (EN + ZH) linked to `C08844T5WBQ` which is not the HAMi channel.

All other pages on the site use `C07T10BU4R2` (`#hami-dev`). Fixed both language versions.