### PR TITLE
fix: correct NVIDIA capitalization in community page

### DIFF
--- a/src/pages/community.js
+++ b/src/pages/community.js
@@ -32,7 +32,7 @@ const maintainers = [
   {
     name: "Leibo Wang",
     github: "https://github.com/william-wang",
-    employer: "Nvidia",
+    employer: "NVIDIA",
     employerZh: "英伟达",
     employerUrl: "https://www.nvidia.com",
   },


### PR DESCRIPTION
The company's official name is "NVIDIA" (all caps), not "Nvidia".