### PR TITLE
docs: align monitoring metric names with HAMi v2.9 exporters

### DIFF
--- a/docs/userguide/monitoring/device-allocation.md
+++ b/docs/userguide/monitoring/device-allocation.md
@@ -13,14 +13,14 @@ It contains the following metrics:
 
 | Metrics | Description | Example |
 | --- | --- | --- |
-| GPUDeviceCoreLimit | GPUDeviceCoreLimit Device memory core limit for a certain GPU | `{deviceidx="0",deviceuuid="GPU-00552014-5c87-89ac-b1a6-7b53aa24b0ec",nodeid="aio-node67",zone="vGPU"}` 100 |
-| GPUDeviceMemoryLimit | GPUDeviceMemoryLimit Device memory limit for a certain GPU | `{deviceidx="0",deviceuuid="GPU-00552014-5c87-89ac-b1a6-7b53aa24b0ec",nodeid="aio-node67",zone="vGPU"}` 3.4359738368e+10 |
-| GPUDeviceCoreAllocated | Device core allocated for a certain GPU | `{deviceidx="0",deviceuuid="GPU-00552014-5c87-89ac-b1a6-7b53aa24b0ec",nodeid="aio-node67",zone="vGPU"}` 45 |
-| GPUDeviceMemoryAllocated | Device memory allocated for a certain GPU | `{devicecores="0",deviceidx="0",deviceuuid="aio-node74-arm-Ascend310P-0",nodeid="aio-node74-arm",zone="vGPU"}` 3.221225472e+09 |
-| GPUDeviceSharedNum | Number of containers sharing this GPU | `{deviceidx="0",deviceuuid="GPU-00552014-5c87-89ac-b1a6-7b53aa24b0ec",nodeid="aio-node67",zone="vGPU"}` 1 |
-| vGPUCoreAllocated | vGPU core allocated from a container | `{containeridx="Ascend310P",deviceuuid="aio-node74-arm-Ascend310P-0",nodename="aio-node74-arm",podname="ascend310p-pod",podnamespace="default",zone="vGPU"}` 50 |
-| vGPUMemoryAllocated | vGPU memory allocated from a container | `{containeridx="Ascend310P",deviceuuid="aio-node74-arm-Ascend310P-0",nodename="aio-node74-arm",podname="ascend310p-pod",podnamespace="default",zone="vGPU"}` 3.221225472e+09 |
-| QuotaUsed | resourcequota usage for a certain device | `{quotaName="nvidia.com/gpucores", quotanamespace="default",limit="200",zone="vGPU"}` 100 |
+| hami_gpu_core_limit_ratio | Device core limit for a certain GPU | `{device_index="0",device_uuid="GPU-00552014-5c87-89ac-b1a6-7b53aa24b0ec",node="aio-node67",zone="vGPU"}` 100 |
+| hami_gpu_memory_limit_bytes | Device memory limit for a certain GPU | `{device_index="0",device_uuid="GPU-00552014-5c87-89ac-b1a6-7b53aa24b0ec",node="aio-node67",zone="vGPU"}` 3.4359738368e+10 |
+| hami_gpu_core_allocated_ratio | Device core allocated for a certain GPU | `{device_index="0",device_uuid="GPU-00552014-5c87-89ac-b1a6-7b53aa24b0ec",node="aio-node67",zone="vGPU"}` 45 |
+| hami_gpu_memory_allocated_bytes | Device memory allocated for a certain GPU | `{device_cores="0",device_index="0",device_uuid="aio-node74-arm-Ascend310P-0",node="aio-node74-arm",zone="vGPU"}` 3.221225472e+09 |
+| hami_gpu_shared_count | Number of containers sharing this GPU | `{device_index="0",device_uuid="GPU-00552014-5c87-89ac-b1a6-7b53aa24b0ec",node="aio-node67",zone="vGPU"}` 1 |
+| hami_vgpu_core_allocated_ratio | vGPU core allocated from a container | `{container_index="Ascend310P",device_uuid="aio-node74-arm-Ascend310P-0",node="aio-node74-arm",pod="ascend310p-pod",namespace="default",zone="vGPU"}` 50 |
+| hami_vgpu_memory_allocated_bytes | vGPU memory allocated from a container | `{container_index="Ascend310P",device_uuid="aio-node74-arm-Ascend310P-0",node="aio-node74-arm",pod="ascend310p-pod",namespace="default",zone="vGPU"}` 3.221225472e+09 |
+| hami_resource_quota_used | resourcequota usage for a certain device | `{quota_name="nvidia.com/gpucores", namespace="default",limit="200",zone="vGPU"}` 100 |
 
 If you are using [HAMi DRA](../../installation/how-to-use-hami-dra), the metrics will be:
 

