### PR TITLE
docs: document per-container and per-vGPU real-time metrics

### DIFF
--- a/docs/userguide/monitoring/real-time-device-usage.md
+++ b/docs/userguide/monitoring/real-time-device-usage.md
@@ -9,9 +9,28 @@ You can get the real-time device memory and core utilization by visiting `{GPU n
 curl {GPU node ip}:31992/metrics
 ```
 
-It contains the following metrics:
+It contains the following host-level metrics:
 
 | Metrics | Description | Example |
 | --- | --- | --- |
-| hami_host_gpu_utilization_ratio | GPU real-time utilization on host | `{device_index="0",device_uuid="GPU-00552014-5c87-89ac-b1a6-7b53aa24b0ec",zone="vGPU"}` 0 |
-| hami_host_gpu_memory_used_bytes | GPU real-time device memory usage on host | `{device_index="0",device_uuid="GPU-00552014-5c87-89ac-b1a6-7b53aa24b0ec",zone="vGPU"}` 2.87244288e+08 |
+| hami_host_gpu_utilization_ratio | GPU core utilization ratio on host (0-100) | `{device_index="0",device_type="NVIDIA-NVIDIA H200",device_uuid="GPU-00552014-5c87-89ac-b1a6-7b53aa24b0ec",zone="vGPU"}` 0 |
+| hami_host_gpu_memory_used_bytes | GPU real-time device memory usage on host | `{device_index="0",device_type="NVIDIA-NVIDIA H200",device_uuid="GPU-00552014-5c87-89ac-b1a6-7b53aa24b0ec",zone="vGPU"}` 2.87244288e+08 |
+
+It also exposes per-container and per-vGPU metrics for each scheduled task:
+
+| Metrics | Description | Example |
+| --- | --- | --- |
+| hami_container_device_utilization_ratio | Container device SM utilization ratio | `{container="cuda",device_uuid="GPU-00552014-5c87-89ac-b1a6-7b53aa24b0ec",namespace="default",pod="vgpu-share",vdevice_index="0",zone="vGPU"}` 0 |
+| hami_container_device_memory_bytes | Container device memory usage breakdown in bytes | `{buffer_size="0",container="cuda",context_size="0",device_uuid="GPU-00552014-5c87-89ac-b1a6-7b53aa24b0ec",module_size="0",namespace="default",offset="0",pod="vgpu-share",vdevice_index="0",zone="vGPU"}` 0 |
+| hami_container_last_kernel_elapsed_seconds | Seconds since last kernel execution in container | `{container="cuda",device_uuid="GPU-00552014-5c87-89ac-b1a6-7b53aa24b0ec",namespace="default",pod="vgpu-share",vdevice_index="0",zone="vGPU"}` 3664 |
+| hami_vgpu_memory_used_bytes | vGPU device memory usage in bytes | `{container="cuda",device_uuid="GPU-00552014-5c87-89ac-b1a6-7b53aa24b0ec",namespace="default",pod="vgpu-share",vdevice_index="0",zone="vGPU"}` 0 |
+| hami_vgpu_memory_limit_bytes | vGPU device memory limit in bytes | `{container="cuda",device_uuid="GPU-00552014-5c87-89ac-b1a6-7b53aa24b0ec",namespace="default",pod="vgpu-share",vdevice_index="0",zone="vGPU"}` 2.097152e+10 |
+| hami_vgpu_memory_buffer_bytes | Container device memory buffer size in bytes | `{container="cuda",device_uuid="GPU-00552014-5c87-89ac-b1a6-7b53aa24b0ec",namespace="default",pod="vgpu-share",vdevice_index="0",zone="vGPU"}` 6.83935744e+08 |
+| hami_vgpu_memory_context_bytes | Container device memory context size in bytes | `{container="cuda",device_uuid="GPU-00552014-5c87-89ac-b1a6-7b53aa24b0ec",namespace="default",pod="vgpu-share",vdevice_index="0",zone="vGPU"}` 0 |
+| hami_vgpu_memory_module_bytes | Container device memory module size in bytes | `{container="cuda",device_uuid="GPU-00552014-5c87-89ac-b1a6-7b53aa24b0ec",namespace="default",pod="vgpu-share",vdevice_index="0",zone="vGPU"}` 0 |
+
+:::note
+
+The `context_size`, `module_size`, `buffer_size` and `offset` labels on `hami_container_device_memory_bytes` will be deprecated in v2.10.0. Use `hami_vgpu_memory_context_bytes`, `hami_vgpu_memory_module_bytes` and `hami_vgpu_memory_buffer_bytes` instead.
+
+:::

