### PR TITLE
fix: update minimum Go version to 1.26 in contributing guide

### DIFF
--- a/docs/contributor/contributing.md
+++ b/docs/contributor/contributing.md
@@ -60,7 +60,7 @@ Before opening an issue or PR, search existing issues and discussions for relate
 
 **For HAMi core (Go):**
 
-- Go 1.21+
+- Go 1.26+
 - `kubectl` and access to a Kubernetes cluster with a supported GPU or accelerator
 
 **For documentation (website):**


### PR DESCRIPTION
The contributing guide listed Go 1.21+ but the v2.9.0 release upgraded the project to Go 1.26.2. Contributors building from source need Go 1.26+.