### PR TITLE
fix: correct technical errors in zh current docs

### DIFF
--- a/i18n/zh/docusaurus-plugin-content-docs/current/get-started/deploy-with-helm.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/current/get-started/deploy-with-helm.md
@@ -12,7 +12,7 @@ title: 使用 Helm 部署 HAMi
 ## 先决条件 {#prerequisites}
 
 - [Helm](https://helm.sh/zh/docs/) v3+
-- [kubectl](https://kubernetes.io/docs/tasks/tools/install-kubectl/) v1.16+
+- [kubectl](https://kubernetes.io/docs/tasks/tools/install-kubectl/) v1.23+
 - [CUDA](https://developer.nvidia.com/cuda-toolkit) v10.2+
 - [NVIDIA 驱动](https://www.nvidia.cn/drivers/unix/) v440+
 
@@ -93,7 +93,7 @@ sudo systemctl daemon-reload && sudo systemctl restart containerd
 通过添加 "gpu=on" 标签将 GPU 节点标记为可调度 HAMi 任务。未标记的节点将无法被调度器管理。
 
 ```bash
-kubectl label nodes {节点ID} gpu=on
+kubectl label nodes <node-name> gpu=on
 ```
 
 ### 3. 使用 Helm 部署 HAMi {#deploy-hami-using-helm}
@@ -147,7 +147,7 @@ spec:
 执行查询命令：
 
 ```bash
-kubectl exec -it gpu-pod nvidia-smi
+kubectl exec -it gpu-pod -- nvidia-smi
 ```
 
 预期输出：

--- a/i18n/zh/docusaurus-plugin-content-docs/current/installation/online-installation.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/current/installation/online-installation.md
@@ -12,6 +12,7 @@ translated: true
 
 ```bash
 helm repo add hami-charts https://project-hami.github.io/HAMi/
+helm repo update
 ```
 
 ## 获取你的 Kubernetes 版本
@@ -19,15 +20,15 @@ helm repo add hami-charts https://project-hami.github.io/HAMi/
 安装时需要 Kubernetes 版本。你可以使用以下命令获取此信息：
 
 ```bash
-kubectl version --short
+kubectl version
 ```
 
 ## 安装
 
-确保 `scheduler.kubeScheduler.imageTag` 与你的 Kubernetes 服务器版本匹配。例如，如果你的集群服务器版本是 v1.16.8，请使用以下命令进行部署：
+确保 `scheduler.kubeScheduler.imageTag` 与你的 Kubernetes 服务器版本匹配。例如，如果你的集群服务器版本是 v1.29.0，请使用以下命令进行部署：
 
 ```bash
-helm install hami hami-charts/hami --set scheduler.kubeScheduler.imageTag=v1.16.8 -n kube-system
+helm install hami hami-charts/hami --set scheduler.kubeScheduler.imageTag=v1.29.0 -n kube-system
 ```
 
 你可以通过编辑[配置](../userguide/configure.md)来自定义安装。

--- a/i18n/zh/docusaurus-plugin-content-docs/current/installation/prerequisites.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/current/installation/prerequisites.md
@@ -65,5 +65,5 @@ sudo systemctl daemon-reload && sudo systemctl restart containerd
 为了让 HAMi 调度器能够识别 GPU 节点，请为 GPU 节点添加标签 `gpu=on`。如果没有该标签，调度器将无法管理这些节点。
 
 ```bash
-kubectl label nodes {nodeid} gpu=on
+kubectl label nodes <node-name> gpu=on
 ```


### PR DESCRIPTION
Fix several technical errors in the Chinese (zh) current documentation:

- `installation/prerequisites.md`: `{nodeid}` -> `<node-name>` in kubectl label command
- `get-started/deploy-with-helm.md`: `{节点ID}` -> `<node-name>`, kubectl `v1.16+` -> `v1.23+`, add missing `--` in kubectl exec command
- `installation/online-installation.md`: add `helm repo update` after `helm repo add`, remove deprecated `--short` flag from `kubectl version`, update example Kubernetes version from `v1.16.8` to `v1.29.0`

These are the same categories of issues already fixed for the English docs in PRs #503 and #504.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * 更新中文安装与部署指南，补充更准确的命令示例和前置要求。
  * 调整节点打标签、检查资源与安装步骤的示例写法，便于按最新方式操作。
  * 升级 Helm 在线安装相关说明，新增仓库更新步骤，并同步示例 Kubernetes 版本。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->