### PR TITLE
fix: correct CNCF Slack channel ID in v2.9.0 blog post

### DIFF
--- a/blog/hami-v2-9-0-release/index.md
+++ b/blog/hami-v2-9-0-release/index.md
@@ -265,4 +265,4 @@ We sincerely welcome more developers, users, and ecosystem partners to join the 
 - Volcano vGPU Device Plugin: [https://github.com/Project-HAMi/volcano-vgpu-device-plugin](https://github.com/Project-HAMi/volcano-vgpu-device-plugin)
 - Documentation: [https://project-hami.io](https://project-hami.io)
 - Community Discord (recommended): [https://discord.gg/Amhy7XmbNq](https://discord.gg/Amhy7XmbNq)
-- Community CNCF Slack: [https://cloud-native.slack.com/archives/C08844T5WBQ](https://cloud-native.slack.com/archives/C08844T5WBQ)
+- Community CNCF Slack: [https://cloud-native.slack.com/archives/C07T10BU4R2](https://cloud-native.slack.com/archives/C07T10BU4R2)


### PR DESCRIPTION
The CNCF Slack link in the v2.9.0 release post used channel ID `C08844T5WBQ`. Every other page (contributing.md, community.js, other blog posts) uses `C07T10BU4R2`. Standardizes to the correct channel ID.