### PR TITLE
fix: replace {nodeid} placeholder in versioned_docs

### DIFF
--- a/versioned_docs/version-v1.3.0/get-started/nginx-example.md
+++ b/versioned_docs/version-v1.3.0/get-started/nginx-example.md
@@ -95,7 +95,7 @@ sudo systemctl daemon-reload && systemctl restart containerd
 Label your GPU nodes for scheduling with HAMi by adding the label "gpu=on". Without this label, the nodes cannot be managed by the HAMi scheduler.
 
 ```bash
-kubectl label nodes {nodeid} gpu=on
+kubectl label nodes <node-name> gpu=on
 ```
 
 #### 3. Deploy HAMi using Helm

--- a/versioned_docs/version-v1.3.0/installation/prerequisites.md
+++ b/versioned_docs/version-v1.3.0/installation/prerequisites.md
@@ -85,5 +85,5 @@ sudo systemctl daemon-reload && systemctl restart containerd
 Label your GPU nodes for scheduling with HAMi by adding the label "gpu=on". Without this label, the nodes cannot be managed by the HAMi scheduler.
 
 ```bash
-kubectl label nodes {nodeid} gpu=on
+kubectl label nodes <node-name> gpu=on
 ```

--- a/versioned_docs/version-v2.4.1/get-started/nginx-example.md
+++ b/versioned_docs/version-v2.4.1/get-started/nginx-example.md
@@ -95,7 +95,7 @@ sudo systemctl daemon-reload && systemctl restart containerd
 Label your GPU nodes for scheduling with HAMi by adding the label "gpu=on". Without this label, the nodes cannot be managed by the HAMi scheduler.
 
 ```bash
-kubectl label nodes {nodeid} gpu=on
+kubectl label nodes <node-name> gpu=on
 ```
 
 #### 3. Deploy HAMi using Helm

--- a/versioned_docs/version-v2.4.1/installation/prerequisites.md
+++ b/versioned_docs/version-v2.4.1/installation/prerequisites.md
@@ -85,5 +85,5 @@ sudo systemctl daemon-reload && systemctl restart containerd
 Label your GPU nodes for scheduling with HAMi by adding the label "gpu=on". Without this label, the nodes cannot be managed by the HAMi scheduler.
 
 ```bash
-kubectl label nodes {nodeid} gpu=on
+kubectl label nodes <node-name> gpu=on
 ```

--- a/versioned_docs/version-v2.5.0/get-started/nginx-example.md
+++ b/versioned_docs/version-v2.5.0/get-started/nginx-example.md
@@ -95,7 +95,7 @@ sudo systemctl daemon-reload && systemctl restart containerd
 Label your GPU nodes for scheduling with HAMi by adding the label "gpu=on". Without this label, the nodes cannot be managed by the HAMi scheduler.
 
 ```bash
-kubectl label nodes {nodeid} gpu=on
+kubectl label nodes <node-name> gpu=on
 ```
 
 #### 3. Deploy HAMi using Helm

--- a/versioned_docs/version-v2.5.0/installation/prerequisites.md
+++ b/versioned_docs/version-v2.5.0/installation/prerequisites.md
@@ -85,5 +85,5 @@ sudo systemctl daemon-reload && systemctl restart containerd
 Label your GPU nodes for scheduling with HAMi by adding the label "gpu=on". Without this label, the nodes cannot be managed by the HAMi scheduler.
 
 ```bash
-kubectl label nodes {nodeid} gpu=on
+kubectl label nodes <node-name> gpu=on
 ```

--- a/versioned_docs/version-v2.5.1/get-started/nginx-example.md
+++ b/versioned_docs/version-v2.5.1/get-started/nginx-example.md
@@ -95,7 +95,7 @@ sudo systemctl daemon-reload && systemctl restart containerd
 Label your GPU nodes for scheduling with HAMi by adding the label "gpu=on". Without this label, the nodes cannot be managed by the HAMi scheduler.
 
 ```bash
-kubectl label nodes {nodeid} gpu=on
+kubectl label nodes <node-name> gpu=on
 ```
 
 #### 3. Deploy HAMi using Helm

--- a/versioned_docs/version-v2.5.1/installation/prerequisites.md
+++ b/versioned_docs/version-v2.5.1/installation/prerequisites.md
@@ -85,5 +85,5 @@ sudo systemctl daemon-reload && systemctl restart containerd
 Label your GPU nodes for scheduling with HAMi by adding the label "gpu=on". Without this label, the nodes cannot be managed by the HAMi scheduler.
 
 ```bash
-kubectl label nodes {nodeid} gpu=on
+kubectl label nodes <node-name> gpu=on
 ```