--- a/docs/userguide/monitoring/grafana-dashboard.md
+++ b/docs/userguide/monitoring/grafana-dashboard.md
@@ -39,10 +39,10 @@ For Prometheus Operator, create a `ServiceMonitor` targeting the `hami-device-pl
 
 Key metrics:
 
-| Metric                            | Description                                |
-| --------------------------------- | ------------------------------------------ |
-| `hami_host_gpu_utilization_ratio` | GPU real-time utilization on host (0–100)  |
-| `hami_host_gpu_memory_used_bytes` | GPU real-time device memory usage on host  |
+| Metric                            | Description                               |
+| --------------------------------- | ----------------------------------------- |
+| `hami_host_gpu_utilization_ratio` | GPU real-time utilization on host (0–100) |
+| `hami_host_gpu_memory_used_bytes` | GPU real-time device memory usage on host |
 
 ## Prerequisites
 

--- a/docs/userguide/monitoring/grafana-dashboard.md
+++ b/docs/userguide/monitoring/grafana-dashboard.md
@@ -39,11 +39,10 @@ For Prometheus Operator, create a `ServiceMonitor` targeting the `hami-device-pl
 
 Key metrics:
 
-| Metric                                 | Description                                 |
-| -------------------------------------- | ------------------------------------------- |
-| `Device_memory_desc_of_container`      | Virtual GPU memory allocated to a container |
-| `Device_utilization_desc_of_container` | GPU compute utilization per container       |
-| `Device_memory_limit_of_container`     | Memory limit set for the container          |
+| Metric                            | Description                                |
+| --------------------------------- | ------------------------------------------ |
+| `hami_host_gpu_utilization_ratio` | GPU real-time utilization on host (0–100)  |
+| `hami_host_gpu_memory_used_bytes` | GPU real-time device memory usage on host  |
 
 ## Prerequisites
 

--- a/docs/userguide/monitoring/real-time-device-usage.md
+++ b/docs/userguide/monitoring/real-time-device-usage.md
@@ -13,9 +13,5 @@ It contains the following metrics:
 
 | Metrics | Description | Example |
 | --- | --- | --- |
-| Device_memory_desc_of_container | Container device memory real-time usage | `{context="0",ctrname="2-1-3-pod-1",data="0",deviceuuid="GPU-00552014-5c87-89ac-b1a6-7b53aa24b0ec",module="0",offset="0",podname="2-1-3-pod-1",podnamespace="default",vdeviceid="0",zone="vGPU"}` 0 |
-| Device_utilization_desc_of_container | Container device real-time utilization | `{ctrname="2-1-3-pod-1",deviceuuid="GPU-00552014-5c87-89ac-b1a6-7b53aa24b0ec",podname="2-1-3-pod-1",podnamespace="default",vdeviceid="0",zone="vGPU"}` 0 |
-| HostCoreUtilization | GPU real-time utilization on host | `{deviceidx="0",deviceuuid="GPU-00552014-5c87-89ac-b1a6-7b53aa24b0ec",zone="vGPU"}` 0 |
-| HostGPUMemoryUsage | GPU real-time device memory usage on host | `{deviceidx="0",deviceuuid="GPU-00552014-5c87-89ac-b1a6-7b53aa24b0ec",zone="vGPU"}` 2.87244288e+08 |
-| vGPU_device_memory_limit_in_bytes | device limit for a certain container | `{ctrname="2-1-3-pod-1",deviceuuid="GPU-00552014-5c87-89ac-b1a6-7b53aa24b0ec",podname="2-1-3-pod-1",podnamespace="default",vdeviceid="0",zone="vGPU"}` 2.62144e+09 |
-| vGPU_device_memory_usage_in_bytes | device usage for a certain container | `{ctrname="2-1-3-pod-1",deviceuuid="GPU-00552014-5c87-89ac-b1a6-7b53aa24b0ec",podname="2-1-3-pod-1",podnamespace="default",vdeviceid="0",zone="vGPU"}` 0 |
+| hami_host_gpu_utilization_ratio | GPU real-time utilization on host | `{device_index="0",device_uuid="GPU-00552014-5c87-89ac-b1a6-7b53aa24b0ec",zone="vGPU"}` 0 |
+| hami_host_gpu_memory_used_bytes | GPU real-time device memory usage on host | `{device_index="0",device_uuid="GPU-00552014-5c87-89ac-b1a6-7b53aa24b0ec",zone="vGPU"}` 2.87244288e+08 |

--- a/i18n/zh/docusaurus-plugin-content-docs/current/userguide/monitoring/device-allocation.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/current/userguide/monitoring/device-allocation.md
@@ -14,14 +14,14 @@ curl {scheduler node ip}:31993/metrics
 
 | 指标 | 描述 | 示例 |
 | --- | --- | --- |
