### PR TITLE
Update CNCF project status from Sandbox to Incubating

### DIFF
--- a/src/data/home/heroStats.js
+++ b/src/data/home/heroStats.js
@@ -2,7 +2,7 @@ const heroStats = [
   {
     key: "cncf",
     label: { en: "CNCF", zh: "CNCF" },
-    value: { en: "Sandbox", zh: "Sandbox 项目" },
+    value: { en: "Incubating", zh: "孵化项目" },
   },
   {
     key: "release",

--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -702,33 +702,33 @@ export default function Home() {
               </div>
               <div className={styles.cncfFeatureBody}>
                 <span className={styles.cncfEyebrow}>
-                  {isZh ? "CNCF Sandbox 项目" : "CNCF Sandbox Project"}
+                  {isZh ? "CNCF 孵化项目" : "CNCF Incubating Project"}
                 </span>
                 <h2 className={styles.cncfFeatureTitle}>
-                  {isZh ? "HAMi 是 CNCF Sandbox 项目" : "HAMi is a CNCF Sandbox project"}
+                  {isZh ? "HAMi 是 CNCF 孵化项目" : "HAMi is a CNCF Incubating project"}
                 </h2>
                 <p className={styles.cncfFeatureText}>
                   {isZh ? (
                     <>
                       HAMi 是云原生计算基金会（CNCF）的{" "}
                       <a
-                        href="https://landscape.cncf.io/?item=orchestration-management--scheduling-orchestration--hami"
+                        href="https://landscape.cncf.io/?group=projects-and-products&project=incubating&item=orchestration-management--scheduling-orchestration--hami"
                         target="_blank"
                         rel="noopener noreferrer"
                       >
-                        Sandbox 项目
+                        孵化项目
                       </a>
-                      ， 并被收录于 CNCF 技术全景图和 CNAI 技术全景图。
+                      ，并被收录于 CNCF 技术全景图和 CNAI 技术全景图。
                     </>
                   ) : (
                     <>
-                      HAMi is a{" "}
+                      HAMi is an{" "}
                       <a
-                        href="https://landscape.cncf.io/?item=orchestration-management--scheduling-orchestration--hami"
+                        href="https://landscape.cncf.io/?group=projects-and-products&project=incubating&item=orchestration-management--scheduling-orchestration--hami"
                         target="_blank"
                         rel="noopener noreferrer"
                       >
-                        Sandbox project
+                        Incubating project
                       </a>{" "}
                       of the Cloud Native Computing Foundation (CNCF), listed in both the CNCF
                       Landscape and the CNAI Landscape.

--- a/src/theme/Footer/index.js
+++ b/src/theme/Footer/index.js
@@ -167,12 +167,12 @@ function Footer() {
       <div className={styles.cncfBar}>
         <a
           className={styles.cncfLink}
-          href="https://www.cncf.io/sandbox-projects/"
+          href="https://landscape.cncf.io/?group=projects-and-products&project=incubating&item=orchestration-management--scheduling-orchestration--hami"
           target="_blank"
           rel="noreferrer"
         >
           <img className={styles.cncfLogo} src={cncfLogo} alt="CNCF" />
-          <span>{isZh ? "HAMi 是 CNCF Sandbox 项目" : "HAMi is a CNCF Sandbox project"}</span>
+          <span>{isZh ? "HAMi 是 CNCF 孵化项目" : "HAMi is a CNCF Incubating project"}</span>
         </a>
       </div>
       {i18n.currentLocale === "zh" && (


### PR DESCRIPTION
HAMi has been promoted to CNCF Incubating. This updates the website to reflect the new status in both the English and Chinese versions:

- **Homepage CNCF section** (`src/pages/index.js`): eyebrow, heading, and paragraph now say Incubating (孵化项目 for zh), and both landscape links point to the incubating entry: https://landscape.cncf.io/?group=projects-and-products&project=incubating&item=orchestration-management--scheduling-orchestration--hami
- **Hero stat** (`src/data/home/heroStats.js`): "CNCF Sandbox" → "CNCF Incubating" (zh: 孵化项目)
- **Bottom banner** (`src/theme/Footer/index.js`): now reads "HAMi is a CNCF Incubating project" (zh: HAMi 是 CNCF 孵化项目, fully localized with no English mixed in) and links to the incubating landscape entry instead of cncf.io/sandbox-projects.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Content Updates**
  * Updated the CNCF status shown across the site from **Sandbox** to **Incubating**.
  * Refreshed the corresponding English and Chinese labels to match the new status.
  * Adjusted the linked CNCF Landscape reference so it points to the updated incubating-project listing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->