### PR TITLE
fix: correct helm.sh zh URL in versioned_docs

### DIFF
--- a/versioned_docs/version-v1.3.0/get-started/nginx-example.md
+++ b/versioned_docs/version-v1.3.0/get-started/nginx-example.md
@@ -11,7 +11,7 @@ This guide will cover:
 
 ### Prerequisites
 
-- [Helm](https://helm.sh/zh/docs/) version v3+
+- [Helm](https://helm.sh/docs/) version v3+
 - [kubectl](https://kubernetes.io/docs/tasks/tools/install-kubectl/) version v1.16+
 - [CUDA](https://developer.nvidia.com/cuda-toolkit) version v10.2+
 - [NVIDIA Driver](https://www.nvidia.cn/drivers/unix/) v440+

--- a/versioned_docs/version-v1.3.0/installation/prerequisites.md
+++ b/versioned_docs/version-v1.3.0/installation/prerequisites.md
@@ -4,7 +4,7 @@ title: Prerequisites
 
 ## Prerequisites
 
-- [Helm](https://helm.sh/zh/docs/) version v3+
+- [Helm](https://helm.sh/docs/) version v3+
 - [kubectl](https://kubernetes.io/docs/tasks/tools/install-kubectl/) version v1.16+
 - [CUDA](https://developer.nvidia.com/cuda-toolkit) version v10.2+
 - [NVIDIA Driver](https://www.nvidia.cn/drivers/unix/) v440+

--- a/versioned_docs/version-v2.4.1/get-started/nginx-example.md
+++ b/versioned_docs/version-v2.4.1/get-started/nginx-example.md
@@ -11,7 +11,7 @@ This guide will cover:
 
 ## Prerequisites
 
-- [Helm](https://helm.sh/zh/docs/) version v3+
+- [Helm](https://helm.sh/docs/) version v3+
 - [kubectl](https://kubernetes.io/docs/tasks/tools/install-kubectl/) version v1.16+
 - [CUDA](https://developer.nvidia.com/cuda-toolkit) version v10.2+
 - [NVIDIA Driver](https://www.nvidia.cn/drivers/unix/) v440+

--- a/versioned_docs/version-v2.4.1/installation/prerequisites.md
+++ b/versioned_docs/version-v2.4.1/installation/prerequisites.md
@@ -4,7 +4,7 @@ title: Prerequisites
 
 ## Prerequisites
 
-- [Helm](https://helm.sh/zh/docs/) version v3+
+- [Helm](https://helm.sh/docs/) version v3+
 - [kubectl](https://kubernetes.io/docs/tasks/tools/install-kubectl/) version v1.16+
 - [CUDA](https://developer.nvidia.com/cuda-toolkit) version v10.2+
 - [NVIDIA Driver](https://www.nvidia.cn/drivers/unix/) v440+

--- a/versioned_docs/version-v2.5.0/get-started/nginx-example.md
+++ b/versioned_docs/version-v2.5.0/get-started/nginx-example.md
@@ -11,7 +11,7 @@ This guide will cover:
 
 ## Prerequisites
 
-- [Helm](https://helm.sh/zh/docs/) version v3+
+- [Helm](https://helm.sh/docs/) version v3+
 - [kubectl](https://kubernetes.io/docs/tasks/tools/install-kubectl/) version v1.16+
 - [CUDA](https://developer.nvidia.com/cuda-toolkit) version v10.2+
 - [NVIDIA Driver](https://www.nvidia.cn/drivers/unix/) v440+

--- a/versioned_docs/version-v2.5.0/installation/prerequisites.md
+++ b/versioned_docs/version-v2.5.0/installation/prerequisites.md
@@ -4,7 +4,7 @@ title: Prerequisites
 
 ## Prerequisites
 
-- [Helm](https://helm.sh/zh/docs/) version v3+
+- [Helm](https://helm.sh/docs/) version v3+
 - [kubectl](https://kubernetes.io/docs/tasks/tools/install-kubectl/) version v1.16+
 - [CUDA](https://developer.nvidia.com/cuda-toolkit) version v10.2+
 - [NVIDIA Driver](https://www.nvidia.cn/drivers/unix/) v440+

--- a/versioned_docs/version-v2.5.1/get-started/nginx-example.md
+++ b/versioned_docs/version-v2.5.1/get-started/nginx-example.md
@@ -11,7 +11,7 @@ This guide will cover:
 
 ## Prerequisites
 
-- [Helm](https://helm.sh/zh/docs/) version v3+
+- [Helm](https://helm.sh/docs/) version v3+
 - [kubectl](https://kubernetes.io/docs/tasks/tools/install-kubectl/) version v1.16+
 - [CUDA](https://developer.nvidia.com/cuda-toolkit) version v10.2+
 - [NVIDIA Driver](https://www.nvidia.cn/drivers/unix/) v440+

--- a/versioned_docs/version-v2.5.1/installation/prerequisites.md
+++ b/versioned_docs/version-v2.5.1/installation/prerequisites.md
@@ -4,7 +4,7 @@ title: Prerequisites
 
 ## Prerequisites
 
-- [Helm](https://helm.sh/zh/docs/) version v3+
+- [Helm](https://helm.sh/docs/) version v3+
 - [kubectl](https://kubernetes.io/docs/tasks/tools/install-kubectl/) version v1.16+
 - [CUDA](https://developer.nvidia.com/cuda-toolkit) version v10.2+
 - [NVIDIA Driver](https://www.nvidia.cn/drivers/unix/) v440+

--- a/versioned_docs/version-v2.6.0/get-started/nginx-example.md
+++ b/versioned_docs/version-v2.6.0/get-started/nginx-example.md
@@ -11,7 +11,7 @@ This guide will cover:
 
 ## Prerequisites
 
-- [Helm](https://helm.sh/zh/docs/) version v3+
+- [Helm](https://helm.sh/docs/) version v3+
 - [kubectl](https://kubernetes.io/docs/tasks/tools/install-kubectl/) version v1.16+
 - [CUDA](https://developer.nvidia.com/cuda-toolkit) version v10.2+
 - [NVIDIA Driver](https://www.nvidia.cn/drivers/unix/) v440+

--- a/versioned_docs/version-v2.6.0/installation/prerequisites.md
+++ b/versioned_docs/version-v2.6.0/installation/prerequisites.md
@@ -4,7 +4,7 @@ title: Prerequisites
 
 ## Prerequisites
 
-- [Helm](https://helm.sh/zh/docs/) version v3+
+- [Helm](https://helm.sh/docs/) version v3+
 - [kubectl](https://kubernetes.io/docs/tasks/tools/install-kubectl/) version v1.16+
 - [CUDA](https://developer.nvidia.com/cuda-toolkit) version v10.2+
 - [NVIDIA Driver](https://www.nvidia.cn/drivers/unix/) v440+

--- a/versioned_docs/version-v2.7.0/get-started/deploy-with-helm.md
+++ b/versioned_docs/version-v2.7.0/get-started/deploy-with-helm.md
@@ -11,7 +11,7 @@ This guide will cover:
 
 ## Prerequisites {#prerequisites}
 
-- [Helm](https://helm.sh/zh/docs/) version v3+
+- [Helm](https://helm.sh/docs/) version v3+
 - [kubectl](https://kubernetes.io/docs/tasks/tools/install-kubectl/) version v1.16+
 - [CUDA](https://developer.nvidia.com/cuda-toolkit) version v10.2+
 - [NVIDIA Driver](https://www.nvidia.cn/drivers/unix/) v440+

--- a/versioned_docs/version-v2.7.0/installation/prerequisites.md
+++ b/versioned_docs/version-v2.7.0/installation/prerequisites.md
@@ -4,7 +4,7 @@ title: Prerequisites
 
 Before installing HAMi, make sure the following tools and dependencies are properly installed in your environment:
 
-- [Helm](https://helm.sh/zh/docs/) v3+
+- [Helm](https://helm.sh/docs/) v3+
 - [kubectl](https://kubernetes.io/docs/tasks/tools/install-kubectl/) v1.16+
 - [CUDA](https://developer.nvidia.com/cuda-toolkit) v10.2+
 - [NVIDIA Driver](https://www.nvidia.cn/drivers/unix/) v440+

--- a/versioned_docs/version-v2.8.0/get-started/deploy-with-helm.md
+++ b/versioned_docs/version-v2.8.0/get-started/deploy-with-helm.md
@@ -11,7 +11,7 @@ This guide covers:
 
 ## Prerequisites {#prerequisites}
 
-- [Helm](https://helm.sh/zh/docs/) v3+
+- [Helm](https://helm.sh/docs/) v3+
 - [kubectl](https://kubernetes.io/docs/tasks/tools/install-kubectl/) v1.16+
 - [CUDA](https://developer.nvidia.com/cuda-toolkit) v10.2+
 - [NVIDIA Driver](https://www.nvidia.cn/drivers/unix/) v440+

--- a/versioned_docs/version-v2.9.0/get-started/deploy-with-helm.md
+++ b/versioned_docs/version-v2.9.0/get-started/deploy-with-helm.md
@@ -11,7 +11,7 @@ This guide covers:
 
 ## Prerequisites {#prerequisites}
 
-- [Helm](https://helm.sh/zh/docs/) v3+
+- [Helm](https://helm.sh/docs/) v3+
 - [kubectl](https://kubernetes.io/docs/tasks/tools/install-kubectl/) v1.16+
 - [CUDA](https://developer.nvidia.com/cuda-toolkit) v10.2+
 - [NVIDIA Driver](https://www.nvidia.cn/drivers/unix/) v440+


### PR DESCRIPTION
Replace helm.sh/zh/docs/ with helm.sh/docs/ across all versioned docs (v1.3.0 through v2.9.0).