--- a/versioned_docs/version-v2.6.0/get-started/nginx-example.md
+++ b/versioned_docs/version-v2.6.0/get-started/nginx-example.md
@@ -95,7 +95,7 @@ sudo systemctl daemon-reload && systemctl restart containerd
 Label your GPU nodes for scheduling with HAMi by adding the label "gpu=on". Without this label, the nodes cannot be managed by the HAMi scheduler.
 
 ```bash
-kubectl label nodes {nodeid} gpu=on
+kubectl label nodes <node-name> gpu=on
 ```
 
 #### 3. Deploy HAMi using Helm

--- a/versioned_docs/version-v2.6.0/installation/prerequisites.md
+++ b/versioned_docs/version-v2.6.0/installation/prerequisites.md
@@ -63,5 +63,5 @@ sudo systemctl daemon-reload && systemctl restart containerd
 Label your GPU nodes for scheduling with HAMi by adding the label "gpu=on". Without this label, the nodes cannot be managed by the HAMi scheduler.
 
 ```bash
-kubectl label nodes {nodeid} gpu=on
+kubectl label nodes <node-name> gpu=on
 ```

--- a/versioned_docs/version-v2.7.0/get-started/deploy-with-helm.md
+++ b/versioned_docs/version-v2.7.0/get-started/deploy-with-helm.md
@@ -102,7 +102,7 @@ Label your GPU nodes for scheduling with HAMi by adding the label "gpu=on".
 Without this label, the nodes cannot be managed by the HAMi scheduler.
 
 ```bash
-kubectl label nodes {nodeid} gpu=on
+kubectl label nodes <node-name> gpu=on
 ```
 
 #### 3. Deploy HAMi using Helm {#deploy-hami-using-helm}

--- a/versioned_docs/version-v2.7.0/installation/prerequisites.md
+++ b/versioned_docs/version-v2.7.0/installation/prerequisites.md
@@ -62,5 +62,5 @@ sudo systemctl daemon-reload && systemctl restart containerd
 Label your GPU nodes for scheduling with HAMi by adding the label "gpu=on". Without this label, the nodes cannot be managed by the HAMi scheduler.
 
 ```bash
-kubectl label nodes {nodeid} gpu=on
+kubectl label nodes <node-name> gpu=on
 ```

--- a/versioned_docs/version-v2.8.0/get-started/deploy-with-helm.md
+++ b/versioned_docs/version-v2.8.0/get-started/deploy-with-helm.md
@@ -93,7 +93,7 @@ sudo systemctl daemon-reload && sudo systemctl restart containerd
 Label your GPU nodes for HAMi scheduling with `gpu=on`. Nodes without this label cannot be managed by the scheduler.
 
 ```bash
-kubectl label nodes {nodeid} gpu=on
+kubectl label nodes <node-name> gpu=on
 ```
 
 ### 3. Deploy HAMi using Helm {#deploy-hami-using-helm}

--- a/versioned_docs/version-v2.8.0/installation/prerequisites.md
+++ b/versioned_docs/version-v2.8.0/installation/prerequisites.md
@@ -65,5 +65,5 @@ sudo systemctl daemon-reload && sudo systemctl restart containerd
 Label your GPU nodes for scheduling with HAMi by adding the label "gpu=on". Without this label, the nodes cannot be managed by the HAMi scheduler.
 
 ```bash
-kubectl label nodes {nodeid} gpu=on
+kubectl label nodes <node-name> gpu=on
 ```

--- a/versioned_docs/version-v2.9.0/get-started/deploy-with-helm.md
+++ b/versioned_docs/version-v2.9.0/get-started/deploy-with-helm.md
@@ -93,7 +93,7 @@ sudo systemctl daemon-reload && sudo systemctl restart containerd
 Label your GPU nodes for HAMi scheduling with `gpu=on`. Nodes without this label cannot be managed by the scheduler.
 
 ```bash
-kubectl label nodes {nodeid} gpu=on
+kubectl label nodes <node-name> gpu=on
 ```
 
 ### 3. Deploy HAMi using Helm {#deploy-hami-using-helm}

--- a/versioned_docs/version-v2.9.0/installation/prerequisites.md
+++ b/versioned_docs/version-v2.9.0/installation/prerequisites.md
@@ -65,5 +65,5 @@ sudo systemctl daemon-reload && sudo systemctl restart containerd
 Label your GPU nodes for scheduling with HAMi by adding the label "gpu=on". Without this label, the nodes cannot be managed by the HAMi scheduler.
 
 ```bash
-kubectl label nodes {nodeid} gpu=on
+kubectl label nodes <node-name> gpu=on
 ```


### PR DESCRIPTION
Replace {nodeid} with <node-name> in kubectl label commands across all versioned docs (v1.3.0 through v2.9.0).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified the Kubernetes node-labeling examples across multiple versioned setup and Helm guides.
  * Replaced the `{nodeid}` placeholder with the more readable `<node-name>` in `kubectl label` commands.
  * Kept the required `gpu=on` label and all other setup steps unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->