### PR TITLE
fix: remove outdated version reference from releases page

### DIFF
--- a/docs/releases.md
+++ b/docs/releases.md
@@ -12,7 +12,7 @@ This section provides guidelines on release timelines and release branch mainten
 
 ### Release Timelines
 
-HAMi uses the Semantic Versioning schema. HAMi v2.4.0 was released in September 2024. This project follows a given version number MAJOR.MINOR.PATCH.
+HAMi uses the Semantic Versioning schema. This project follows a given version number MAJOR.MINOR.PATCH.
 
 ### MAJOR release
 


### PR DESCRIPTION
The releases page mentioned "HAMi v2.4.0 was released in September 2024" as an example. The current release is v2.9.0, making this misleading. Removes the version-specific sentence.