### PR TITLE
remove stale v2.4.0 example from releases.md

### DIFF
--- a/docs/releases.md
+++ b/docs/releases.md
@@ -12,7 +12,7 @@ This section provides guidelines on release timelines and release branch mainten
 
 ### Release Timelines
 
-HAMi uses the Semantic Versioning schema. HAMi v2.4.0 was released in September 2024. This project follows a given version number MAJOR.MINOR.PATCH.
+HAMi uses the Semantic Versioning schema. This project follows a given version number MAJOR.MINOR.PATCH.
 
 ### MAJOR release
 

--- a/i18n/zh/docusaurus-plugin-content-docs/current/releases.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/current/releases.md
@@ -13,7 +13,7 @@ translated: true
 
 ### 发布时间表
 
-HAMi 使用语义版本控制模式。HAMi v2.4.0 于 2024 年 9 月发布。该项目遵循给定的版本号 MAJOR.MINOR.PATCH。
+HAMi 使用语义版本控制模式。该项目遵循给定的版本号 MAJOR.MINOR.PATCH。
 
 ### MAJOR 版本
 

--- a/i18n/zh/docusaurus-plugin-content-docs/version-v2.9.0/releases.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/version-v2.9.0/releases.md
@@ -13,7 +13,7 @@ translated: true
 
 ### 发布时间表
 
-HAMi 使用语义版本控制模式。HAMi v2.4.0 于 2024 年 9 月发布。该项目遵循给定的版本号 MAJOR.MINOR.PATCH。
+HAMi 使用语义版本控制模式。该项目遵循给定的版本号 MAJOR.MINOR.PATCH。
 
 ### MAJOR 版本
 

--- a/versioned_docs/version-v2.9.0/releases.md
+++ b/versioned_docs/version-v2.9.0/releases.md
@@ -12,7 +12,7 @@ This section provides guidelines on release timelines and release branch mainten
 
 ### Release Timelines
 
-HAMi uses the Semantic Versioning schema. HAMi v2.4.0 was released in September 2024. This project follows a given version number MAJOR.MINOR.PATCH.
+HAMi uses the Semantic Versioning schema. This project follows a given version number MAJOR.MINOR.PATCH.
 
 ### MAJOR release
 


### PR DESCRIPTION
The sentence "HAMi v2.4.0 was released in September 2024" in the Release Timelines section is outdated. The current release is v2.9.0.

Removed from `docs/releases.md`, `versioned_docs/version-v2.9.0/releases.md`, and both ZH counterparts.