--- a/i18n/zh/docusaurus-plugin-content-docs/current/userguide/monitoring/real-time-device-usage.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/current/userguide/monitoring/real-time-device-usage.md
@@ -10,9 +10,28 @@ translated: true
 curl {GPU 节点 IP}:31992/metrics
 ```
 
-它包含以下指标：
+它包含以下主机级指标：
 
 | 指标 | 描述 | 示例 |
 | --- | --- | --- |
-| hami_host_gpu_utilization_ratio | 主机上的 GPU 实时利用率 | `{device_index="0",device_uuid="GPU-00552014-5c87-89ac-b1a6-7b53aa24b0ec",zone="vGPU"}` 0 |
-| hami_host_gpu_memory_used_bytes | 主机上的 GPU 实时设备显存使用情况 | `{device_index="0",device_uuid="GPU-00552014-5c87-89ac-b1a6-7b53aa24b0ec",zone="vGPU"}` 2.87244288e+08 |
+| hami_host_gpu_utilization_ratio | 主机上的 GPU 核心利用率（0-100） | `{device_index="0",device_type="NVIDIA-NVIDIA H200",device_uuid="GPU-00552014-5c87-89ac-b1a6-7b53aa24b0ec",zone="vGPU"}` 0 |
+| hami_host_gpu_memory_used_bytes | 主机上的 GPU 实时设备显存使用情况 | `{device_index="0",device_type="NVIDIA-NVIDIA H200",device_uuid="GPU-00552014-5c87-89ac-b1a6-7b53aa24b0ec",zone="vGPU"}` 2.87244288e+08 |
+
+它还为每个调度的任务暴露每容器和每 vGPU 的指标：
+
+| 指标 | 描述 | 示例 |
+| --- | --- | --- |
+| hami_container_device_utilization_ratio | 容器设备 SM 利用率 | `{container="cuda",device_uuid="GPU-00552014-5c87-89ac-b1a6-7b53aa24b0ec",namespace="default",pod="vgpu-share",vdevice_index="0",zone="vGPU"}` 0 |
+| hami_container_device_memory_bytes | 容器设备显存使用明细（字节） | `{buffer_size="0",container="cuda",context_size="0",device_uuid="GPU-00552014-5c87-89ac-b1a6-7b53aa24b0ec",module_size="0",namespace="default",offset="0",pod="vgpu-share",vdevice_index="0",zone="vGPU"}` 0 |
+| hami_container_last_kernel_elapsed_seconds | 容器中自上次 kernel 执行以来经过的秒数 | `{container="cuda",device_uuid="GPU-00552014-5c87-89ac-b1a6-7b53aa24b0ec",namespace="default",pod="vgpu-share",vdevice_index="0",zone="vGPU"}` 3664 |
+| hami_vgpu_memory_used_bytes | vGPU 设备显存使用量（字节） | `{container="cuda",device_uuid="GPU-00552014-5c87-89ac-b1a6-7b53aa24b0ec",namespace="default",pod="vgpu-share",vdevice_index="0",zone="vGPU"}` 0 |
+| hami_vgpu_memory_limit_bytes | vGPU 设备显存上限（字节） | `{container="cuda",device_uuid="GPU-00552014-5c87-89ac-b1a6-7b53aa24b0ec",namespace="default",pod="vgpu-share",vdevice_index="0",zone="vGPU"}` 2.097152e+10 |
+| hami_vgpu_memory_buffer_bytes | 容器设备显存 buffer 大小（字节） | `{container="cuda",device_uuid="GPU-00552014-5c87-89ac-b1a6-7b53aa24b0ec",namespace="default",pod="vgpu-share",vdevice_index="0",zone="vGPU"}` 6.83935744e+08 |
+| hami_vgpu_memory_context_bytes | 容器设备显存 context 大小（字节） | `{container="cuda",device_uuid="GPU-00552014-5c87-89ac-b1a6-7b53aa24b0ec",namespace="default",pod="vgpu-share",vdevice_index="0",zone="vGPU"}` 0 |
+| hami_vgpu_memory_module_bytes | 容器设备显存 module 大小（字节） | `{container="cuda",device_uuid="GPU-00552014-5c87-89ac-b1a6-7b53aa24b0ec",namespace="default",pod="vgpu-share",vdevice_index="0",zone="vGPU"}` 0 |
+
+:::note
+
+`hami_container_device_memory_bytes` 上的 `context_size`、`module_size`、`buffer_size` 和 `offset` 标签将在 v2.10.0 中弃用，请改用 `hami_vgpu_memory_context_bytes`、`hami_vgpu_memory_module_bytes` 和 `hami_vgpu_memory_buffer_bytes`。
+
+:::

--- a/i18n/zh/docusaurus-plugin-content-docs/version-v2.9.0/userguide/monitoring/real-time-device-usage.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/version-v2.9.0/userguide/monitoring/real-time-device-usage.md
@@ -10,9 +10,28 @@ translated: true
 curl {GPU 节点 IP}:31992/metrics
 ```
 