-| GPUDeviceCoreLimit | GPU 设备核心限制 | `{deviceidx="0",deviceuuid="GPU-00552014-5c87-89ac-b1a6-7b53aa24b0ec",nodeid="aio-node67",zone="vGPU"}` 100 |
-| GPUDeviceMemoryLimit | GPU 设备显存限制 | `{deviceidx="0",deviceuuid="GPU-00552014-5c87-89ac-b1a6-7b53aa24b0ec",nodeid="aio-node67",zone="vGPU"}` 3.4359738368e+10 |
-| GPUDeviceCoreAllocated | 分配给某个 GPU 的设备核心 | `{deviceidx="0",deviceuuid="GPU-00552014-5c87-89ac-b1a6-7b53aa24b0ec",nodeid="aio-node67",zone="vGPU"}` 45 |
-| GPUDeviceMemoryAllocated | 分配给某个 GPU 的设备显存 | `{devicecores="0",deviceidx="0",deviceuuid="aio-node74-arm-Ascend310P-0",nodeid="aio-node74-arm",zone="vGPU"}` 3.221225472e+09 |
-| GPUDeviceSharedNum | 共享此 GPU 的容器数量 | `{deviceidx="0",deviceuuid="GPU-00552014-5c87-89ac-b1a6-7b53aa24b0ec",nodeid="aio-node67",zone="vGPU"}` 1 |
-| vGPUCoreAllocated | 分配给某个容器的 vGPU 核心数量 | `{containeridx="Ascend310P",deviceuuid="aio-node74-arm-Ascend310P-0",nodename="aio-node74-arm",podname="ascend310p-pod",podnamespace="default",zone="vGPU"}` 50 |
-| vGPUMemoryAllocated | 分配给某个容器的 vGPU 显存 | `{containeridx="Ascend310P",deviceuuid="aio-node74-arm-Ascend310P-0",nodename="aio-node74-arm",podname="ascend310p-pod",podnamespace="default",zone="vGPU"}` 3.221225472e+09 |
-| QuotaUsed | resourcequota 的使用情况 | `{quotaName="nvidia.com/gpucores", quotanamespace="default",limit="200",zone="vGPU"}` 100 |
+| hami_gpu_core_limit_ratio | GPU 设备核心限制 | `{device_index="0",device_uuid="GPU-00552014-5c87-89ac-b1a6-7b53aa24b0ec",node="aio-node67",zone="vGPU"}` 100 |
+| hami_gpu_memory_limit_bytes | GPU 设备显存限制 | `{device_index="0",device_uuid="GPU-00552014-5c87-89ac-b1a6-7b53aa24b0ec",node="aio-node67",zone="vGPU"}` 3.4359738368e+10 |
+| hami_gpu_core_allocated_ratio | 分配给某个 GPU 的设备核心 | `{device_index="0",device_uuid="GPU-00552014-5c87-89ac-b1a6-7b53aa24b0ec",node="aio-node67",zone="vGPU"}` 45 |
+| hami_gpu_memory_allocated_bytes | 分配给某个 GPU 的设备显存 | `{device_cores="0",device_index="0",device_uuid="aio-node74-arm-Ascend310P-0",node="aio-node74-arm",zone="vGPU"}` 3.221225472e+09 |
+| hami_gpu_shared_count | 共享此 GPU 的容器数量 | `{device_index="0",device_uuid="GPU-00552014-5c87-89ac-b1a6-7b53aa24b0ec",node="aio-node67",zone="vGPU"}` 1 |
+| hami_vgpu_core_allocated_ratio | 分配给某个容器的 vGPU 核心数量 | `{container_index="Ascend310P",device_uuid="aio-node74-arm-Ascend310P-0",node="aio-node74-arm",pod="ascend310p-pod",namespace="default",zone="vGPU"}` 50 |
+| hami_vgpu_memory_allocated_bytes | 分配给某个容器的 vGPU 显存 | `{container_index="Ascend310P",device_uuid="aio-node74-arm-Ascend310P-0",node="aio-node74-arm",pod="ascend310p-pod",namespace="default",zone="vGPU"}` 3.221225472e+09 |
+| hami_resource_quota_used | resourcequota 的使用情况 | `{quota_name="nvidia.com/gpucores", namespace="default",limit="200",zone="vGPU"}` 100 |
 
 如果你在使用 [HAMi DRA](../../installation/how-to-use-hami-dra), 它将暴露如下指标 :
 

--- a/i18n/zh/docusaurus-plugin-content-docs/current/userguide/monitoring/grafana-dashboard.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/current/userguide/monitoring/grafana-dashboard.md
@@ -38,11 +38,10 @@ scrape_configs:
 
 关键指标：
 
