### PR TITLE
fix: update minimum Kubernetes version in prerequisites

### DIFF
--- a/docs/installation/prerequisites.md
+++ b/docs/installation/prerequisites.md
@@ -7,7 +7,7 @@ Before installing HAMi, make sure the following tools and dependencies are prope
 - NVIDIA drivers >= 440
 - nvidia-docker version > 2.0
 - default runtime configured as nvidia for containerd/docker/cri-o container runtime
-- Kubernetes version >= 1.18
+- Kubernetes version >= 1.23
 - glibc >= 2.17 & glibc < 2.30
 - kernel version >= 3.10
 - helm > 3.0


### PR DESCRIPTION
The stated minimum of k8s 1.18 is outdated. HAMi uses APIs and features that require at least 1.23. Updates the minimum to 1.23.