### PR TITLE
Vendor lab manifests in-repo, fix broken hami-workshop links (#449)

### DIFF
--- a/i18n/zh/docusaurus-plugin-content-docs-tutorials/current/labs/gpu-partitioning.md
+++ b/i18n/zh/docusaurus-plugin-content-docs-tutorials/current/labs/gpu-partitioning.md
@@ -42,7 +42,7 @@ flowchart LR
 ## 前提条件
 
 - 已完成 [实验 1: 在线安装](./online-install.md) 的集群：HAMi 已安装，GPU 节点已标记 `gpu=on`
-- 来自 [`examples/03-gpu-partitioning/`](https://github.com/Project-HAMi/hami-workshop/tree/main/examples/03-gpu-partitioning) 的清单文件
+- 来自 [`tutorials/labs/examples/03-gpu-partitioning/`](https://github.com/Project-HAMi/website/tree/master/tutorials/labs/examples/03-gpu-partitioning) 的清单文件
 
 ## 步骤 1: 了解 HAMi 资源类型
 

--- a/i18n/zh/docusaurus-plugin-content-docs-tutorials/current/labs/hami-dra.md
+++ b/i18n/zh/docusaurus-plugin-content-docs-tutorials/current/labs/hami-dra.md
@@ -38,7 +38,7 @@ HAMi DRA 驱动实现了 [DRA Consumable Capacity](https://github.com/kubernetes
 ## 前提条件
 
 - 已完成 [实验 1](./online-install.md) 的集群，Kubernetes **v1.34 或更高版本**，已安装 HAMi 和 GPU Operator
-- 来自 [`examples/04-hami-dra/`](https://github.com/Project-HAMi/hami-workshop/tree/main/examples/04-hami-dra) 的清单文件
+- 来自 [`tutorials/labs/examples/04-hami-dra/`](https://github.com/Project-HAMi/website/tree/master/tutorials/labs/examples/04-hami-dra) 的清单文件
 
 ## 实验概览
 
@@ -54,7 +54,7 @@ flowchart LR
 
 ## 步骤 1: 启用 DRAConsumableCapacity Feature Gate
 
-DRA 本身在 v1.34 中已 GA，但*可消耗容量*（多个 Pod 从同一设备的容量池中抽取）需要在控制面组件和 kubelet 上启用 `DRAConsumableCapacity` Feature Gate。以 root 身份运行 [`enable-dra-feature-gates.sh`](https://github.com/Project-HAMi/hami-workshop/blob/main/examples/04-hami-dra/enable-dra-feature-gates.sh)：
+DRA 本身在 v1.34 中已 GA，但*可消耗容量*（多个 Pod 从同一设备的容量池中抽取）需要在控制面组件和 kubelet 上启用 `DRAConsumableCapacity` Feature Gate。以 root 身份运行 [`enable-dra-feature-gates.sh`](https://github.com/Project-HAMi/website/blob/master/tutorials/labs/examples/04-hami-dra/enable-dra-feature-gates.sh)：
 
 ```bash
 for f in kube-apiserver kube-scheduler kube-controller-manager; do

--- a/tutorials/labs/examples/03-gpu-partitioning/gpucores-pod.yaml
+++ b/tutorials/labs/examples/03-gpu-partitioning/gpucores-pod.yaml
@@ -1,0 +1,29 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: gpucores-pod
+spec:
+  restartPolicy: Never
+  containers:
+    - name: app
+      image: pytorch/pytorch:2.4.0-cuda12.1-cudnn9-runtime
+      env:
+        # "force" caps utilization strictly at gpucores.
+        # The default policy allows bursting above the cap while the GPU is idle.
+        - name: GPU_CORE_UTILIZATION_POLICY
+          value: "force"
+      command:
+        - python
+        - -c
+        - |
+          import torch
+          a = torch.randn(4096, 4096, device="cuda")
+          b = torch.randn(4096, 4096, device="cuda")
+          print("Starting matrix multiplication loop", flush=True)
+          while True:
+              a = a @ b / 4096
+      resources:
+        limits:
+          nvidia.com/gpu: 1 # request 1 vGPU
+          nvidia.com/gpumem: 4000 # limit this Pod to 4000 MiB of VRAM
+          nvidia.com/gpucores: 30 # limit this Pod to 30% of GPU compute

--- a/tutorials/labs/examples/03-gpu-partitioning/gpumem-pod-a.yaml
+++ b/tutorials/labs/examples/03-gpu-partitioning/gpumem-pod-a.yaml
@@ -1,0 +1,14 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: gpumem-pod-a
+spec:
+  restartPolicy: Never
+  containers:
+    - name: app
+      image: nvidia/cuda:12.4.1-base-ubuntu22.04
+      command: ["sleep", "infinity"]
+      resources:
+        limits:
+          nvidia.com/gpu: 1 # request 1 vGPU
+          nvidia.com/gpumem: 4000 # limit this Pod to 4000 MiB of VRAM

--- a/tutorials/labs/examples/03-gpu-partitioning/gpumem-pod-b.yaml
+++ b/tutorials/labs/examples/03-gpu-partitioning/gpumem-pod-b.yaml
@@ -1,0 +1,14 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: gpumem-pod-b
+spec:
+  restartPolicy: Never
+  containers:
+    - name: app
+      image: nvidia/cuda:12.4.1-base-ubuntu22.04
+      command: ["sleep", "infinity"]
+      resources:
+        limits:
+          nvidia.com/gpu: 1 # request 1 vGPU
+          nvidia.com/gpumem: 4000 # limit this Pod to 4000 MiB of VRAM

--- a/tutorials/labs/examples/03-gpu-partitioning/oom-test-pod.yaml
+++ b/tutorials/labs/examples/03-gpu-partitioning/oom-test-pod.yaml
@@ -1,0 +1,27 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: oom-test-pod
+spec:
+  restartPolicy: Never
+  containers:
+    - name: app
+      image: pytorch/pytorch:2.4.0-cuda12.1-cudnn9-runtime
+      command:
+        - python
+        - -c
+        - |
+          import torch
+          chunks = []
+          try:
+              while True:
+                  # allocate 512 MiB per iteration
+                  chunks.append(torch.empty(512, 1024, 1024, dtype=torch.uint8, device="cuda"))
+                  print(f"Allocated {len(chunks) * 512} MiB", flush=True)
+          except RuntimeError as e:
+              print(f"Hit the limit after {len(chunks) * 512} MiB:", flush=True)
+              print(str(e).split(".")[0], flush=True)
+      resources:
+        limits:
+          nvidia.com/gpu: 1 # request 1 vGPU
+          nvidia.com/gpumem: 4000 # limit this Pod to 4000 MiB of VRAM

--- a/tutorials/labs/examples/04-hami-dra/ds-gpu-operator.yaml
+++ b/tutorials/labs/examples/04-hami-dra/ds-gpu-operator.yaml
@@ -1,0 +1,147 @@
+# Source: https://github.com/Project-HAMi/k8s-dra-driver (demo/yaml/ds.yaml)
+# Adjusted for clusters where the NVIDIA GPU Operator manages the driver:
+# NVIDIA_DRIVER_ROOT and the driver-root hostPath point at /run/nvidia/driver
+# instead of / (use the upstream file unchanged if your driver is installed on the host).
+---
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  name: hami-dra-driver-kubelet-plugin
+  namespace: hami-dra-driver
+spec:
+  revisionHistoryLimit: 10
+  selector:
+    matchLabels:
+      hami-dra-driver-component: kubelet-plugin
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/instance: hami-dra-driver
+        app.kubernetes.io/name: hami-dra-driver
+        hami-dra-driver-component: kubelet-plugin
+    spec:
+      initContainers:
+        - name: init-container
+          image: projecthami/k8s-dra-driver:v0.1.0
+          securityContext:
+            privileged: true
+          command: [bash, /usr/bin/kubelet-plugin-prestart.sh]
+          env:
+            - name: NVIDIA_DRIVER_ROOT
+              value: /run/nvidia/driver
+            - name: NVIDIA_VISIBLE_DEVICES
+              value: void
+            - name: KUBELET_REGISTRAR_DIRECTORY_PATH
+              value: /var/lib/kubelet/plugins_registry
+            - name: KUBELET_PLUGINS_DIRECTORY_PATH
+              value: /var/lib/kubelet/plugins
+          volumeMounts:
+            - name: driver-root-parent
+              mountPath: /driver-root-parent
+              readOnly: true
+      containers:
+        - args:
+            - |-
+              # Conditionally mask the params file to prevent this container from
+              # recreating any missing GPU device nodes. This is necessary, for
+              # example, when running under nvkind to limit the set GPUs governed
+              # by the plugin even though it has cgroup access to all of them.
+              if [ "${MASK_NVIDIA_DRIVER_PARAMS}" = "true" ]; then
+                cp /proc/driver/nvidia/params root/gpu-params
+                sed -i 's/^ModifyDeviceFiles: 1$/ModifyDeviceFiles: 0/' root/gpu-params
+                mount --bind root/gpu-params /proc/driver/nvidia/params
+              fi
+              hami-kubelet-plugin -v 10
+          command:
+            - bash
+            - -c
+          env:
+            - name: MASK_NVIDIA_DRIVER_PARAMS
+              value: "true"
+            - name: NVIDIA_DRIVER_ROOT
+              value: /run/nvidia/driver
+            - name: NVIDIA_VISIBLE_DEVICES
+              value: void
+            - name: CDI_ROOT
+              value: /var/run/cdi
+            - name: NVIDIA_MIG_CONFIG_DEVICES
+              value: all
+            - name: NODE_NAME
+              valueFrom:
+                fieldRef:
+                  apiVersion: v1
+                  fieldPath: spec.nodeName
+            - name: NAMESPACE
+              valueFrom:
+                fieldRef:
+                  apiVersion: v1
+                  fieldPath: metadata.namespace
+            - name: KUBELET_REGISTRAR_DIRECTORY_PATH
+              value: /var/lib/kubelet/plugins_registry
+            - name: KUBELET_PLUGINS_DIRECTORY_PATH
+              value: /var/lib/kubelet/plugins
+            - name: IMAGE_NAME
+              value: projecthami/k8s-dra-driver:v0.1.0
+          lifecycle:
+            postStart:
+              exec:
+                command: ["/bin/bash", "-c", "/usr/bin/vgpu-init.sh /usr/local/vgpu/"]
+          image: projecthami/k8s-dra-driver:v0.1.0
+          imagePullPolicy: IfNotPresent
+          name: gpus
+          securityContext:
+            privileged: true
+          terminationMessagePath: /dev/termination-log
+          terminationMessagePolicy: File
+          volumeMounts:
+            - mountPath: /var/lib/kubelet/plugins_registry
+              name: plugins-registry
+            - mountPath: /var/lib/kubelet/plugins
+              mountPropagation: Bidirectional
+              name: plugins
+            - mountPath: /var/run/cdi
+              name: cdi
+            - mountPath: /driver-root
+              mountPropagation: HostToContainer
+              name: driver-root
+              readOnly: true
+            - mountPath: /usr/local/vgpu
+              name: host-vgpu
+            - mountPath: /tmp
+              name: host-tmp
+      dnsPolicy: ClusterFirst
+      serviceAccount: hami-dra-driver-service-account
+      serviceAccountName: hami-dra-driver-service-account
+      volumes:
+        - hostPath:
+            path: /var/lib/kubelet/plugins_registry
+            type: ""
+          name: plugins-registry
+        - hostPath:
+            path: /var/lib/kubelet/plugins
+            type: ""
+          name: plugins
+        - hostPath:
+            path: /var/run/cdi
+            type: ""
+          name: cdi
+        - hostPath:
+            path: /run/nvidia
+            type: DirectoryOrCreate
+          name: driver-root-parent
+        - hostPath:
+            path: /run/nvidia/driver
+            type: DirectoryOrCreate
+          name: driver-root
+        - hostPath:
+            path: /dev
+            type: ""
+          name: host-dev
+        - hostPath:
+            path: /usr/local/vgpu
+            type: DirectoryOrCreate
+          name: host-vgpu
+        - hostPath:
+            path: /tmp
+            type: ""
+          name: host-tmp

--- a/tutorials/labs/examples/04-hami-dra/enable-dra-feature-gates.sh
+++ b/tutorials/labs/examples/04-hami-dra/enable-dra-feature-gates.sh
@@ -1,0 +1,16 @@
+#!/bin/bash
+set -e
+for f in kube-apiserver kube-scheduler kube-controller-manager; do
+  grep -q 'DRAConsumableCapacity' /etc/kubernetes/manifests/$f.yaml || \
+  sed -i "/    - $f/a\\    - --feature-gates=DRAConsumableCapacity=true" /etc/kubernetes/manifests/$f.yaml
+done
+grep -q DRAConsumableCapacity /var/lib/kubelet/config.yaml || cat >> /var/lib/kubelet/config.yaml <<KEOF
+featureGates:
+  DRAConsumableCapacity: true
+KEOF
+systemctl restart kubelet
+echo "waiting for apiserver..."
+sleep 20
+until kubectl get nodes >/dev/null 2>&1; do sleep 5; done
+kubectl get nodes
+kubectl api-resources --api-group=resource.k8s.io | head -6

--- a/tutorials/labs/examples/04-hami-dra/pod-0.yaml
+++ b/tutorials/labs/examples/04-hami-dra/pod-0.yaml
@@ -1,0 +1,23 @@
+# Source: https://github.com/Project-HAMi/k8s-dra-driver (demo/yaml/pod-0.yaml)
+---
+apiVersion: v1
+kind: Pod
+metadata:
+  namespace: test-dra
+  name: pod-0
+spec:
+  containers:
+    - name: ctr0
+      image: ubuntu:24.04
+      command: ["bash", "-c"]
+      args: ["export; trap 'exit 0' TERM; sleep 9999 & wait"]
+      resources:
+        requests:
+          cpu: 1
+        limits:
+          cpu: 1
+        claims:
+          - name: single-gpu
+  resourceClaims:
+    - name: single-gpu
+      resourceClaimName: single-gpu-0

--- a/tutorials/labs/examples/04-hami-dra/pod-tpl-0.yaml
+++ b/tutorials/labs/examples/04-hami-dra/pod-tpl-0.yaml
@@ -1,0 +1,23 @@
+# Source: https://github.com/Project-HAMi/k8s-dra-driver (demo/yaml/pod-tpl-0.yaml)
+---
+apiVersion: v1
+kind: Pod
+metadata:
+  namespace: test-dra
+  name: pod-tpl-1
+spec:
+  containers:
+    - name: ctr0
+      image: ubuntu:24.04
+      command: ["bash", "-c"]
+      args: ["export; trap 'exit 0' TERM; sleep 9999 & wait"]
+      resources:
+        requests:
+          cpu: 1.5
+        limits:
+          cpu: 1.5
+        claims:
+          - name: gpu
+  resourceClaims:
+    - name: gpu
+      resourceClaimTemplateName: single-gpu-tpl

--- a/tutorials/labs/examples/04-hami-dra/rbac.yaml
+++ b/tutorials/labs/examples/04-hami-dra/rbac.yaml
@@ -1,0 +1,127 @@
+# Source: https://github.com/Project-HAMi/k8s-dra-driver (demo/yaml/rbac.yaml)
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: hami-dra-driver
+spec:
+  finalizers:
+    - kubernetes
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: hami-dra-driver-service-account
+  namespace: hami-dra-driver
+---
+apiVersion: v1
+items:
+  - apiVersion: rbac.authorization.k8s.io/v1
+    kind: Role
+    metadata:
+      name: hami-dra-driver-role
+      namespace: hami-dra-driver
+    rules:
+      - apiGroups:
+          - apps
+        resources:
+          - daemonsets
+          - deployments
+        verbs:
+          - get
+          - list
+          - watch
+          - create
+          - update
+          - patch
+          - delete
+kind: List
+metadata:
+  resourceVersion: ""
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: hami-dra-driver-role-binding
+  namespace: hami-dra-driver
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: hami-dra-driver-role
+subjects:
+  - kind: ServiceAccount
+    name: hami-dra-driver-service-account
+    namespace: hami-dra-driver
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: hami-dra-driver-clusterrole
+rules:
+  - apiGroups:
+      - resource.k8s.io
+    resources:
+      - resourceclaims
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - resource.k8s.io
+    resources:
+      - resourceclaimtemplates
+    verbs:
+      - get
+      - list
+      - watch
+      - create
+      - update
+      - delete
+  - apiGroups:
+      - resource.k8s.io
+    resources:
+      - resourceslices
+    verbs:
+      - get
+      - list
+      - watch
+      - create
+      - update
+      - delete
+  - apiGroups:
+      - resource.k8s.io
+    resources:
+      - resourceclaims/status
+    verbs:
+      - get
+      - update
+      - patch
+  - apiGroups:
+      - resource.k8s.io
+    resources:
+      - resourceclaims/driver
+    verbs:
+      - associated-node:update
+      - associated-node:patch
+  - apiGroups:
+      - ""
+    resources:
+      - nodes
+    verbs:
+      - get
+      - list
+      - watch
+      - update
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: hami-dra-driver-clusterrole-binding-hami-dra-driver
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: hami-dra-driver-clusterrole
+subjects:
+  - kind: ServiceAccount
+    name: hami-dra-driver-service-account
+    namespace: hami-dra-driver

--- a/tutorials/labs/examples/04-hami-dra/setup.yaml
+++ b/tutorials/labs/examples/04-hami-dra/setup.yaml
@@ -1,0 +1,75 @@
+# Source: https://github.com/Project-HAMi/k8s-dra-driver (demo/yaml/setup.yaml)
+---
+apiVersion: resource.k8s.io/v1
+kind: DeviceClass
+metadata:
+  name: hami-core-gpu.project-hami.io
+spec:
+  selectors:
+    - cel:
+        expression: |-
+          device.driver == "hami-core-gpu.project-hami.io" && device.attributes["hami-core-gpu.project-hami.io"].type == "hami-gpu"
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: test-dra
+
+---
+apiVersion: resource.k8s.io/v1
+kind: ResourceClaim
+metadata:
+  namespace: test-dra
+  name: single-gpu-0
+spec:
+  devices:
+    requests:
+      - name: single-gpu
+        exactly:
+          deviceClassName: hami-core-gpu.project-hami.io
+          capacity:
+            requests:
+              cores: 30
+              memory: "4Gi"
+
+---
+apiVersion: resource.k8s.io/v1
+kind: ResourceClaim
+metadata:
+  namespace: test-dra
+  name: double-gpu-0
+spec:
+  devices:
+    requests:
+      - name: double-gpu-0-0
+        exactly:
+          deviceClassName: hami-core-gpu.project-hami.io
+          capacity:
+            requests:
+              cores: 30
+              memory: "4Gi"
+      - name: double-gpu-0-1
+        exactly:
+          deviceClassName: hami-core-gpu.project-hami.io
+          capacity:
+            requests:
+              cores: 60
+              memory: "8Gi"
+
+---
+apiVersion: resource.k8s.io/v1
+kind: ResourceClaimTemplate
+metadata:
+  namespace: test-dra
+  name: single-gpu-tpl
+spec:
+  spec:
+    devices:
+      requests:
+        - name: single-gpu
+          exactly:
+            deviceClassName: hami-core-gpu.project-hami.io
+            capacity:
+              requests:
+                cores: 30
+                memory: "4Gi"

--- a/tutorials/labs/gpu-partitioning.md
+++ b/tutorials/labs/gpu-partitioning.md
@@ -42,7 +42,7 @@ flowchart LR
 ## Prerequisites
 
 - A cluster from [Lab 1: Online Installation](./online-install.md): HAMi installed, GPU node labeled `gpu=on`
-- The manifests from [`examples/03-gpu-partitioning/`](https://github.com/Project-HAMi/hami-workshop/tree/main/examples/03-gpu-partitioning)
+- The manifests from [`tutorials/labs/examples/03-gpu-partitioning/`](https://github.com/Project-HAMi/website/tree/master/tutorials/labs/examples/03-gpu-partitioning)
 
 ## Step 1: Understand HAMi Resource Types
 

--- a/tutorials/labs/hami-dra.md
+++ b/tutorials/labs/hami-dra.md
@@ -38,7 +38,7 @@ The HAMi DRA driver implements the [DRA Consumable Capacity](https://github.com/
 ## Prerequisites
 
 - A cluster from [Lab 1](./online-install.md) on Kubernetes **v1.34 or newer**, with HAMi and GPU Operator installed
-- The manifests from [`examples/04-hami-dra/`](https://github.com/Project-HAMi/hami-workshop/tree/main/examples/04-hami-dra)
+- The manifests from [`tutorials/labs/examples/04-hami-dra/`](https://github.com/Project-HAMi/website/tree/master/tutorials/labs/examples/04-hami-dra)
 
 ## Lab Overview
 
@@ -54,7 +54,7 @@ flowchart LR
 
 ## Step 1: Enable the DRAConsumableCapacity Feature Gate
 
-DRA itself is GA in v1.34, but _consumable capacity_ (multiple Pods drawing from one device's capacity pool) requires the `DRAConsumableCapacity` feature gate on the control plane components and the kubelet. Run [`enable-dra-feature-gates.sh`](https://github.com/Project-HAMi/hami-workshop/blob/main/examples/04-hami-dra/enable-dra-feature-gates.sh) as root:
+DRA itself is GA in v1.34, but _consumable capacity_ (multiple Pods drawing from one device's capacity pool) requires the `DRAConsumableCapacity` feature gate on the control plane components and the kubelet. Run [`enable-dra-feature-gates.sh`](https://github.com/Project-HAMi/website/blob/master/tutorials/labs/examples/04-hami-dra/enable-dra-feature-gates.sh) as root:
 
 ```bash
 for f in kube-apiserver kube-scheduler kube-controller-manager; do


### PR DESCRIPTION
## Problem

Fixes #449.

The GPU partitioning and DRA labs referenced manifest files in the now-**archived** [`Project-HAMi/hami-workshop`](https://github.com/Project-HAMi/hami-workshop) repo, but those directories no longer exist there, so readers hit 404s:

| Lab doc | Broken link |
|---|---|
| `tutorials/labs/gpu-partitioning.md` | `hami-workshop/.../examples/03-gpu-partitioning/` |
| `tutorials/labs/hami-dra.md` | `hami-workshop/.../examples/04-hami-dra/` (+ `enable-dra-feature-gates.sh`) |
| `i18n/zh/.../labs/gpu-partitioning.md` | same |
| `i18n/zh/.../labs/hami-dra.md` | same |

## Fix

Following the issue's recommendation, the manifests are **vendored into this repo** so the labs are self-contained and no longer depend on an archived external repo:

- Added `tutorials/labs/examples/03-gpu-partitioning/` — `gpumem-pod-a.yaml`, `gpumem-pod-b.yaml`, `oom-test-pod.yaml`, `gpucores-pod.yaml`
- Added `tutorials/labs/examples/04-hami-dra/` — `enable-dra-feature-gates.sh`, `rbac.yaml`, `ds-gpu-operator.yaml`, `setup.yaml`, `pod-0.yaml`, `pod-tpl-0.yaml`
- Repointed all four doc links (English + Chinese) from `Project-HAMi/hami-workshop` to the in-repo `Project-HAMi/website` copies

The manifests are byte-for-byte the files that were used to verify the labs. The legitimate `hami-workshop` mentions that remain are the node/VM/pool names in captured command output, which intentionally reflect the real test environment.

## Testing

`npm run build` passes for both `en` and `zh` locales with no broken-link errors (`onBrokenLinks: "throw"`).