-| 指标                                   | 说明                      |
-| -------------------------------------- | ------------------------- |
-| `Device_memory_desc_of_container`      | 分配给容器的虚拟 GPU 显存 |
-| `Device_utilization_desc_of_container` | 每容器的 GPU 算力利用率   |
-| `Device_memory_limit_of_container`     | 为容器设置的显存限制      |
+| 指标                              | 说明                              |
+| --------------------------------- | --------------------------------- |
+| `hami_host_gpu_utilization_ratio` | 主机上的 GPU 实时利用率（0–100）  |
+| `hami_host_gpu_memory_used_bytes` | 主机上的 GPU 实时设备显存使用情况 |
 
 ## 前置条件
 

--- a/i18n/zh/docusaurus-plugin-content-docs/current/userguide/monitoring/real-time-device-usage.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/current/userguide/monitoring/real-time-device-usage.md
@@ -14,9 +14,5 @@ curl {GPU 节点 IP}:31992/metrics
 
 | 指标 | 描述 | 示例 |
 | --- | --- | --- |
-| Device_memory_desc_of_container | 容器设备显存实时使用情况 | `{context="0",ctrname="2-1-3-pod-1",data="0",deviceuuid="GPU-00552014-5c87-89ac-b1a6-7b53aa24b0ec",module="0",offset="0",podname="2-1-3-pod-1",podnamespace="default",vdeviceid="0",zone="vGPU"}` 0 |
-| Device_utilization_desc_of_container | 容器设备实时利用率 | `{ctrname="2-1-3-pod-1",deviceuuid="GPU-00552014-5c87-89ac-b1a6-7b53aa24b0ec",podname="2-1-3-pod-1",podnamespace="default",vdeviceid="0",zone="vGPU"}` 0 |
-| HostCoreUtilization | 主机上的 GPU 实时利用率 | `{deviceidx="0",deviceuuid="GPU-00552014-5c87-89ac-b1a6-7b53aa24b0ec",zone="vGPU"}` 0 |
-| HostGPUMemoryUsage | 主机上的 GPU 实时设备显存使用情况 | `{deviceidx="0",deviceuuid="GPU-00552014-5c87-89ac-b1a6-7b53aa24b0ec",zone="vGPU"}` 2.87244288e+08 |
-| vGPU_device_memory_limit_in_bytes | 某个容器的设备限制 | `{ctrname="2-1-3-pod-1",deviceuuid="GPU-00552014-5c87-89ac-b1a6-7b53aa24b0ec",podname="2-1-3-pod-1",podnamespace="default",vdeviceid="0",zone="vGPU"}` 2.62144e+09 |
-| vGPU_device_memory_usage_in_bytes | 某个容器的设备使用情况 | `{ctrname="2-1-3-pod-1",deviceuuid="GPU-00552014-5c87-89ac-b1a6-7b53aa24b0ec",podname="2-1-3-pod-1",podnamespace="default",vdeviceid="0",zone="vGPU"}` 0 |
+| hami_host_gpu_utilization_ratio | 主机上的 GPU 实时利用率 | `{device_index="0",device_uuid="GPU-00552014-5c87-89ac-b1a6-7b53aa24b0ec",zone="vGPU"}` 0 |
+| hami_host_gpu_memory_used_bytes | 主机上的 GPU 实时设备显存使用情况 | `{device_index="0",device_uuid="GPU-00552014-5c87-89ac-b1a6-7b53aa24b0ec",zone="vGPU"}` 2.87244288e+08 |

--- a/i18n/zh/docusaurus-plugin-content-docs/version-v2.9.0/userguide/monitoring/device-allocation.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/version-v2.9.0/userguide/monitoring/device-allocation.md
@@ -14,14 +14,14 @@ curl {scheduler node ip}:31993/metrics
 
 | 指标 | 描述 | 示例 |
 | --- | --- | --- |
