### PR TITLE
fix: use consistent underscore in registry placeholder in offline-installation

### DIFF
--- a/docs/installation/offline-installation.md
+++ b/docs/installation/offline-installation.md
@@ -18,8 +18,8 @@ Load the images, tag them with your internal registry, and push them to your reg
 docker load -i {HAMi_image}.tar
 docker tag projecthami/hami:{HAMi version} {your_inner_registry}/hami:{HAMi version}
 docker push {your_inner_registry}/hami:{HAMi version}
-docker tag ghcr.io/kubernetes/ingress-nginx/kube-webhook-certgen:v1.5.2 {your inner_registry}/kube-webhook-certgen:v1.5.2
-docker push {your inner_registry}/kube-webhook-certgen:v1.5.2
+docker tag ghcr.io/kubernetes/ingress-nginx/kube-webhook-certgen:v1.5.2 {your_inner_registry}/kube-webhook-certgen:v1.5.2
+docker push {your_inner_registry}/kube-webhook-certgen:v1.5.2
 docker tag registry.cn-hangzhou.aliyuncs.com/google_containers/kube-scheduler:{your kubernetes version} {your_inner_registry}/kube-scheduler:{your kubernetes version}
 docker push {your_inner_registry}/kube-scheduler:{your kubernetes version}
 ```


### PR DESCRIPTION
Lines 21-22 of `offline-installation.md` used `{your inner_registry}` (with a space) while all other lines in the same file use `{your_inner_registry}` (with underscore). Standardize to underscore form.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified the offline installation steps to use a consistent internal registry placeholder in the image tagging and push commands.
  * Improved the instructions to reduce confusion when following the offline setup process.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->