### PR TITLE
fix: replace curly-brace IP and node placeholders in monitoring and volcano-vgpu docs

### DIFF
--- a/docs/installation/how-to-use-volcano-vgpu.md
+++ b/docs/installation/how-to-use-volcano-vgpu.md
@@ -61,7 +61,7 @@ kubectl create -f https://raw.githubusercontent.com/Project-HAMi/volcano-vgpu-de
 Check the node status, it is ok if `volcano.sh/vgpu-number` is included in the allocatable resources.
 
 ```shell
-kubectl get node {node name} -oyaml
+kubectl get node <node-name> -oyaml
 ```
 
 ```yaml
@@ -129,5 +129,5 @@ If you do not request GPUs when using the device plugin with NVIDIA images, all 
 volcano-scheduler-metrics records all GPU usage and limits. Visit the following address to get the metrics.
 
 ```shell
-curl {volcano scheduler cluster ip}:8080/metrics
+curl <scheduler-ip>:8080/metrics
 ```

--- a/docs/userguide/monitoring/device-allocation.md
+++ b/docs/userguide/monitoring/device-allocation.md
@@ -3,10 +3,10 @@ title: Cluster device allocation endpoint
 sidebar_label: Cluster device allocation
 ---
 
-You can get the overview of cluster device allocation and limit by visiting `{scheduler node ip}:31993/metrics`, or add it to a prometheus endpoint, as the command below:
+You can get the overview of cluster device allocation and limit by visiting `<scheduler-ip>:31993/metrics`, or add it to a prometheus endpoint, as the command below:
 
 ```bash
-curl {scheduler node ip}:31993/metrics
+curl <scheduler-ip>:31993/metrics
 ```
 
 It contains the following metrics:

--- a/docs/userguide/monitoring/real-time-device-usage.md
+++ b/docs/userguide/monitoring/real-time-device-usage.md
@@ -3,10 +3,10 @@ title: Real-time device usage endpoint
 sidebar_label: Real-time device usage
 ---
 
-You can get the real-time device memory and core utilization by visiting `{GPU node ip}:31992/metrics`, or add it to a prometheus endpoint, as the command below:
+You can get the real-time device memory and core utilization by visiting `<GPU-node-ip>:31992/metrics`, or add it to a prometheus endpoint, as the command below:
 
 ```bash
-curl {GPU node ip}:31992/metrics
+curl <GPU-node-ip>:31992/metrics
 ```
 
 It contains the following metrics:

--- a/docs/userguide/volcano-vgpu/nvidia-gpu/how-to-use-volcano-vgpu.md
+++ b/docs/userguide/volcano-vgpu/nvidia-gpu/how-to-use-volcano-vgpu.md
@@ -61,7 +61,7 @@ kubectl create -f https://raw.githubusercontent.com/Project-HAMi/volcano-vgpu-de
 Check the node status, it is ok if `volcano.sh/vgpu-number` is included in the allocatable resources.
 
 ```shell
-kubectl get node {node name} -oyaml
+kubectl get node <node-name> -oyaml
 ```
 
 ```yaml
@@ -129,5 +129,5 @@ If you do not request GPUs when using the device plugin with NVIDIA images, all 
 volcano-scheduler-metrics records all GPU usage and limits. Visit the following address to get the metrics.
 
 ```shell
-curl {volcano scheduler cluster ip}:8080/metrics
+curl <scheduler-ip>:8080/metrics
 ```

--- a/docs/userguide/volcano-vgpu/nvidia-gpu/monitor.md
+++ b/docs/userguide/volcano-vgpu/nvidia-gpu/monitor.md
@@ -5,7 +5,7 @@ title: Monitor volcano-vgpu
 volcano-scheduler-metrics records all GPU usage and limits. Visit the following address to get the metrics.
 
 ```shell
-curl {volcano scheduler cluster ip}:8080/metrics
+curl <scheduler-ip>:8080/metrics
 ```
 
 It contains the following metrics:


### PR DESCRIPTION
Replace curly-brace placeholders with angle-bracket form to match the convention used elsewhere:

- `{GPU node ip}` -> `<GPU-node-ip>` in real-time-device-usage.md
- `{scheduler node ip}` -> `<scheduler-ip>` in device-allocation.md
- `{volcano scheduler cluster ip}` -> `<scheduler-ip>` in monitor.md and both how-to-use-volcano-vgpu.md files
- `{node name}` -> `<node-name>` in both how-to-use-volcano-vgpu.md files

Files changed:
- `docs/userguide/monitoring/real-time-device-usage.md`
- `docs/userguide/monitoring/device-allocation.md`
- `docs/userguide/volcano-vgpu/nvidia-gpu/monitor.md`
- `docs/userguide/volcano-vgpu/nvidia-gpu/how-to-use-volcano-vgpu.md`
- `docs/installation/how-to-use-volcano-vgpu.md`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Improved several user guide and installation examples with clearer placeholder text for cluster node names and IP addresses.
  * Standardized metrics endpoint examples across vGPU and monitoring docs for easier copy-and-paste use.
  * Updated command snippets to use consistent angle-bracket placeholders, making setup and verification steps easier to follow.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->