### PR TITLE
fix: remove deprecated --short flag from kubectl version command

### DIFF
--- a/docs/installation/upgrade.md
+++ b/docs/installation/upgrade.md
@@ -17,7 +17,7 @@ Verify that your target HAMi version is compatible with your current Kubernetes 
 helm list -n kube-system | grep hami
 
 # Kubernetes version
-kubectl version --short
+kubectl version
 
 # NVIDIA driver version (on GPU nodes)
 nvidia-smi | grep "Driver Version"


### PR DESCRIPTION
\`kubectl version --short\` was removed in Kubernetes 1.28. Users on any modern cluster will get an error. Removes the flag so the command works.