### PR TITLE
update enflame sharing docs

### DIFF
--- a/docs/installation/upgrade.md
+++ b/docs/installation/upgrade.md
@@ -46,7 +46,7 @@ kubectl get all -n kube-system -l app=hami -o yaml > hami-state-backup.yaml
 
 ```bash
 # Find pods using GPU
-kubectl get pods --all-namespaces -o json | jq -r '.items[] | select(.spec.containers[]?.resources.limits | select(. != null) | select(has("nvidia.com/gpu") or has("enflame.com/vgcu"))) | "\(.metadata.namespace) \(.metadata.name)"'
+kubectl get pods --all-namespaces -o json | jq -r '.items[] | select(.spec.containers[]?.resources.limits | select(. != null) | select(has("nvidia.com/gpu"))) | "\(.metadata.namespace) \(.metadata.name)"'
 
 # Delete or reschedule these pods
 kubectl delete pods <pod-name> -n <namespace> --grace-period=30

--- a/docs/userguide/enflame-device/enable-enflame-gcu-sharing.md
+++ b/docs/userguide/enflame-device/enable-enflame-gcu-sharing.md
@@ -4,26 +4,20 @@ title: Enable Enflame GCU Sharing
 
 ## Introduction
 
-**HAMi now supports sharing on enflame.com/gcu (i.e., S60) by implementing most device-sharing features as NVIDIA GPUs**, including:
+HAMi now supports Enflame **DRS** hard partition scheduling, aligned with Enflame native scheduler behavior.
 
-**GCU sharing**: Each task can allocate a portion of GCU instead of a whole GCU card, thus GCU can be shared among multiple tasks.
-
-**Device Memory and Core Control**: GCUs can be allocated with a certain percentage of device memory and core, with hard limits enforced to prevent exceeding the allocation.
-
-**Device UUID Selection**: You can specify which GCU devices to use or exclude using annotations.
-
-**No task YAML changes required**: All GCU jobs are automatically supported after installation.
+DRS is a hard-slice mode similar to NVIDIA MIG and Ascend VNPU templates.
 
 ## Prerequisites
 
-- Enflame gcushare-device-plugin >= 2.1.6 (please consult your device provider, gcushare has two components: gcushare-scheduler-plugin and gcushare-device-plugin; only gcushare-device-plugin is needed here)
-- driver version >= 1.2.3.14
+- Enflame gcushare-device-plugin >= 2.2.14 (please consult your device provider; only `gcushare-device-plugin` is needed — do not install `gcushare-scheduler-plugin`)
+- driver version >= 1.8.7
 - kubernetes >= 1.24
-- enflame-container-toolkit >=2.0.50
+- enflame-container-toolkit >= 2.0.50
 
-## Enabling GCU-sharing Support
+## Enable Enflame DRS Scheduling
 
-- Deploy gcushare-device-plugin on enflame nodes (Please consult your device provider to acquire its package and document)
+- Deploy `gcushare-device-plugin` on Enflame nodes (please consult your device provider to acquire its package and documentation)
 
 :::caution
 
@@ -31,43 +25,38 @@ Install only `gcushare-device-plugin`. Do not install the `gcushare-scheduler-pl
 
 :::
 
-:::note
-
-The default resource names are:
-
-- `enflame.com/vgcu` for GCU count (only 1 is supported currently)
-- `enflame.com/vgcu-percentage` for the percentage of memory and cores in a GCU slice
-
-You can customize these names by modifying the `hami-scheduler-device` ConfigMap.
-
-:::
-
-- Set 'devices.enflame.enabled=true' when deploy HAMi
+- Set `devices.enflame.enabled=true` when deploying HAMi
 
 ```bash
 helm install hami hami-charts/hami --set devices.enflame.enabled=true -n kube-system
 ```
 
-## Device Granularity
+:::note
 
-HAMi divides each Enflame GCU into 100 units for resource allocation. Requesting a portion of a GCU corresponds to requesting a specific number of these units.
+The default resource names are:
 
-### GCU Slice Allocation
+- `enflame.com/drs-gcu` for direct DRS slice requests
+- `enflame.com/gcu-memory` for memory requests (in MiB)
+- `enflame.com/gcu-core` for core requests (as a percentage)
 
