### PR TITLE
fix: correct Vastai Chinese label in ecosystem section

### DIFF
--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -108,7 +108,7 @@ const heroDeviceEcosystem = [
   },
   {
     key: "vaststream",
-    label: { en: "Vaststream", zh: "壁仞" },
+    label: { en: "Vaststream", zh: "瀚博半导体" },
     logo: "img/ecosystem/vaststream.jpg",
   },
 ];


### PR DESCRIPTION
The Chinese label for Vastai Technologies was set to "壁仞" (which is Biren Technology's Chinese name). The correct Chinese name for Vastai Technologies is "瀚博半导体".

Note: a related PR (fix/vaststream-english-name) changes the English label from "Vaststream" to "Vastai". That PR may need a trivial rebase after this one merges.