### PR TITLE
docs: make AGENTS.md tool agnostic

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,6 +1,6 @@
 # AGENTS.md
 
-This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+This file provides guidance to AI coding agents when working with code in this repository.
 
 ## Project Overview
 


### PR DESCRIPTION
AGENTS.md is meant to work as a shared instruction file for any AI coding agent, not one specific tool. The intro line named a single vendor. Made it generic.