### PR TITLE
fix: correct sentence punctuation in architecture.md

### DIFF
--- a/docs/core-concepts/architecture.md
+++ b/docs/core-concepts/architecture.md
@@ -15,7 +15,7 @@ HAMi consists of the following components:
 
 ## HAMi MutatingWebhook {#hami-mutatingwebhook}
 
-HAMi MutatingWebhook checks if this task can be handled by HAMi, It scans the resource field of each pod submitted, If each resource the pod requires is either 'CPU', 'Memory' or a HAMi-resource, Then it will set the schedulerName field of this pod to 'HAMi-scheduler'.
+HAMi MutatingWebhook checks if this task can be handled by HAMi. It scans the resource field of each pod submitted. If each resource the pod requires is either 'CPU', 'Memory' or a HAMi-resource, then it will set the schedulerName field of this pod to 'HAMi-scheduler'.
 
 ## HAMi Scheduler {#hami-scheduler}
 


### PR DESCRIPTION
Fixes comma splices on line 18: split run-on sentence into three separate sentences.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Refined wording and punctuation in the HAMi MutatingWebhook documentation for clearer, more polished reading.
  * No functional behavior, architecture details, or user-facing workflows were changed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->