-它包含以下指标：
+它包含以下主机级指标：
 
 | 指标 | 描述 | 示例 |
 | --- | --- | --- |
-| hami_host_gpu_utilization_ratio | 主机上的 GPU 实时利用率 | `{device_index="0",device_uuid="GPU-00552014-5c87-89ac-b1a6-7b53aa24b0ec",zone="vGPU"}` 0 |
-| hami_host_gpu_memory_used_bytes | 主机上的 GPU 实时设备显存使用情况 | `{device_index="0",device_uuid="GPU-00552014-5c87-89ac-b1a6-7b53aa24b0ec",zone="vGPU"}` 2.87244288e+08 |
+| hami_host_gpu_utilization_ratio | 主机上的 GPU 核心利用率（0-100） | `{device_index="0",device_type="NVIDIA-NVIDIA H200",device_uuid="GPU-00552014-5c87-89ac-b1a6-7b53aa24b0ec",zone="vGPU"}` 0 |
+| hami_host_gpu_memory_used_bytes | 主机上的 GPU 实时设备显存使用情况 | `{device_index="0",device_type="NVIDIA-NVIDIA H200",device_uuid="GPU-00552014-5c87-89ac-b1a6-7b53aa24b0ec",zone="vGPU"}` 2.87244288e+08 |
+
+它还为每个调度的任务暴露每容器和每 vGPU 的指标：
+
+| 指标 | 描述 | 示例 |
+| --- | --- | --- |
+| hami_container_device_utilization_ratio | 容器设备 SM 利用率 | `{container="cuda",device_uuid="GPU-00552014-5c87-89ac-b1a6-7b53aa24b0ec",namespace="default",pod="vgpu-share",vdevice_index="0",zone="vGPU"}` 0 |
+| hami_container_device_memory_bytes | 容器设备显存使用明细（字节） | `{buffer_size="0",container="cuda",context_size="0",device_uuid="GPU-00552014-5c87-89ac-b1a6-7b53aa24b0ec",module_size="0",namespace="default",offset="0",pod="vgpu-share",vdevice_index="0",zone="vGPU"}` 0 |
+| hami_container_last_kernel_elapsed_seconds | 容器中自上次 kernel 执行以来经过的秒数 | `{container="cuda",device_uuid="GPU-00552014-5c87-89ac-b1a6-7b53aa24b0ec",namespace="default",pod="vgpu-share",vdevice_index="0",zone="vGPU"}` 3664 |
+| hami_vgpu_memory_used_bytes | vGPU 设备显存使用量（字节） | `{container="cuda",device_uuid="GPU-00552014-5c87-89ac-b1a6-7b53aa24b0ec",namespace="default",pod="vgpu-share",vdevice_index="0",zone="vGPU"}` 0 |
+| hami_vgpu_memory_limit_bytes | vGPU 设备显存上限（字节） | `{container="cuda",device_uuid="GPU-00552014-5c87-89ac-b1a6-7b53aa24b0ec",namespace="default",pod="vgpu-share",vdevice_index="0",zone="vGPU"}` 2.097152e+10 |
+| hami_vgpu_memory_buffer_bytes | 容器设备显存 buffer 大小（字节） | `{container="cuda",device_uuid="GPU-00552014-5c87-89ac-b1a6-7b53aa24b0ec",namespace="default",pod="vgpu-share",vdevice_index="0",zone="vGPU"}` 6.83935744e+08 |
+| hami_vgpu_memory_context_bytes | 容器设备显存 context 大小（字节） | `{container="cuda",device_uuid="GPU-00552014-5c87-89ac-b1a6-7b53aa24b0ec",namespace="default",pod="vgpu-share",vdevice_index="0",zone="vGPU"}` 0 |
+| hami_vgpu_memory_module_bytes | 容器设备显存 module 大小（字节） | `{container="cuda",device_uuid="GPU-00552014-5c87-89ac-b1a6-7b53aa24b0ec",namespace="default",pod="vgpu-share",vdevice_index="0",zone="vGPU"}` 0 |
+
+:::note
+
+`hami_container_device_memory_bytes` 上的 `context_size`、`module_size`、`buffer_size` 和 `offset` 标签将在 v2.10.0 中弃用，请改用 `hami_vgpu_memory_context_bytes`、`hami_vgpu_memory_module_bytes` 和 `hami_vgpu_memory_buffer_bytes`。
+
+:::

