### PR TITLE
fix: remove npm as project dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,7 +40,6 @@
     "@fortawesome/react-fontawesome": "^3.2.0",
     "asciinema-player": "^3.0.1",
     "clsx": "^1.2.1",
-    "npm": "^10.5.2",
     "prism-react-renderer": "^2.4.0",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",


### PR DESCRIPTION
npm should not be listed as a dependency in package.json. It is the package manager, not a project package.

## Test plan
- npm run lint:md passes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Removed an unused package entry from the dependency list, simplifying project maintenance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->