### PR TITLE
fix: add helm repo update in versioned_docs

### DIFF
--- a/versioned_docs/version-v1.3.0/get-started/nginx-example.md
+++ b/versioned_docs/version-v1.3.0/get-started/nginx-example.md
@@ -110,6 +110,7 @@ Then, add the HAMi repo in helm
 
 ```bash
 helm repo add hami-charts https://project-hami.github.io/HAMi/
+helm repo update
 ```
 
 During installation, set the Kubernetes scheduler image version to match your Kubernetes server version. For instance, if your cluster server version is 1.16.8, use the following command for deployment:

--- a/versioned_docs/version-v1.3.0/installation/online-installation.md
+++ b/versioned_docs/version-v1.3.0/installation/online-installation.md
@@ -10,6 +10,7 @@ You can add HAMi chart repository using the following command:
 
 ```bash
 helm repo add hami-charts https://project-hami.github.io/HAMi/
+helm repo update
 ```
 
 ## Get your kubernetes version

--- a/versioned_docs/version-v2.4.1/get-started/nginx-example.md
+++ b/versioned_docs/version-v2.4.1/get-started/nginx-example.md
@@ -110,6 +110,7 @@ Then, add the HAMi repo in helm
 
 ```bash
 helm repo add hami-charts https://project-hami.github.io/HAMi/
+helm repo update
 ```
 
 During installation, set the Kubernetes scheduler image version to match your Kubernetes server version. For instance, if your cluster server version is 1.16.8, use the following command for deployment:

--- a/versioned_docs/version-v2.4.1/installation/online-installation.md
+++ b/versioned_docs/version-v2.4.1/installation/online-installation.md
@@ -11,6 +11,7 @@ You can add HAMi chart repository using the following command:
 
 ```bash
 helm repo add hami-charts https://project-hami.github.io/HAMi/
+helm repo update
 ```
 
 ## Get your kubernetes version

--- a/versioned_docs/version-v2.5.0/get-started/nginx-example.md
+++ b/versioned_docs/version-v2.5.0/get-started/nginx-example.md
@@ -110,6 +110,7 @@ Then, add the HAMi repo in helm
 
 ```bash
 helm repo add hami-charts https://project-hami.github.io/HAMi/
+helm repo update
 ```
 
 During installation, set the Kubernetes scheduler image version to match your Kubernetes server version. For instance, if your cluster server version is 1.16.8, use the following command for deployment:

--- a/versioned_docs/version-v2.5.0/installation/online-installation.md
+++ b/versioned_docs/version-v2.5.0/installation/online-installation.md
@@ -11,6 +11,7 @@ You can add HAMi chart repository using the following command:
 
 ```bash
 helm repo add hami-charts https://project-hami.github.io/HAMi/
+helm repo update
 ```
 
 ## Get your kubernetes version

--- a/versioned_docs/version-v2.5.1/get-started/nginx-example.md
+++ b/versioned_docs/version-v2.5.1/get-started/nginx-example.md
@@ -110,6 +110,7 @@ Then, add the HAMi repo in helm
 
 ```bash
 helm repo add hami-charts https://project-hami.github.io/HAMi/
+helm repo update
 ```
 
 During installation, set the Kubernetes scheduler image version to match your Kubernetes server version. For instance, if your cluster server version is 1.16.8, use the following command for deployment:

--- a/versioned_docs/version-v2.5.1/installation/online-installation.md
+++ b/versioned_docs/version-v2.5.1/installation/online-installation.md
@@ -11,6 +11,7 @@ You can add HAMi chart repository using the following command:
 
 ```bash
 helm repo add hami-charts https://project-hami.github.io/HAMi/
+helm repo update
 ```
 
 ## Get your kubernetes version

--- a/versioned_docs/version-v2.6.0/get-started/nginx-example.md
+++ b/versioned_docs/version-v2.6.0/get-started/nginx-example.md
@@ -110,6 +110,7 @@ Then, add the HAMi repo in helm
 
 ```bash
 helm repo add hami-charts https://project-hami.github.io/HAMi/
+helm repo update
 ```
 
 During installation, set the Kubernetes scheduler image version to match your Kubernetes server version. For instance, if your cluster server version is 1.16.8, use the following command for deployment:

--- a/versioned_docs/version-v2.6.0/installation/online-installation.md
+++ b/versioned_docs/version-v2.6.0/installation/online-installation.md
@@ -11,6 +11,7 @@ You can add HAMi chart repository using the following command:
 
 ```bash
 helm repo add hami-charts https://project-hami.github.io/HAMi/
+helm repo update
 ```
 
 ## Get your Kubernetes version

--- a/versioned_docs/version-v2.7.0/get-started/deploy-with-helm.md
+++ b/versioned_docs/version-v2.7.0/get-started/deploy-with-helm.md
@@ -117,6 +117,7 @@ Then, add the HAMi repo in helm
 
 ```bash
 helm repo add hami-charts https://project-hami.github.io/HAMi/
+helm repo update
 ```
 
 During installation, set the Kubernetes scheduler image version to match your

--- a/versioned_docs/version-v2.7.0/installation/online-installation.md
+++ b/versioned_docs/version-v2.7.0/installation/online-installation.md
@@ -11,6 +11,7 @@ You can add HAMi chart repository using the following command:
 
 ```bash
 helm repo add hami-charts https://project-hami.github.io/HAMi/
+helm repo update
 ```
 
 ## Get your Kubernetes version

--- a/versioned_docs/version-v2.8.0/get-started/deploy-with-helm.md
+++ b/versioned_docs/version-v2.8.0/get-started/deploy-with-helm.md
@@ -108,6 +108,7 @@ Add the Helm repository:
 
 ```bash
 helm repo add hami-charts https://project-hami.github.io/HAMi/
+helm repo update
 ```
 
 During installation, set the Kubernetes scheduler image to match your cluster version. For example, if your cluster version is 1.29.0:

--- a/versioned_docs/version-v2.8.0/get-started/verify-hami.md
+++ b/versioned_docs/version-v2.8.0/get-started/verify-hami.md
@@ -99,6 +99,7 @@ kubectl label nodes $(hostname) gpu=on --overwrite
 
 ```bash
 helm repo add hami-charts https://project-hami.github.io/HAMi/
+helm repo update
 helm install hami hami-charts/hami -n kube-system
 ```
 

--- a/versioned_docs/version-v2.8.0/installation/how-to-use-hami-dra.md
+++ b/versioned_docs/version-v2.8.0/installation/how-to-use-hami-dra.md
@@ -19,6 +19,7 @@ You can use the following commands to add the HAMi chart repository and update d
 
 ```bash
 helm repo add hami-charts https://project-hami.github.io/HAMi/
+helm repo update
 helm dependency build
 ```
 

--- a/versioned_docs/version-v2.8.0/installation/online-installation.md
+++ b/versioned_docs/version-v2.8.0/installation/online-installation.md
@@ -11,6 +11,7 @@ You can add HAMi chart repository using the following command:
 
 ```bash
 helm repo add hami-charts https://project-hami.github.io/HAMi/
+helm repo update
 ```
 
 ## Get your Kubernetes version

--- a/versioned_docs/version-v2.9.0/get-started/deploy-with-helm.md
+++ b/versioned_docs/version-v2.9.0/get-started/deploy-with-helm.md
@@ -108,6 +108,7 @@ Add the Helm repository:
 
 ```bash
 helm repo add hami-charts https://project-hami.github.io/HAMi/
+helm repo update
 ```
 
 During installation, set the Kubernetes scheduler image to match your cluster version. For example, if your cluster version is 1.29.0:

--- a/versioned_docs/version-v2.9.0/get-started/verify-hami.md
+++ b/versioned_docs/version-v2.9.0/get-started/verify-hami.md
@@ -103,6 +103,7 @@ kubectl label nodes $(hostname) gpu=on --overwrite
 
 ```bash
 helm repo add hami-charts https://project-hami.github.io/HAMi/
+helm repo update
 helm install hami hami-charts/hami -n kube-system
 ```
 

--- a/versioned_docs/version-v2.9.0/installation/online-installation.md
+++ b/versioned_docs/version-v2.9.0/installation/online-installation.md
@@ -11,6 +11,7 @@ You can add HAMi chart repository using the following command:
 
 ```bash
 helm repo add hami-charts https://project-hami.github.io/HAMi/
+helm repo update
 ```
 
 ## Get your Kubernetes version


### PR DESCRIPTION
Add missing helm repo update after helm repo add hami-charts across all versioned docs (v1.3.0 through v2.9.0).