### PR TITLE
fix: use canonical AWS homepage URL in ecosystem section

### DIFF
--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -237,7 +237,7 @@ const vendorEcosystem = [
     logo: "img/ecosystem/nvidia.svg",
     href: "https://www.nvidia.com",
   },
-  { key: "aws", name: "AWS", logo: "img/ecosystem/aws.svg", href: "https://www.aws.com" },
+  { key: "aws", name: "AWS", logo: "img/ecosystem/aws.svg", href: "https://aws.amazon.com" },
   {
     key: "ascend",
     name: "Huawei Ascend",


### PR DESCRIPTION
`www.aws.com` redirects to `aws.amazon.com` but using the non-canonical URL is fragile. Change to the canonical URL.