### PR TITLE
fix: replace broken check-links script with working tool

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "lint": "npm run lint:md",
     "format:check": "prettier --check .",
     "format": "prettier --write .",
-    "check-links": "npm run build && npx html-link-checker --root ./build --quiet || true",
+    "check-links": "npm run build && npx linkinator ./build --recurse || true",
     "check:all": "npm run lint && npm run format:check && npm run build"
   },
   "dependencies": {


### PR DESCRIPTION
check-links called npx html-link-checker, a package that does not exist on npm. The script always failed with a 404 for anyone who ran it. Swapped in linkinator, which is real and actively maintained.