### PR TITLE
fix: correct organizationName to match actual GitHub org

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -56,7 +56,7 @@ module.exports = {
       onBrokenMarkdownLinks: "throw",
     },
   },
-  organizationName: "hami-io",
+  organizationName: "Project-HAMi",
   projectName: "website",
   favicon: "img/logo.svg",
   clientModules: [


### PR DESCRIPTION
organizationName was set to hami-io but the actual GitHub org is Project-HAMi. This only affects npm run deploy, which is unused since the site deploys via Netlify. Fixed it to be correct in case anyone runs it.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the site’s organization name in the documentation configuration to reflect the new Project-HAMi branding.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->