-- Each unit of `enflame.com/vgcu-percentage` represents 1% device memory and 1% core
-- If no memory request is specified, the system defaults to using 100% of the available memory
-- Memory allocation is enforced with hard limits to ensure tasks do not exceed their allocated memory
-- Core allocation is enforced with hard limits to ensure tasks do not exceed their allocated cores
+You can customize these names by modifying the `hami-scheduler-device` ConfigMap.
 
-## Running Enflame jobs
+:::
 
-Enflame GCUs can now be requested by a container using the `enflame.com/vgcu` and `enflame.com/vgcu-percentage` resource type:
+## Running DRS Workloads
+
+HAMi supports two request styles:
+
+1. Direct DRS slice request (`enflame.com/drs-gcu`)
+2. Unified memory/core request (`enflame.com/gcu-memory` + `enflame.com/gcu-core`); HAMi converts it to a DRS profile internally.
+
+### Direct DRS slice request
 
 ```yaml
 apiVersion: v1
 kind: Pod
 metadata:
-  name: gcushare-pod-2
+  name: gcushare-pod-drs
   namespace: kube-system
 spec:
   terminationGracePeriodSeconds: 0
@@ -75,14 +64,38 @@ spec:
     - name: pod-gcu-example1
       image: ubuntu:22.04
       imagePullPolicy: IfNotPresent
-      command:
-        - sleep
-      args:
-        - "100000"
+      command: ["sleep"]
+      args: ["100000"]
       resources:
         limits:
-          enflame.com/vgcu: 1
-          enflame.com/vgcu-percentage: 22
+          enflame.com/drs-gcu: 3
+        requests:
+          enflame.com/drs-gcu: 3
+```
+
+### Request by memory/core (recommended unified API)
+
+```yaml
+apiVersion: v1
+kind: Pod
+metadata:
+  name: gcushare-pod-by-spec
+  namespace: kube-system
+spec:
+  terminationGracePeriodSeconds: 0
+  containers:
+    - name: pod-gcu-example1
+      image: ubuntu:22.04
+      imagePullPolicy: IfNotPresent
+      command: ["sleep"]
+      args: ["100000"]
+      resources:
+        limits:
+          enflame.com/gcu-memory: 20480 # MiB
+          enflame.com/gcu-core: 40 # percent
+        requests:
+          enflame.com/gcu-memory: 20480
+          enflame.com/gcu-core: 40
 ```
 
 :::tip
