### PR TITLE
fix: remove outdated glibc upper bound from prerequisites

### DIFF
--- a/docs/installation/prerequisites.md
+++ b/docs/installation/prerequisites.md
@@ -7,7 +7,6 @@ Before installing HAMi, make sure the following tools and dependencies are prope
 - NVIDIA drivers >= 440
 - default runtime configured as nvidia for containerd/docker/cri-o container runtime
 - Kubernetes version >= 1.23
-- glibc >= 2.17 & glibc < 2.30
 - helm > 3.0
 
 ## Preparing your GPU Nodes

--- a/i18n/zh/docusaurus-plugin-content-docs/current/installation/prerequisites.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/current/installation/prerequisites.md
@@ -8,7 +8,6 @@ title: 前置条件
 - nvidia-docker 版本 > 2.0
 - 默认运行时配置为 NVIDIA 运行时
 - Kubernetes 版本 >= 1.18
-- glibc >= 2.17 且 glibc < 2.30
 - kernel 版本 >= 3.10
 - helm 版本 > 3.0
 

--- a/i18n/zh/docusaurus-plugin-content-docs/version-v2.8.0/installation/prerequisites.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/version-v2.8.0/installation/prerequisites.md
@@ -9,7 +9,6 @@ translated: true
 - nvidia-docker 版本 > 2.0
 - 默认运行时配置为 NVIDIA 运行时
 - Kubernetes 版本 >= 1.18
-- glibc >= 2.17 & glibc < 2.30
 - kernel 版本 >= 3.10
 - helm 版本 > 3.0
 

--- a/i18n/zh/docusaurus-plugin-content-docs/version-v2.9.0/installation/prerequisites.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/version-v2.9.0/installation/prerequisites.md
@@ -8,7 +8,6 @@ title: 前置条件
 - nvidia-docker 版本 > 2.0
 - 默认运行时配置为 NVIDIA 运行时
 - Kubernetes 版本 >= 1.18
-- glibc >= 2.17 且 glibc < 2.30
 - kernel 版本 >= 3.10
 - helm 版本 > 3.0
 

--- a/versioned_docs/version-v2.8.0/installation/prerequisites.md
+++ b/versioned_docs/version-v2.8.0/installation/prerequisites.md
@@ -8,7 +8,6 @@ Before installing HAMi, make sure the following tools and dependencies are prope
 - nvidia-docker version > 2.0
 - default runtime configured as nvidia for containerd/docker/cri-o container runtime
 - Kubernetes version >= 1.18
-- glibc >= 2.17 & glibc < 2.30
 - kernel version >= 3.10
 - helm > 3.0
 

--- a/versioned_docs/version-v2.9.0/installation/prerequisites.md
+++ b/versioned_docs/version-v2.9.0/installation/prerequisites.md
@@ -8,7 +8,6 @@ Before installing HAMi, make sure the following tools and dependencies are prope
 - nvidia-docker version > 2.0
 - default runtime configured as nvidia for containerd/docker/cri-o container runtime
 - Kubernetes version >= 1.18
-- glibc >= 2.17 & glibc < 2.30
 - kernel version >= 3.10
 - helm > 3.0
 


### PR DESCRIPTION
The constraint `glibc < 2.30` blocks Ubuntu 22.04+ (ships glibc 2.35) and any modern Linux distro. This constraint is not enforced or tested by the project. Removes the line entirely.