-| GPUDeviceCoreLimit | GPU 设备核心限制 | `{deviceidx="0",deviceuuid="GPU-00552014-5c87-89ac-b1a6-7b53aa24b0ec",nodeid="aio-node67",zone="vGPU"}` 100 |
-| GPUDeviceMemoryLimit | GPU 设备显存限制 | `{deviceidx="0",deviceuuid="GPU-00552014-5c87-89ac-b1a6-7b53aa24b0ec",nodeid="aio-node67",zone="vGPU"}` 3.4359738368e+10 |
-| GPUDeviceCoreAllocated | 分配给某个 GPU 的设备核心 | `{deviceidx="0",deviceuuid="GPU-00552014-5c87-89ac-b1a6-7b53aa24b0ec",nodeid="aio-node67",zone="vGPU"}` 45 |
-| GPUDeviceMemoryAllocated | 分配给某个 GPU 的设备显存 | `{devicecores="0",deviceidx="0",deviceuuid="aio-node74-arm-Ascend310P-0",nodeid="aio-node74-arm",zone="vGPU"}` 3.221225472e+09 |
-| GPUDeviceSharedNum | 共享此 GPU 的容器数量 | `{deviceidx="0",deviceuuid="GPU-00552014-5c87-89ac-b1a6-7b53aa24b0ec",nodeid="aio-node67",zone="vGPU"}` 1 |
-| vGPUCoreAllocated | 分配给某个容器的 vGPU 核心数量 | `{containeridx="Ascend310P",deviceuuid="aio-node74-arm-Ascend310P-0",nodename="aio-node74-arm",podname="ascend310p-pod",podnamespace="default",zone="vGPU"}` 50 |
-| vGPUMemoryAllocated | 分配给某个容器的 vGPU 显存 | `{containeridx="Ascend310P",deviceuuid="aio-node74-arm-Ascend310P-0",nodename="aio-node74-arm",podname="ascend310p-pod",podnamespace="default",zone="vGPU"}` 3.221225472e+09 |
-| QuotaUsed | resourcequota 的使用情况 | `{quotaName="nvidia.com/gpucores", quotanamespace="default",limit="200",zone="vGPU"}` 100 |
+| hami_gpu_core_limit_ratio | GPU 设备核心限制 | `{device_index="0",device_uuid="GPU-00552014-5c87-89ac-b1a6-7b53aa24b0ec",node="aio-node67",zone="vGPU"}` 100 |
+| hami_gpu_memory_limit_bytes | GPU 设备显存限制 | `{device_index="0",device_uuid="GPU-00552014-5c87-89ac-b1a6-7b53aa24b0ec",node="aio-node67",zone="vGPU"}` 3.4359738368e+10 |
+| hami_gpu_core_allocated_ratio | 分配给某个 GPU 的设备核心 | `{device_index="0",device_uuid="GPU-00552014-5c87-89ac-b1a6-7b53aa24b0ec",node="aio-node67",zone="vGPU"}` 45 |
+| hami_gpu_memory_allocated_bytes | 分配给某个 GPU 的设备显存 | `{device_cores="0",device_index="0",device_uuid="aio-node74-arm-Ascend310P-0",node="aio-node74-arm",zone="vGPU"}` 3.221225472e+09 |
+| hami_gpu_shared_count | 共享此 GPU 的容器数量 | `{device_index="0",device_uuid="GPU-00552014-5c87-89ac-b1a6-7b53aa24b0ec",node="aio-node67",zone="vGPU"}` 1 |
+| hami_vgpu_core_allocated_ratio | 分配给某个容器的 vGPU 核心数量 | `{container_index="Ascend310P",device_uuid="aio-node74-arm-Ascend310P-0",node="aio-node74-arm",pod="ascend310p-pod",namespace="default",zone="vGPU"}` 50 |
+| hami_vgpu_memory_allocated_bytes | 分配给某个容器的 vGPU 显存 | `{container_index="Ascend310P",device_uuid="aio-node74-arm-Ascend310P-0",node="aio-node74-arm",pod="ascend310p-pod",namespace="default",zone="vGPU"}` 3.221225472e+09 |
+| hami_resource_quota_used | resourcequota 的使用情况 | `{quota_name="nvidia.com/gpucores", namespace="default",limit="200",zone="vGPU"}` 100 |
 
 如果你在使用 [HAMi DRA](../../installation/how-to-use-hami-dra), 它将暴露如下指标 :
 

--- a/i18n/zh/docusaurus-plugin-content-docs/version-v2.9.0/userguide/monitoring/grafana-dashboard.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/version-v2.9.0/userguide/monitoring/grafana-dashboard.md
@@ -38,11 +38,10 @@ scrape_configs:
 
 关键指标：
 
-| 指标                                   | 说明                      |
-| -------------------------------------- | ------------------------- |
-| `Device_memory_desc_of_container`      | 分配给容器的虚拟 GPU 显存 |
-| `Device_utilization_desc_of_container` | 每容器的 GPU 算力利用率   |
-| `Device_memory_limit_of_container`     | 为容器设置的显存限制      |
+| 指标                              | 说明                              |
+| --------------------------------- | --------------------------------- |
+| `hami_host_gpu_utilization_ratio` | 主机上的 GPU 实时利用率（0–100）  |
+| `hami_host_gpu_memory_used_bytes` | 主机上的 GPU 实时设备显存使用情况 |
 
 ## 前置条件
 

--- a/i18n/zh/docusaurus-plugin-content-docs/version-v2.9.0/userguide/monitoring/real-time-device-usage.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/version-v2.9.0/userguide/monitoring/real-time-device-usage.md
@@ -14,9 +14,5 @@ curl {GPU 节点 IP}:31992/metrics
 
 | 指标 | 描述 | 示例 |
 | --- | --- | --- |
