### PR TITLE
fix: correct vGPU casing in webui dev guide

### DIFF
--- a/docs/developers/hami-webui-development-guide.md
+++ b/docs/developers/hami-webui-development-guide.md
@@ -144,7 +144,7 @@ Under `packages/web/projects/vgpu/api/`:
 Prefer extracting reusable fetch/filter/pagination logic into hooks:
 
 - Common hooks: `packages/web/src/hooks`
-- VGPU business hooks: `packages/web/projects/vgpu/hooks`
+- vGPU business hooks: `packages/web/projects/vgpu/hooks`
 
 ## What this guide helps with
 


### PR DESCRIPTION
Rest of the docs write vGPU. This one line had it as VGPU.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the developer guide to use consistent capitalization for vGPU terminology.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->