### PR TITLE
fix: replace curly-brace node placeholders and fix Ascend URL

### DIFF
--- a/docs/installation/how-to-use-volcano-ascend.md
+++ b/docs/installation/how-to-use-volcano-ascend.md
@@ -33,7 +33,7 @@ Additional installation methods can be found in [the Volcano Quick Start Guide](
 ### Label the Node with ascend=on
 
 ```shell
-kubectl label node {ascend-node} ascend=on
+kubectl label node <ascend-node> ascend=on
 ```
 
 ### Deploy `hami-scheduler-device` config map

--- a/docs/userguide/ascend-device/enable-ascend-sharing.md
+++ b/docs/userguide/ascend-device/enable-ascend-sharing.md
@@ -22,7 +22,7 @@ This mode implements a soft slicing mechanism based on `libvnpu.so` interception
 ## Prerequisites
 
 - Huawei Ascend device type: 910B, 910A, 310P
-- [Huawei Ascend docker runtime](https://gitcode.com/Huawei Ascend/mind-cluster/tree/master/component/ascend-docker-runtime)
+- [Ascend docker runtime](https://gitcode.com/Ascend/mind-cluster/tree/master/component/ascend-docker-runtime)
 
 **Additional requirements for Soft Slicing (hami-vnpu-core):**
 
@@ -82,7 +82,7 @@ devices:
 ### 1. Label the Node
 
 ```bash
-kubectl label node {ascend-node} ascend=on
+kubectl label node <ascend-node> ascend=on
 ```
 
 ### 2. Deploy RuntimeClass

--- a/docs/userguide/vastai/enable-vastai-sharing.md
+++ b/docs/userguide/vastai/enable-vastai-sharing.md
@@ -19,7 +19,7 @@ HAMi now supports sharing `vastaitech.com/va` (Vastaitech) devices and provides 
 #### Label the Node
 
 ```bash
-kubectl label node {vastai-node} vastai=on
+kubectl label node <vastai-node> vastai=on
 ```
 
 #### Deploy the `vastai-device-plugin`


### PR DESCRIPTION
Replace `{ascend-node}` and `{vastai-node}` curly-brace placeholders with angle-bracket form (`<ascend-node>`, `<vastai-node>`) to match the convention used elsewhere in the docs.

Also fix a broken URL in `enable-ascend-sharing.md` that had a space in the path (`Huawei Ascend/mind-cluster`), correcting it to `Ascend/mind-cluster` to match all other references to the same resource.

Files changed:
- `docs/userguide/ascend-device/enable-ascend-sharing.md`
- `docs/installation/how-to-use-volcano-ascend.md`
- `docs/userguide/vastai/enable-vastai-sharing.md`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Standardized node-labeling examples to use angle-bracket placeholders in setup guides.
  * Updated the Ascend sharing guide with a clearer prerequisite link label.
  * Kept the step-by-step instructions unchanged aside from these example and link text improvements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->