### PR TITLE
fix: correct Manufactor typo in versioned_docs

### DIFF
--- a/versioned_docs/version-v1.3.0/userguide/device-supported.md
+++ b/versioned_docs/version-v1.3.0/userguide/device-supported.md
@@ -4,7 +4,7 @@ title: Device supported by HAMi
 
 The view of device supported by HAMi is shown in this table below:
 
-| Production  | manufactor | Type        |MemoryIsolation | CoreIsolation | MultiCard support |
+| Production | Manufacturer | Type        |MemoryIsolation | CoreIsolation | MultiCard support |
 |-------------|------------|-------------|-----------|---------------|-------------------|
 | GPU         | NVIDIA     | All         | Yes              | Yes            | Yes                |
 | MLU         | Cambricon  | 370, 590    | Yes              | Yes            | No                |

--- a/versioned_docs/version-v2.4.1/userguide/device-supported.md
+++ b/versioned_docs/version-v2.4.1/userguide/device-supported.md
@@ -4,7 +4,7 @@ title: Device supported by HAMi
 
 The view of device supported by HAMi is shown in this table below:
 
-| Production  | manufactor | Type        |MemoryIsolation | CoreIsolation | MultiCard support |
+| Production | Manufacturer | Type        |MemoryIsolation | CoreIsolation | MultiCard support |
 |-------------|------------|-------------|-----------|---------------|-------------------|
 | GPU         | NVIDIA     | All         | Yes              | Yes            | Yes                |
 | MLU         | Cambricon  | 370, 590    | Yes              | Yes            | No                |

--- a/versioned_docs/version-v2.5.0/userguide/device-supported.md
+++ b/versioned_docs/version-v2.5.0/userguide/device-supported.md
@@ -4,7 +4,7 @@ title: Device supported by HAMi
 
 The view of device supported by HAMi is shown in this table below:
 
-| Production  | manufactor | Type        |MemoryIsolation | CoreIsolation | MultiCard support |
+| Production | Manufacturer | Type        |MemoryIsolation | CoreIsolation | MultiCard support |
 |-------------|------------|-------------|-----------|---------------|-------------------|
 | GPU         | NVIDIA     | All         | Yes              | Yes            | Yes                |
 | MLU         | Cambricon  | 370, 590    | Yes              | Yes            | No                |

--- a/versioned_docs/version-v2.5.1/userguide/device-supported.md
+++ b/versioned_docs/version-v2.5.1/userguide/device-supported.md
@@ -4,7 +4,7 @@ title: Device supported by HAMi
 
 The table below lists the devices supported by HAMi:
 
-| Type | Manufactor | Models | MemoryIsolation | CoreIsolation | MultiCard Support |
+| Type | Manufacturer | Models | MemoryIsolation | CoreIsolation | MultiCard Support |
 |------|------------|------|-----------------|---------------|-------------------|
 | GPU | NVIDIA | All | Yes | Yes | Yes |
 | MLU | Cambricon | 370, 590 | Yes | Yes | No |

--- a/versioned_docs/version-v2.6.0/userguide/device-supported.md
+++ b/versioned_docs/version-v2.6.0/userguide/device-supported.md
@@ -4,7 +4,7 @@ title: Device supported by HAMi
 
 The table below lists the devices supported by HAMi:
 
-| Type | Manufactor | Models | MemoryIsolation | CoreIsolation | MultiCard Support |
+| Type | Manufacturer | Models | MemoryIsolation | CoreIsolation | MultiCard Support |
 |------|------------|------|-----------------|---------------|-------------------|
 | GPU | NVIDIA | All | Yes | Yes | Yes |
 | MLU | Cambricon | 370, 590 | Yes | Yes | No |

--- a/versioned_docs/version-v2.7.0/userguide/device-supported.md
+++ b/versioned_docs/version-v2.7.0/userguide/device-supported.md
@@ -4,7 +4,7 @@ title: Device supported by HAMi
 
 The table below lists the devices supported by HAMi:
 
-| Type | Manufactor | Models | MemoryIsolation | CoreIsolation | MultiCard Support |
+| Type | Manufacturer | Models | MemoryIsolation | CoreIsolation | MultiCard Support |
 |------|------------|------|-----------------|---------------|-------------------|
 | GPU | NVIDIA | All | Yes | Yes | Yes |
 | MLU | Cambricon | 370, 590 | Yes | Yes | No |


### PR DESCRIPTION
Fix Manufactor/manufactor -> Manufacturer in device-supported.md across v1.3.0 through v2.7.0.