### PR TITLE
fix: remove stale kernel version requirement from prerequisites

### DIFF
--- a/docs/installation/prerequisites.md
+++ b/docs/installation/prerequisites.md
@@ -9,7 +9,6 @@ Before installing HAMi, make sure the following tools and dependencies are prope
 - default runtime configured as nvidia for containerd/docker/cri-o container runtime
 - Kubernetes version >= 1.18
 - glibc >= 2.17 & glibc < 2.30
-- kernel version >= 3.10
 - helm > 3.0
 
 ## Preparing your GPU Nodes


### PR DESCRIPTION
Kernel 3.10 is from 2013 and EOL. No supported Kubernetes version runs on kernel 3.10. This entry signals outdated docs without adding value. Removes it.