### PR TITLE
fix: use correct namespace in v2.9.0 upgrade command

### DIFF
--- a/blog/hami-v2-9-0-release/index.md
+++ b/blog/hami-v2-9-0-release/index.md
@@ -200,7 +200,7 @@ Upgrade to v2.9.0 via Helm:
 ```bash
 helm repo add hami-charts https://project-hami.github.io/HAMi/
 helm repo update
-helm upgrade hami hami-charts/hami -n hami-system
+helm upgrade hami hami-charts/hami -n kube-system
 ```
 
 For complete installation documentation, refer to: [https://project-hami.io/docs/installation/online-installation](https://project-hami.io/docs/installation/online-installation)


### PR DESCRIPTION
The upgrade command in the v2.9.0 blog post used `-n hami-system` but the standard installation uses `-n kube-system` (as documented in online-installation.md). Using the wrong namespace would upgrade the wrong Helm release.