### PR TITLE
add missing Vastai VA16 row to ZH device support table

### DIFF
--- a/i18n/zh/docusaurus-plugin-content-docs/current/userguide/device-supported.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/current/userguide/device-supported.md
@@ -16,4 +16,5 @@ HAMi 支持的设备如下表所示：
 | GPU      | 沐曦（Metax）             | MXC500            | 是       | 是       | 否       |
 | GCU      | 燧原科技（Enflame）       | S60               | 是       | 是       | 否       |
 | XPU      | 昆仑芯（Kunlunxin）       | P800              | 是       | 是       | 否       |
+| GPU      | 瀚博（Vastai）            | VA16              | 是       | 是       | 否       |
 | DPU      | 太初元碁（Teco）          | 检查中            | 进行中   | 进行中   | 否       |

--- a/i18n/zh/docusaurus-plugin-content-docs/version-v2.9.0/userguide/device-supported.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/version-v2.9.0/userguide/device-supported.md
@@ -16,4 +16,5 @@ HAMi 支持的设备如下表所示：
 | GPU      | 沐曦（Metax）             | MXC500            | 是       | 是       | 否       |
 | GCU      | 燧原科技（Enflame）       | S60               | 是       | 是       | 否       |
 | XPU      | 昆仑芯（Kunlunxin）       | P800              | 是       | 是       | 否       |
+| GPU      | 瀚博（Vastai）            | VA16              | 是       | 是       | 否       |
 | DPU      | 太初元碁（Teco）          | 检查中            | 进行中   | 进行中   | 否       |


### PR DESCRIPTION
The EN device support table has `| GPU | Vastai | VA16 |` (added in v2.9.0) but both the current and v2.9.0 versioned ZH translations were missing this row.

Added `| GPU | 瀚博（Vastai） | VA16 | 是 | 是 | 否 |` to both ZH files.