### PR TITLE
fix: mark DRA support as completed in roadmap

### DIFF
--- a/docs/contributor/roadmap.md
+++ b/docs/contributor/roadmap.md
@@ -31,7 +31,7 @@ sidebar_label: Roadmap
   - [ ] numa affinity
 - [ ] Integrated gpu-operator
 - [ ] Rich observability support
-- [ ] DRA support
+- [x] DRA support
 - [ ] Support Intel GPU device
 - [ ] Support AMD GPU device
 - [x] Support Enflame GCU device


### PR DESCRIPTION
DRA support shipped as GA in v2.9.0 (HAMi-DRA subproject). The roadmap checkbox is still unchecked. Marks it as complete.