### PR TITLE
fix: correct relative link in troubleshooting.md

### DIFF
--- a/docs/troubleshooting/troubleshooting.md
+++ b/docs/troubleshooting/troubleshooting.md
@@ -15,7 +15,7 @@ If a container exceeds its `nvidia.com/gpumem` limit, check the following causes
   containerd config dump | grep default_runtime_name
   ```
 
-  The output must show `nvidia`. If not, follow the [Prerequisites](./installation/online-installation) guide.
+  The output must show `nvidia`. If not, follow the [Prerequisites](../installation/online-installation) guide.
 
 - If you don’t explicitly request vGPUs when using the device plugin with NVIDIA images, all GPUs on the host may be exposed to your container.
 - Currently, A100 MIG can be supported in only "none" and "mixed" modes.


### PR DESCRIPTION
Link to online-installation used `./` instead of `../`, resolving to a nonexistent path.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated a troubleshooting guide link in the GPU memory limit section so the prerequisites reference points to the correct installation page.
  * No other troubleshooting content was changed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->