--- a/versioned_docs/version-v2.9.0/userguide/monitoring/real-time-device-usage.md
+++ b/versioned_docs/version-v2.9.0/userguide/monitoring/real-time-device-usage.md
@@ -9,9 +9,28 @@ You can get the real-time device memory and core utilization by visiting `{GPU n
 curl {GPU node ip}:31992/metrics
 ```
 
-It contains the following metrics:
+It contains the following host-level metrics:
 
 | Metrics | Description | Example |
 | --- | --- | --- |
-| hami_host_gpu_utilization_ratio | GPU real-time utilization on host | `{device_index="0",device_uuid="GPU-00552014-5c87-89ac-b1a6-7b53aa24b0ec",zone="vGPU"}` 0 |
-| hami_host_gpu_memory_used_bytes | GPU real-time device memory usage on host | `{device_index="0",device_uuid="GPU-00552014-5c87-89ac-b1a6-7b53aa24b0ec",zone="vGPU"}` 2.87244288e+08 |
+| hami_host_gpu_utilization_ratio | GPU core utilization ratio on host (0-100) | `{device_index="0",device_type="NVIDIA-NVIDIA H200",device_uuid="GPU-00552014-5c87-89ac-b1a6-7b53aa24b0ec",zone="vGPU"}` 0 |
+| hami_host_gpu_memory_used_bytes | GPU real-time device memory usage on host | `{device_index="0",device_type="NVIDIA-NVIDIA H200",device_uuid="GPU-00552014-5c87-89ac-b1a6-7b53aa24b0ec",zone="vGPU"}` 2.87244288e+08 |
+
+It also exposes per-container and per-vGPU metrics for each scheduled task:
+
+| Metrics | Description | Example |
+| --- | --- | --- |
+| hami_container_device_utilization_ratio | Container device SM utilization ratio | `{container="cuda",device_uuid="GPU-00552014-5c87-89ac-b1a6-7b53aa24b0ec",namespace="default",pod="vgpu-share",vdevice_index="0",zone="vGPU"}` 0 |
+| hami_container_device_memory_bytes | Container device memory usage breakdown in bytes | `{buffer_size="0",container="cuda",context_size="0",device_uuid="GPU-00552014-5c87-89ac-b1a6-7b53aa24b0ec",module_size="0",namespace="default",offset="0",pod="vgpu-share",vdevice_index="0",zone="vGPU"}` 0 |
+| hami_container_last_kernel_elapsed_seconds | Seconds since last kernel execution in container | `{container="cuda",device_uuid="GPU-00552014-5c87-89ac-b1a6-7b53aa24b0ec",namespace="default",pod="vgpu-share",vdevice_index="0",zone="vGPU"}` 3664 |
+| hami_vgpu_memory_used_bytes | vGPU device memory usage in bytes | `{container="cuda",device_uuid="GPU-00552014-5c87-89ac-b1a6-7b53aa24b0ec",namespace="default",pod="vgpu-share",vdevice_index="0",zone="vGPU"}` 0 |
+| hami_vgpu_memory_limit_bytes | vGPU device memory limit in bytes | `{container="cuda",device_uuid="GPU-00552014-5c87-89ac-b1a6-7b53aa24b0ec",namespace="default",pod="vgpu-share",vdevice_index="0",zone="vGPU"}` 2.097152e+10 |
+| hami_vgpu_memory_buffer_bytes | Container device memory buffer size in bytes | `{container="cuda",device_uuid="GPU-00552014-5c87-89ac-b1a6-7b53aa24b0ec",namespace="default",pod="vgpu-share",vdevice_index="0",zone="vGPU"}` 6.83935744e+08 |
+| hami_vgpu_memory_context_bytes | Container device memory context size in bytes | `{container="cuda",device_uuid="GPU-00552014-5c87-89ac-b1a6-7b53aa24b0ec",namespace="default",pod="vgpu-share",vdevice_index="0",zone="vGPU"}` 0 |
+| hami_vgpu_memory_module_bytes | Container device memory module size in bytes | `{container="cuda",device_uuid="GPU-00552014-5c87-89ac-b1a6-7b53aa24b0ec",namespace="default",pod="vgpu-share",vdevice_index="0",zone="vGPU"}` 0 |
+
+:::note
+
+The `context_size`, `module_size`, `buffer_size` and `offset` labels on `hami_container_device_memory_bytes` will be deprecated in v2.10.0. Use `hami_vgpu_memory_context_bytes`, `hami_vgpu_memory_module_bytes` and `hami_vgpu_memory_buffer_bytes` instead.
+
+:::


