### PR TITLE
fix: improve wording in releases page versioning section

### DIFF
--- a/docs/releases.md
+++ b/docs/releases.md
@@ -34,7 +34,7 @@ Patch releases are for backwards-compatible bug fixes and very minor enhancement
 
 HAMi uses GitHub tags to manage versions. New releases and release candidates are published using the wildcard tag `v<major>.<minor>.<patch>`.
 
-Whenever a PR is merged into the master branch, CI will pull the latest code, generate an image and upload it to the mirror repository. The latest image of HAMi components can usually be downloaded online using the latest tag. Whenever a release is released, the image will also be released, and the tag is the same as the tag of the release above.
+Whenever a PR is merged into the master branch, CI will pull the latest code, generate an image and publish it to the container registry. The latest image of HAMi components can usually be downloaded online using the latest tag. Whenever a release is published, the image will also be published, and the tag is the same as the tag of the release above.
 
 ### Issues
 


### PR DESCRIPTION
Two wording issues in the same sentence on the releases page:
- "Whenever a release is released" is redundant
- "mirror repository" confuses English readers (sounds like a git mirror; the intended meaning is container registry)

Fixes both in one commit since they are in the same sentence.