### PR TITLE
chore: remove dead zh translation keys

### DIFF
--- a/i18n/zh/code.json
+++ b/i18n/zh/code.json
@@ -251,12 +251,6 @@
   "Supporters": {
     "message": "支持者"
   },
-  "HAMi is a": {
-    "message": "HAMi 是一个"
-  },
-  "sandbox project": {
-    "message": "沙盒项目"
-  },
   "了解更多": {
     "message": "了解更多"
   },


### PR DESCRIPTION
i18n/zh/code.json had two old keys, HAMi is a and sandbox project, from an earlier version of the homepage code. No component uses Translate with these ids anymore, the homepage now builds its bilingual text with plain ternaries. These keys never render, removing them.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated Chinese localization content by removing two outdated message entries.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->