### PR DESCRIPTION
## What

Expands the **real-time device usage endpoint** (`:31992`) documentation from 2 metrics to the full set exported by the HAMi v2.9 device plugin.

Previously only `hami_host_gpu_utilization_ratio` and `hami_host_gpu_memory_used_bytes` were documented; the endpoint actually exposes a per-container and per-vGPU metric family that was undocumented.

## Changes

- Added the `device_type` label to the `hami_host_gpu_*` examples to match real output.
- Documented the per-container / per-vGPU metrics:
  - `hami_container_device_utilization_ratio`
  - `hami_container_device_memory_bytes`
  - `hami_container_last_kernel_elapsed_seconds`
  - `hami_vgpu_memory_used_bytes`
  - `hami_vgpu_memory_limit_bytes`
  - `hami_vgpu_memory_buffer_bytes`
  - `hami_vgpu_memory_context_bytes`
  - `hami_vgpu_memory_module_bytes`
- Added a note that the `context_size` / `module_size` / `buffer_size` / `offset` labels on `hami_container_device_memory_bytes` will be deprecated in v2.10.0, in favor of `hami_vgpu_memory_{context,module,buffer}_bytes`.

## Verification

All metric names, labels, and example values were captured from a live **HAMi v2.9.0** cluster (NVIDIA H200 nodes). The v2.10.0 deprecation note is taken verbatim from the exporter's `# HELP` text.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Expanded the real-time device usage guide with clearer host-level metric descriptions and updated label examples.
  * Added documentation for new per-container and per-vGPU metrics, including utilization and memory breakdown details.
  * Included a deprecation note for certain memory labels in v2.10.0 and pointed readers to the replacement metrics.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->