### PR TITLE
fix: remove duplicate Enflame and incorrect AMD from v2.9.0 blog device list

### DIFF
--- a/blog/hami-v2-9-0-release/index.md
+++ b/blog/hami-v2-9-0-release/index.md
@@ -130,7 +130,7 @@ resources:
 #   vastaitech.com/nouse-va: "1"
 ```
 
-With Vastai device support, HAMi now covers over a dozen heterogeneous compute devices including **NVIDIA, Huawei Ascend, Cambricon, Hygon DCU, Biren, Enflame, MetaX, Kunlunxin, AMD, Iluvatar, Enflame, AWS Neuron, and Vastai Technologies**, making it one of the widest-supported heterogeneous device virtualization and scheduling projects in the Kubernetes ecosystem.
+With Vastai device support, HAMi now covers over a dozen heterogeneous compute devices including **NVIDIA, Huawei Ascend, Cambricon, Hygon DCU, Biren, Enflame, MetaX, Kunlunxin, Iluvatar, AWS Neuron, and Vastai Technologies**, making it one of the widest-supported heterogeneous device virtualization and scheduling projects in the Kubernetes ecosystem.
 
 ## Observability and Security Enhancements
 


### PR DESCRIPTION
The device list in the v2.9.0 blog post listed "Enflame" twice and included "AMD" which is not yet a supported device (it is listed as planned in the roadmap). Removes the duplicate and the incorrect entry.

Note: this PR also removes AMD (issue 15) from the list since both fixes are on the same line.