### PR TITLE
fix: remove deprecated nvidia-docker from prerequisites

### DIFF
--- a/docs/installation/prerequisites.md
+++ b/docs/installation/prerequisites.md
@@ -5,7 +5,6 @@ title: Prerequisites
 Before installing HAMi, make sure the following tools and dependencies are properly installed in your environment:
 
 - NVIDIA drivers >= 440
-- nvidia-docker version > 2.0
 - default runtime configured as nvidia for containerd/docker/cri-o container runtime
 - Kubernetes version >= 1.18
 - glibc >= 2.17 & glibc < 2.30


### PR DESCRIPTION
`nvidia-docker` is deprecated. The page already describes the correct tool (`nvidia-container-toolkit`) in the setup guide below. Removes the outdated bullet point from the requirements list.