-| Device_memory_desc_of_container | 容器设备显存实时使用情况 | `{context="0",ctrname="2-1-3-pod-1",data="0",deviceuuid="GPU-00552014-5c87-89ac-b1a6-7b53aa24b0ec",module="0",offset="0",podname="2-1-3-pod-1",podnamespace="default",vdeviceid="0",zone="vGPU"}` 0 |
-| Device_utilization_desc_of_container | 容器设备实时利用率 | `{ctrname="2-1-3-pod-1",deviceuuid="GPU-00552014-5c87-89ac-b1a6-7b53aa24b0ec",podname="2-1-3-pod-1",podnamespace="default",vdeviceid="0",zone="vGPU"}` 0 |
-| HostCoreUtilization | 主机上的 GPU 实时利用率 | `{deviceidx="0",deviceuuid="GPU-00552014-5c87-89ac-b1a6-7b53aa24b0ec",zone="vGPU"}` 0 |
-| HostGPUMemoryUsage | 主机上的 GPU 实时设备显存使用情况 | `{deviceidx="0",deviceuuid="GPU-00552014-5c87-89ac-b1a6-7b53aa24b0ec",zone="vGPU"}` 2.87244288e+08 |
-| vGPU_device_memory_limit_in_bytes | 某个容器的设备限制 | `{ctrname="2-1-3-pod-1",deviceuuid="GPU-00552014-5c87-89ac-b1a6-7b53aa24b0ec",podname="2-1-3-pod-1",podnamespace="default",vdeviceid="0",zone="vGPU"}` 2.62144e+09 |
-| vGPU_device_memory_usage_in_bytes | 某个容器的设备使用情况 | `{ctrname="2-1-3-pod-1",deviceuuid="GPU-00552014-5c87-89ac-b1a6-7b53aa24b0ec",podname="2-1-3-pod-1",podnamespace="default",vdeviceid="0",zone="vGPU"}` 0 |
+| hami_host_gpu_utilization_ratio | 主机上的 GPU 实时利用率 | `{device_index="0",device_uuid="GPU-00552014-5c87-89ac-b1a6-7b53aa24b0ec",zone="vGPU"}` 0 |
+| hami_host_gpu_memory_used_bytes | 主机上的 GPU 实时设备显存使用情况 | `{device_index="0",device_uuid="GPU-00552014-5c87-89ac-b1a6-7b53aa24b0ec",zone="vGPU"}` 2.87244288e+08 |

--- a/versioned_docs/version-v2.9.0/userguide/monitoring/device-allocation.md
+++ b/versioned_docs/version-v2.9.0/userguide/monitoring/device-allocation.md
@@ -13,14 +13,14 @@ It contains the following metrics:
 
 | Metrics | Description | Example |
 | --- | --- | --- |
-| GPUDeviceCoreLimit | GPUDeviceCoreLimit Device memory core limit for a certain GPU | `{deviceidx="0",deviceuuid="GPU-00552014-5c87-89ac-b1a6-7b53aa24b0ec",nodeid="aio-node67",zone="vGPU"}` 100 |
-| GPUDeviceMemoryLimit | GPUDeviceMemoryLimit Device memory limit for a certain GPU | `{deviceidx="0",deviceuuid="GPU-00552014-5c87-89ac-b1a6-7b53aa24b0ec",nodeid="aio-node67",zone="vGPU"}` 3.4359738368e+10 |
-| GPUDeviceCoreAllocated | Device core allocated for a certain GPU | `{deviceidx="0",deviceuuid="GPU-00552014-5c87-89ac-b1a6-7b53aa24b0ec",nodeid="aio-node67",zone="vGPU"}` 45 |
-| GPUDeviceMemoryAllocated | Device memory allocated for a certain GPU | `{devicecores="0",deviceidx="0",deviceuuid="aio-node74-arm-Ascend310P-0",nodeid="aio-node74-arm",zone="vGPU"}` 3.221225472e+09 |
-| GPUDeviceSharedNum | Number of containers sharing this GPU | `{deviceidx="0",deviceuuid="GPU-00552014-5c87-89ac-b1a6-7b53aa24b0ec",nodeid="aio-node67",zone="vGPU"}` 1 |
-| vGPUCoreAllocated | vGPU core allocated from a container | `{containeridx="Ascend310P",deviceuuid="aio-node74-arm-Ascend310P-0",nodename="aio-node74-arm",podname="ascend310p-pod",podnamespace="default",zone="vGPU"}` 50 |
-| vGPUMemoryAllocated | vGPU memory allocated from a container | `{containeridx="Ascend310P",deviceuuid="aio-node74-arm-Ascend310P-0",nodename="aio-node74-arm",podname="ascend310p-pod",podnamespace="default",zone="vGPU"}` 3.221225472e+09 |
-| QuotaUsed | resourcequota usage for a certain device | `{quotaName="nvidia.com/gpucores", quotanamespace="default",limit="200",zone="vGPU"}` 100 |
+| hami_gpu_core_limit_ratio | Device core limit for a certain GPU | `{device_index="0",device_uuid="GPU-00552014-5c87-89ac-b1a6-7b53aa24b0ec",node="aio-node67",zone="vGPU"}` 100 |
+| hami_gpu_memory_limit_bytes | Device memory limit for a certain GPU | `{device_index="0",device_uuid="GPU-00552014-5c87-89ac-b1a6-7b53aa24b0ec",node="aio-node67",zone="vGPU"}` 3.4359738368e+10 |
+| hami_gpu_core_allocated_ratio | Device core allocated for a certain GPU | `{device_index="0",device_uuid="GPU-00552014-5c87-89ac-b1a6-7b53aa24b0ec",node="aio-node67",zone="vGPU"}` 45 |
+| hami_gpu_memory_allocated_bytes | Device memory allocated for a certain GPU | `{device_cores="0",device_index="0",device_uuid="aio-node74-arm-Ascend310P-0",node="aio-node74-arm",zone="vGPU"}` 3.221225472e+09 |
+| hami_gpu_shared_count | Number of containers sharing this GPU | `{device_index="0",device_uuid="GPU-00552014-5c87-89ac-b1a6-7b53aa24b0ec",node="aio-node67",zone="vGPU"}` 1 |
+| hami_vgpu_core_allocated_ratio | vGPU core allocated from a container | `{container_index="Ascend310P",device_uuid="aio-node74-arm-Ascend310P-0",node="aio-node74-arm",pod="ascend310p-pod",namespace="default",zone="vGPU"}` 50 |
+| hami_vgpu_memory_allocated_bytes | vGPU memory allocated from a container | `{container_index="Ascend310P",device_uuid="aio-node74-arm-Ascend310P-0",node="aio-node74-arm",pod="ascend310p-pod",namespace="default",zone="vGPU"}` 3.221225472e+09 |
+| hami_resource_quota_used | resourcequota usage for a certain device | `{quota_name="nvidia.com/gpucores", namespace="default",limit="200",zone="vGPU"}` 100 |
 
 If you are using [HAMi DRA](../../installation/how-to-use-hami-dra), the metrics will be:
 

