### PR TITLE
fix: rename Vaststream to Vastai in ecosystem section

### DIFF
--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -108,7 +108,7 @@ const heroDeviceEcosystem = [
   },
   {
     key: "vaststream",
-    label: { en: "Vaststream", zh: "瀚博半导体" },
+    label: { en: "Vastai", zh: "瀚博半导体" },
     logo: "img/ecosystem/vaststream.jpg",
   },
 ];
@@ -283,7 +283,7 @@ const vendorEcosystem = [
   },
   {
     key: "vaststream",
-    name: "Vaststream",
+    name: "Vastai",
     logo: "img/ecosystem/vaststream.jpg",
     href: "https://www.birentech.com",
   },


### PR DESCRIPTION
The display name "Vaststream" is inconsistent with the rest of the site. All docs (userguide/vastai/, device-supported.md) and the v2.9.0 blog post use "Vastai". Standardizes to "Vastai" in the homepage ecosystem section.

Note: a related PR (fix/vaststream-zh-label) fixes the Chinese label. That PR should merge first to avoid a trivial conflict on the same line.