### PR TITLE
fix: add Ascend 910C to supported device table

### DIFF
--- a/docs/userguide/device-supported.md
+++ b/docs/userguide/device-supported.md
@@ -9,7 +9,7 @@ The table below lists the devices supported by HAMi:
 | GPU  | NVIDIA        | All               | Yes             | Yes           | Yes               |
 | MLU  | Cambricon     | 370, 590          | Yes             | Yes           | No                |
 | DCU  | Hygon         | Z100, Z100L       | Yes             | Yes           | No                |
-| NPU  | Huawei Ascend | 910B, 910B3, 310P | Yes             | Yes           | No                |
+| NPU  | Huawei Ascend | 910B, 910B3, 910C, 310P | Yes             | Yes           | No                |
 | GPU  | Iluvatar      | All               | Yes             | Yes           | No                |
 | GPU  | Mthreads      | MTT S4000         | Yes             | Yes           | No                |
 | GPU  | Metax         | MXC500            | Yes             | Yes           | No                |

--- a/i18n/zh/docusaurus-plugin-content-docs/current/userguide/device-supported.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/current/userguide/device-supported.md
@@ -10,7 +10,7 @@ HAMi 支持的设备如下表所示：
 | GPU      | 英伟达（NVIDIA）          | 全系列            | 是       | 是       | 是       |
 | MLU      | 寒武纪（Cambricon）       | 370、590          | 是       | 是       | 否       |
 | DCU      | 海光（Hygon）             | Z100、Z100L       | 是       | 是       | 否       |
-| NPU      | 华为昇腾（Huawei Ascend） | 910B、910B3、310P | 是       | 是       | 否       |
+| NPU      | 华为昇腾（Huawei Ascend） | 910B、910B3、910C、310P | 是       | 是       | 否       |
 | GPU      | 天数智芯（Iluvatar）      | 全部              | 是       | 是       | 否       |
 | GPU      | 摩尔线程（Mthreads）      | MTT S4000         | 是       | 是       | 否       |
 | GPU      | 沐曦（Metax）             | MXC500            | 是       | 是       | 否       |

--- a/i18n/zh/docusaurus-plugin-content-docs/version-v2.9.0/userguide/device-supported.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/version-v2.9.0/userguide/device-supported.md
@@ -10,7 +10,7 @@ HAMi 支持的设备如下表所示：
 | GPU      | 英伟达（NVIDIA）          | 全系列            | 是       | 是       | 是       |
 | MLU      | 寒武纪（Cambricon）       | 370、590          | 是       | 是       | 否       |
 | DCU      | 海光（Hygon）             | Z100、Z100L       | 是       | 是       | 否       |
-| NPU      | 华为昇腾（Huawei Ascend） | 910B、910B3、310P | 是       | 是       | 否       |
+| NPU      | 华为昇腾（Huawei Ascend） | 910B、910B3、910C、310P | 是       | 是       | 否       |
 | GPU      | 天数智芯（Iluvatar）      | 全部              | 是       | 是       | 否       |
 | GPU      | 摩尔线程（Mthreads）      | MTT S4000         | 是       | 是       | 否       |
 | GPU      | 沐曦（Metax）             | MXC500            | 是       | 是       | 否       |

--- a/versioned_docs/version-v2.9.0/userguide/device-supported.md
+++ b/versioned_docs/version-v2.9.0/userguide/device-supported.md
@@ -9,7 +9,7 @@ The table below lists the devices supported by HAMi:
 | GPU  | NVIDIA        | All               | Yes             | Yes           | Yes               |
 | MLU  | Cambricon     | 370, 590          | Yes             | Yes           | No                |
 | DCU  | Hygon         | Z100, Z100L       | Yes             | Yes           | No                |
-| NPU  | Huawei Ascend | 910B, 910B3, 310P | Yes             | Yes           | No                |
+| NPU  | Huawei Ascend | 910B, 910B3, 910C, 310P | Yes             | Yes           | No                |
 | GPU  | Iluvatar      | All               | Yes             | Yes           | No                |
 | GPU  | Mthreads      | MTT S4000         | Yes             | Yes           | No                |
 | GPU  | Metax         | MXC500            | Yes             | Yes           | No                |


### PR DESCRIPTION
The v2.9.0 release added support for Ascend 910C (HAMi-core mode) but the device-supported table was not updated. Adds 910C to the Huawei Ascend row.