### PR TITLE
fix Vaststream vendor URL on homepage

### DIFF
--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -285,7 +285,7 @@ const vendorEcosystem = [
     key: "vaststream",
     name: "Vaststream",
     logo: "img/ecosystem/vaststream.jpg",
-    href: "https://www.vastaitech.com",
+    href: "https://www.birentech.com",
   },
 ];
 


### PR DESCRIPTION
The Vaststream (壁仞 / Birentech) entry in the homepage vendor ecosystem list linked to `vastaitech.com`, which is Vastai Technologies - a different company.

Correct URL: `https://www.birentech.com`