### PR TITLE
docs: fix stale tool name in AGENTS.md check-links comment

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -74,7 +74,7 @@ Extracts translatable strings for i18n.
 npm run lint          # markdownlint on docs/tutorials/blog/i18n
 npm run format:check  # prettier --check . (CI runs this)
 npm run format        # prettier --write .
-npm run check-links   # build + html-link-checker on ./build
+npm run check-links   # build + linkinator on ./build
 npm run check:all     # lint && format:check && build
 npm run build:fast    # build English locale only (skips zh, for quick iteration)
 ```


### PR DESCRIPTION
check-links used to run html-link-checker, now runs linkinator. This comment line still named the old tool.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the script description to reflect the current link-checking tool used by the project.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->