--- a/versioned_docs/version-v2.9.0/userguide/monitoring/grafana-dashboard.md
+++ b/versioned_docs/version-v2.9.0/userguide/monitoring/grafana-dashboard.md
@@ -39,10 +39,10 @@ For Prometheus Operator, create a `ServiceMonitor` targeting the `hami-device-pl
 
 Key metrics:
 
-| Metric                            | Description                                |
-| --------------------------------- | ------------------------------------------ |
-| `hami_host_gpu_utilization_ratio` | GPU real-time utilization on host (0–100)  |
-| `hami_host_gpu_memory_used_bytes` | GPU real-time device memory usage on host  |
+| Metric                            | Description                               |
+| --------------------------------- | ----------------------------------------- |
+| `hami_host_gpu_utilization_ratio` | GPU real-time utilization on host (0–100) |
+| `hami_host_gpu_memory_used_bytes` | GPU real-time device memory usage on host |
 
 ## Prerequisites
 

--- a/versioned_docs/version-v2.9.0/userguide/monitoring/grafana-dashboard.md
+++ b/versioned_docs/version-v2.9.0/userguide/monitoring/grafana-dashboard.md
@@ -39,11 +39,10 @@ For Prometheus Operator, create a `ServiceMonitor` targeting the `hami-device-pl
 
 Key metrics:
 
-| Metric                                 | Description                                 |
-| -------------------------------------- | ------------------------------------------- |
-| `Device_memory_desc_of_container`      | Virtual GPU memory allocated to a container |
-| `Device_utilization_desc_of_container` | GPU compute utilization per container       |
-| `Device_memory_limit_of_container`     | Memory limit set for the container          |
+| Metric                            | Description                                |
+| --------------------------------- | ------------------------------------------ |
+| `hami_host_gpu_utilization_ratio` | GPU real-time utilization on host (0–100)  |
+| `hami_host_gpu_memory_used_bytes` | GPU real-time device memory usage on host  |
 
 ## Prerequisites
 

--- a/versioned_docs/version-v2.9.0/userguide/monitoring/real-time-device-usage.md
+++ b/versioned_docs/version-v2.9.0/userguide/monitoring/real-time-device-usage.md
@@ -13,9 +13,5 @@ It contains the following metrics:
 
 | Metrics | Description | Example |
 | --- | --- | --- |
