### PR TITLE
fix: mark MIG support as completed in roadmap

### DIFF
--- a/docs/contributor/roadmap.md
+++ b/docs/contributor/roadmap.md
@@ -24,7 +24,7 @@ sidebar_label: Roadmap
 ## Planned Features
 
 - [ ] Support video codec processing
-- [ ] Support Multi-Instance GPUs (MIG)
+- [x] Support Multi-Instance GPUs (MIG)
 - [ ] Support flexible scheduling policies
   - [x] binpack
   - [x] spread


### PR DESCRIPTION
MIG support was released in v2.5.0+ and is documented in docs/userguide/nvidia-device/dynamic-mig-support.md. The roadmap checkbox is still unchecked. Marks it as complete.