### PR TITLE
fix: use full Moore Threads name in FAQ table

### DIFF
--- a/docs/faq/faq.md
+++ b/docs/faq/faq.md
@@ -11,7 +11,7 @@ title: FAQ
 | Hygon | Z100, Z100L, K100-AI | Core 1%, Memory 1M | Supported, but splitting is not supported when `dcu > 1`. The entire card is exclusively allocated. |
 | Cambricon | 370, 590 | Core 1%, Memory 256M | Supported, but splitting is not supported when `mlu > 1`. The entire card is exclusively allocated. |
 | Iluvatar | All | Core 1%, Memory 256M | Supported, but splitting is not supported when `gpu > 1`. The entire card is exclusively allocated. |
-| Mthreads | MTT S4000 | Core 1 core group, Memory 512M | Supported, but splitting is not supported when `gpu > 1`. The entire card is exclusively allocated. |
+| Moore Threads | MTT S4000 | Core 1 core group, Memory 512M | Supported, but splitting is not supported when `gpu > 1`. The entire card is exclusively allocated. |
 | Metax | MXC500 | Does not support splitting, only whole card allocation is possible. | Supported, but all allocations are for whole cards. |
 
 ## What is vGPU? Why cannot I allocate two vGPUs on the same card despite seeing 10 vGPUs?


### PR DESCRIPTION
The FAQ table used "Mthreads" but the correct company name is "Moore Threads". The roadmap already uses "Moore Threads". Standardizes the FAQ to match.