@@ -91,50 +104,14 @@ More examples are available in the [examples/enflame folder](https://github.com/
 
 :::
 
-## Device UUID Selection
+## Scheduling Annotations
 
-You can specify which GCU devices to use or exclude using annotations:
+During scheduling, HAMi writes DRS-compatible annotations such as:
 
-```yaml
-apiVersion: v1
-kind: Pod
-metadata:
-  name: poddemo
-  annotations:
-    # Use specific GCU devices (comma-separated list)
-    enflame.com/use-gpuuuid: "node1-enflame-0,node1-enflame-1"
-    # Or exclude specific GCU devices (comma-separated list)
-    enflame.com/nouse-gpuuuid: "node1-enflame-2,node1-enflame-3"
-spec:
-  # ... rest of pod spec
-```
+- `assigned-containers`
+- `enflame.com/gcu-assigned`
+- `enflame.com/gcu-assigned-index`
+- `enflame.com/gcu-assigned-minor`
+- `enflame.com/gcu-request-size`
 
-:::note
-
-The device ID format is `{node-name}-enflame-{index}`. You can find the available device IDs in the node status.
-
-:::
-
-### Finding Device UUIDs
-
-You can find the UUIDs of Enflame GCUs on a node using the following command:
-
-```bash
-kubectl get pod <pod-name> -o yaml | grep -A 10 "hami.io/<card-type>-devices-allocated"
-```
-
-Or by examining the node annotations:
-
-```bash
-kubectl get node <node-name> -o yaml | grep -A 10 "hami.io/node-register-<card-type>"
-```
-
-Look for annotations containing device information in the node status.
-
-## Notes
-
-1. GCUshare takes effect only for containers that apply for one GCU (i.e., enflame.com/vgcu=1 ).
-
-2. Multiple GCU allocation in one container is not supported yet
-
-3. `efsmi` inside container shows the total device memory, which is NOT a bug, device memory will be properly limited when running tasks.
+These annotations are consumed by the Enflame device plugin during the Allocate phase.

--- a/i18n/zh/docusaurus-plugin-content-docs/current/installation/upgrade.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/current/installation/upgrade.md
@@ -46,7 +46,7 @@ kubectl get all -n kube-system -l app=hami -o yaml > hami-state-backup.yaml
 
 ```bash
 # 查找使用 GPU 的 Pod
-kubectl get pods --all-namespaces -o json | jq -r '.items[] | select(.spec.containers[]?.resources.limits | select(. != null) | select(has("nvidia.com/gpu") or has("enflame.com/vgcu"))) | "\(.metadata.namespace) \(.metadata.name)"'
+kubectl get pods --all-namespaces -o json | jq -r '.items[] | select(.spec.containers[]?.resources.limits | select(. != null) | select(has("nvidia.com/gpu"))) | "\(.metadata.namespace) \(.metadata.name)"'
 
 # 删除或重新调度这些 Pod
 kubectl delete pods <pod-name> -n <namespace> --grace-period=30

--- a/i18n/zh/docusaurus-plugin-content-docs/current/userguide/enflame-device/enable-enflame-gcu-sharing.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/current/userguide/enflame-device/enable-enflame-gcu-sharing.md
@@ -5,63 +5,55 @@ sidebar_label: GPU 共享
 
 ## 简介
 
-本组件支持复用燧原 GCU 设备 (S60)，并为此提供以下几种与 vGPU 类似的复用功能，包括：
+HAMi 现已支持燧原 **DRS 硬切分**调度，并对齐燧原原生调度器链路。
 
-**GPU 共享**: 每个任务可以只占用一部分显卡，多个任务可以共享一张显卡
-
-**百分比切片能力**: 你现在可以用百分比来申请一个 GCU 切片（例如 20%），本组件会确保任务使用的显存和算力不会超过这个百分比对应的数值
-
-**设备 UUID 选择**: 你可以通过注解指定使用或排除特定的 GCU 设备
-
-**部署说明**: 部署本组件后，只需要部署厂家提供的 gcushare-device-plugin 即可使用
+DRS 是类似 NVIDIA MIG / Ascend VNPU 的硬切分方案。
 
 ## 节点需求
 
-- Enflame gcushare-device-plugin >= 2.1.6
-- driver version >= 1.2.3.14
+- Enflame gcushare-device-plugin >= 2.2.14
+- driver version >= 1.8.7
 - kubernetes >= 1.24
-- enflame-container-toolkit >=2.0.50
+- enflame-container-toolkit >= 2.0.50
 
-## 开启 GCU 复用
+## 开启 DRS 调度
 
-- 部署'gcushare-device-plugin'，燧原的 GCU 共享需要配合厂家提供的'gcushare-device-plugin'一起使用，联系设备提供方获取
+- 部署 `gcushare-device-plugin`，并确保版本支持 DRS（请联系设备提供方获取安装包与文档）
 
 :::note
 
-只需要安装 gcushare-device-plugin，不要安装 gcushare-scheduler-plugin.
+只需要安装 gcushare-device-plugin，不要安装 gcushare-scheduler-plugin。
 
 :::
 
-- 在安装 HAMi 时配置参数'devices.enflame.enabled=true'
+- 在安装 HAMi 时配置参数 `devices.enflame.enabled=true`
 
 ```bash
 helm install hami hami-charts/hami --set devices.enflame.enabled=true -n kube-system
 ```
 
-> **说明：** 默认资源名称如下：
+> **说明：** 默认资源名称包括：
 >
-> - `enflame.com/vgcu` 用于 GCU 数量，这里只能为 1
-> - `enflame.com/vgcu-percentage` 用于生成共享 GCU 切片
+> - `enflame.com/drs-gcu`（直接 DRS 切片请求）
+> - `enflame.com/gcu-memory`（按显存请求，单位 MiB）
+> - `enflame.com/gcu-core`（按算力百分比请求）
 >
-> 你可以通过修改`hami-scheduler-device`配置，来修改这些资源名称
-
-## 设备粒度切分
-
-HAMi 将每个燧原 GCU 划分为 100 个单元进行资源分配。当你请求一部分 GCU 时，实际上是在请求这些单元中的一定数量。
-
-### 显存和核心分配
-
-- 每个 `enflame.com/vgcu-percentage` 单位代表 1% 的算力和 1% 的显存
-- 如果不指定显存请求，系统将默认使用 100% 的可用显存
-- 内存与核心的分配通过硬限制强制执行，确保任务不会超过其分配的显存与核心
+> 你可以通过修改 `hami-scheduler-device` 配置来修改这些资源名称。
 
 ## 运行 GCU 任务
+
+HAMi 支持两种申请方式：
+
+1. 直接申请 DRS 切片数（`enflame.com/drs-gcu`）
+2. 按显存/算力申请（`enflame.com/gcu-memory` + `enflame.com/gcu-core`），由 HAMi 在调度内部换算为 DRS profile。
+
+### 直接申请 DRS 切片
 
 ```yaml
 apiVersion: v1
 kind: Pod
 metadata:
-  name: gcushare-pod-2
+  name: gcushare-pod-drs
   namespace: kube-system
 spec:
   terminationGracePeriodSeconds: 0
@@ -75,56 +67,52 @@ spec:
         - "100000"
       resources:
         limits:
-          enflame.com/vgcu: 1
-          enflame.com/vgcu-percentage: 22
+          enflame.com/drs-gcu: 3
+        requests:
+          enflame.com/drs-gcu: 3
 ```
 
-:::note
-
-查看更多的[用例](https://github.com/Project-HAMi/HAMi/tree/release-v2.6/examples/enflame/).
-
-:::
-
-## 设备 UUID 选择
-
-你可以通过 Pod 注解来指定要使用或排除特定的 GCU 设备：
+### 按显存/算力申请（统一 API）
 
 ```yaml
 apiVersion: v1
 kind: Pod
 metadata:
-  name: poddemo
-  annotations:
-    # Use specific GCU devices (comma-separated list)
-    enflame.com/use-gpuuuid: "node1-enflame-0,node1-enflame-1"
-    # Or exclude specific GCU devices (comma-separated list)
-    enflame.com/nouse-gpuuuid: "node1-enflame-2,node1-enflame-3"
+  name: gcushare-pod-by-spec
+  namespace: kube-system
 spec:
-  # ... rest of pod spec
+  terminationGracePeriodSeconds: 0
+  containers:
+    - name: pod-gcu-example1
+      image: ubuntu:18.04
+      imagePullPolicy: IfNotPresent
+      command:
+        - sleep
+      args:
+        - "100000"
+      resources:
+        limits:
+          enflame.com/gcu-memory: 20480 # MiB
+          enflame.com/gcu-core: 40 # 百分比
+        requests:
+          enflame.com/gcu-memory: 20480
+          enflame.com/gcu-core: 40
 ```
 
-> **说明：** 设备 ID 格式为 `{节点名称}-enflame-{索引}`。你可以在节点状态中找到可用的设备 ID。
+:::note
 
-### 查找设备 UUID
+查看更多的[用例](https://github.com/Project-HAMi/HAMi/tree/master/examples/enflame/)。
 
-你可以使用以下命令查找节点上的燧原 GCU 设备 UUID：
+:::
 
-```bash
-kubectl get pod <pod-name> -o yaml | grep -A 10 "hami.io/<card-type>-devices-allocated"
-```
+## 调度注解
 
-或者通过检查节点注解：
+HAMi 在调度阶段会写入与 DRS 兼容的注解，包括：
 
-```bash
-kubectl get node <node-name> -o yaml | grep -A 10 "hami.io/node-register-<card-type>"
-```
+- `assigned-containers`
+- `enflame.com/gcu-assigned`
+- `enflame.com/gcu-assigned-index`
+- `enflame.com/gcu-assigned-minor`
+- `enflame.com/gcu-request-size`
 
-在节点注解中查找包含设备信息的注解。
-
-## 注意事项
-
-1. 共享模式只对申请一张 GCU 的容器生效（enflame.com/vgcu=1）。
-
-2. 目前暂时不支持一个容器中申请多个 GCU 设备。
-
-3. 任务中使用`efsmi`可以看到全部的显存，但这并非异常，显存会在任务使用过程中被正确限制。
+这些注解将由燧原 device-plugin 在 Allocate 阶段继续处理并完成 DRS instance 绑定。


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated upgrade guidance to identify GPU-using pods using `nvidia.com/gpu` only.
  * Reworked Enflame GPU-sharing docs to describe DRS hard-partition scheduling, with new setup requirements, resource names, and workload examples.
  * Refreshed the Chinese documentation to match the updated Enflame DRS scheduling flow and terminology.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->