### PR TITLE
fix KE Holdings case study URL

### DIFF
--- a/src/data/caseStudies.js
+++ b/src/data/caseStudies.js
@@ -50,7 +50,7 @@ const caseStudiesData = [
         zh: "通过更可预测的调度能力，加速 AI 功能上线。",
       },
     ],
-    url: "https://www.cncf.io/case-studies/ke-holdings/",
+    url: "https://www.cncf.io/case-studies/ke-holdings-inc/",
   },
   {
     name: "DaoCloud",


### PR DESCRIPTION
`src/data/caseStudies.js` used `/case-studies/ke-holdings/` but the canonical CNCF slug is `/case-studies/ke-holdings-inc/`, which is what both the EN and ZH v2.9.0 blog posts already use.