### PR TITLE
fix: quote date field in blog post frontmatter

### DIFF
--- a/blog/hami-core-adopted-by-nvidia-kai-scheduler/index.md
+++ b/blog/hami-core-adopted-by-nvidia-kai-scheduler/index.md
@@ -1,6 +1,6 @@
 ---
 title: "HAMi-core Adopted by NVIDIA KAI Scheduler: GPU Sharing Enters the Hard-Isolation Era"
-date: 2026-06-20
+date: "2026-06-20"
 description: "Two core PRs have merged into NVIDIA KAI Scheduler, making HAMi's GPU memory hard isolation a built-in feature. Cloud-native GPU scheduling moves from cooperative sharing to true hard isolation."
 authors: [hami_community]
 tags:


### PR DESCRIPTION
One blog post had an unquoted date field while all other posts quote it. Made it match the rest.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated a blog post’s metadata date format for consistency, with no changes to the article content.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->