### PR TITLE
remove false .nvmrc reference from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ docs/
 
 ### Prerequisites
 
-- Node.js v20+ (configured in `.nvmrc`)
+- Node.js v20+
 - npm v10+
 
 ### Installation


### PR DESCRIPTION
README says Node.js is "configured in `.nvmrc`" but no `.nvmrc` file exists in the repo.

Removed the parenthetical.