### PR TITLE
Update footer copyright to LF Projects, LLC policy notice

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -404,9 +404,9 @@ module.exports = {
         <strong>© HAMi Authors ${new Date().getFullYear()} | Documentation Distributed under <a href="https://creativecommons.org/licenses/by/4.0">CC-BY-4.0</a> </strong> <strong>| Powered by <a href="https://www.netlify.com">Netlify</a></strong>
         <br />
         <br />
-        The Linux Foundation has registered trademarks and uses trademarks. For a list of trademarks of The Linux Foundation, please see our <a href="https://www.linuxfoundation.org/trademark-usage/">Trademark Usage</a> page.
+        Copyright © HAMi a Series of LF Projects, LLC
         <br />
-        <a href="https://www.linuxfoundation.org/privacy/">Privacy Policy</a> and <a href="https://www.linuxfoundation.org/terms/">Terms of Use</a>.
+        For website terms of use, trademark policy and other project policies please see <a href="https://lfprojects.org/policies/">lfprojects.org/policies/</a>.
       `,
     },
     prism: {

--- a/i18n/zh/docusaurus-theme-classic/footer.json
+++ b/i18n/zh/docusaurus-theme-classic/footer.json
@@ -80,7 +80,7 @@
     "description": "The label of footer link with label=Slack  linking to https://cloud-native.slack.com/archives/C07T10BU4R2/"
   },
   "copyright": {
-    "message": "\n        <br />\n        <strong>© HAMi Authors 2026 | Documentation Distributed under <a href=\"https://creativecommons.org/licenses/by/4.0\">CC-BY-4.0</a> </strong> <strong>| Powered by <a href=\"https://www.netlify.com\">Netlify</a></strong>\n        <br />\n        <br />\n        The Linux Foundation has registered trademarks and uses trademarks. For a list of trademarks of The Linux Foundation, please see our <a href=\"https://www.linuxfoundation.org/trademark-usage/\">Trademark Usage</a> page.\n        <br />\n        <a href=\"https://www.linuxfoundation.org/privacy/\">Privacy Policy</a> and <a href=\"https://www.linuxfoundation.org/terms/\">Terms of Use</a>.\n      ",
+    "message": "\n        <br />\n        <strong>© HAMi Authors 2026 | Documentation Distributed under <a href=\"https://creativecommons.org/licenses/by/4.0\">CC-BY-4.0</a> </strong> <strong>| Powered by <a href=\"https://www.netlify.com\">Netlify</a></strong>\n        <br />\n        <br />\n        Copyright © HAMi a Series of LF Projects, LLC\n        <br />\n        For website terms of use, trademark policy and other project policies please see <a href=\"https://lfprojects.org/policies/\">lfprojects.org/policies/</a>.\n      ",
     "description": "The footer copyright"
   },
   "link.item.label.Discord": {


### PR DESCRIPTION
## What

Replaces the footer legal text with the standard LF Projects, LLC notice:

**Before**
> The Linux Foundation has registered trademarks and uses trademarks. For a list of trademarks of The Linux Foundation, please see our Trademark Usage page.
> Privacy Policy and Terms of Use.

**After**
> Copyright © HAMi a Series of LF Projects, LLC
> For website terms of use, trademark policy and other project policies please see [lfprojects.org/policies/](https://lfprojects.org/policies/).

## Why

HAMi is a Series of LF Projects, LLC, so the footer should point to the LF Projects policies page rather than the Linux Foundation trademark/privacy pages.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated the site footer copyright and policy text to use the new “LF Projects” wording and include a link to lfprojects.org/policies/.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->