### PR TITLE
docs: clarify license section in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -178,6 +178,6 @@ See [OWNERS](./OWNERS) for current maintainers.
 
 ## License
 
-The documentation and website are part of the HAMi project. See the main repository for license information.
+This documentation is licensed under [CC BY 4.0](./LICENSE). The HAMi project code itself is licensed separately, see the [main repository](https://github.com/Project-HAMi/HAMi) for details.
 
 [![FOSSA Status](https://app.fossa.com/api/projects/git%2Bgithub.com%2FProject-HAMi%2Fwebsite.svg?type=large)](https://app.fossa.com/projects/git%2Bgithub.com%2FProject-HAMi%2Fwebsite?ref=badge_large)


### PR DESCRIPTION
README pointed to the main repo for license info but this repo has its own LICENSE file (CC BY 4.0) that was never named. Name it and clarify the code license lives in the main repo.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified the documentation license in the README.
  * Added an explicit statement that the docs are licensed under CC BY 4.0.
  * Noted that the main project code uses a separate license and linked to the main repository for details.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->