-| Device_memory_desc_of_container | Container device memory real-time usage | `{context="0",ctrname="2-1-3-pod-1",data="0",deviceuuid="GPU-00552014-5c87-89ac-b1a6-7b53aa24b0ec",module="0",offset="0",podname="2-1-3-pod-1",podnamespace="default",vdeviceid="0",zone="vGPU"}` 0 |
-| Device_utilization_desc_of_container | Container device real-time utilization | `{ctrname="2-1-3-pod-1",deviceuuid="GPU-00552014-5c87-89ac-b1a6-7b53aa24b0ec",podname="2-1-3-pod-1",podnamespace="default",vdeviceid="0",zone="vGPU"}` 0 |
-| HostCoreUtilization | GPU real-time utilization on host | `{deviceidx="0",deviceuuid="GPU-00552014-5c87-89ac-b1a6-7b53aa24b0ec",zone="vGPU"}` 0 |
-| HostGPUMemoryUsage | GPU real-time device memory usage on host | `{deviceidx="0",deviceuuid="GPU-00552014-5c87-89ac-b1a6-7b53aa24b0ec",zone="vGPU"}` 2.87244288e+08 |
-| vGPU_device_memory_limit_in_bytes | device limit for a certain container | `{ctrname="2-1-3-pod-1",deviceuuid="GPU-00552014-5c87-89ac-b1a6-7b53aa24b0ec",podname="2-1-3-pod-1",podnamespace="default",vdeviceid="0",zone="vGPU"}` 2.62144e+09 |
-| vGPU_device_memory_usage_in_bytes | device usage for a certain container | `{ctrname="2-1-3-pod-1",deviceuuid="GPU-00552014-5c87-89ac-b1a6-7b53aa24b0ec",podname="2-1-3-pod-1",podnamespace="default",vdeviceid="0",zone="vGPU"}` 0 |
+| hami_host_gpu_utilization_ratio | GPU real-time utilization on host | `{device_index="0",device_uuid="GPU-00552014-5c87-89ac-b1a6-7b53aa24b0ec",zone="vGPU"}` 0 |
+| hami_host_gpu_memory_used_bytes | GPU real-time device memory usage on host | `{device_index="0",device_uuid="GPU-00552014-5c87-89ac-b1a6-7b53aa24b0ec",zone="vGPU"}` 2.87244288e+08 |


### PR DESCRIPTION
### What

The monitoring docs still list the pre-v2.9 metric names (CamelCase) and old label
keys. On a running v2.9 cluster the exporters emit Prometheus-style `hami_*`
snake_case names with renamed labels, and the device-plugin endpoint no longer
exposes the per-container series. This updates the docs to match the actual output.

### Changes
- `userguide/monitoring/device-allocation.md` — scheduler endpoint (`:31993`):
  rename the 8 metrics to their `hami_*` names and fix the label keys
  (`device_index`/`device_uuid`/`node`/`container_index`/`namespace`/`pod`/`quota_name`).
- `userguide/monitoring/real-time-device-usage.md` — device-plugin endpoint (`:31992`):
  v2.9 only exposes `hami_host_gpu_utilization_ratio` and
  `hami_host_gpu_memory_used_bytes`; renamed those and removed the four
  per-container rows that are no longer emitted.
- `userguide/monitoring/grafana-dashboard.md` — same `:31992` correction.
- Mirrored the same fixes into `versioned_docs/version-v2.9.0/`.

Metric name mapping:

| old | v2.9 |
| --- | --- |
| `GPUDeviceCoreLimit` | `hami_gpu_core_limit_ratio` |
| `GPUDeviceMemoryLimit` | `hami_gpu_memory_limit_bytes` |
| `GPUDeviceCoreAllocated` | `hami_gpu_core_allocated_ratio` |
| `GPUDeviceMemoryAllocated` | `hami_gpu_memory_allocated_bytes` |
| `GPUDeviceSharedNum` | `hami_gpu_shared_count` |
| `vGPUCoreAllocated` | `hami_vgpu_core_allocated_ratio` |
| `vGPUMemoryAllocated` | `hami_vgpu_memory_allocated_bytes` |
| `QuotaUsed` | `hami_resource_quota_used` |
| `HostCoreUtilization` | `hami_host_gpu_utilization_ratio` |
| `HostGPUMemoryUsage` | `hami_host_gpu_memory_used_bytes` |

### How verified

Curled both endpoints on a v2.9.0 cluster and used the live output for the names,
labels, and example values:

    curl <scheduler-ip>:31993/metrics   # hami_gpu_*, hami_vgpu_*, hami_resource_quota_used, ...
    curl <gpu-node-ip>:31992/metrics    # hami_host_gpu_utilization_ratio, hami_host_gpu_memory_used_bytes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated monitoring documentation (including localized and versioned guides) to match the latest Prometheus metric names and label keys for device allocation, Grafana key metrics, and real-time device usage.
  * Replaced older GPU/vGPU/quota metric references with new `hami_`-prefixed metrics.
  * Switched the documented highlights to host-level GPU utilization ratio and host GPU memory used (bytes).
  * Refreshed example label schemes across the affected pages.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->