### PR TITLE
fix: close truncated code fences in zh versioned docs

### DIFF
--- a/i18n/zh/docusaurus-plugin-content-docs/version-v2.5.0/contributor/lifted.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/version-v2.5.0/contributor/lifted.md
@@ -5,6 +5,10 @@ translated: true
 
 本文档解释了如何管理提升的代码。此任务的一个常见用户案例是开发人员从其他代码库中提升代码到 `pkg/util/lifted` 目录。
 
+- [提升代码的步骤](#提升代码的步骤)
+- [如何编写提升注释](#如何编写提升注释)
+- [示例](#示例)
+
 ## 提升代码的步骤
 
 - 从另一个代码库中复制代码并将其保存到 `pkg/util/lifted` 下的一个 go 文件中。
@@ -115,3 +119,4 @@ type Visitor func(name string) (shouldContinue bool)
 | 提升文件 | 源文件 | 常量/变量/类型/函数 | 更改 |
 | ----------- | ----------- | ------------------- | ------- |
 | visitpod.go | https://github.com/kubernetes/kubernetes/blob/release-1.23/pkg/api/v1/pod/util.go#L82-L83 | type Visitor | N |
+```

--- a/i18n/zh/docusaurus-plugin-content-docs/version-v2.5.0/developers/build.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/version-v2.5.0/developers/build.md
@@ -93,3 +93,4 @@ The push refers to repository [docker.io/projecthami/hami]
 ```bash
 git clone https://github.com/Project-HAMi/HAMi-core.git
 docker build . -f dockerfiles/Dockerfile.{arch}
+```

--- a/i18n/zh/docusaurus-plugin-content-docs/version-v2.5.0/get-started/nginx-example.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/version-v2.5.0/get-started/nginx-example.md
@@ -175,3 +175,4 @@ Wed Apr 10 09:28:58 2024
 |  No running processes found                                                             |
 +-----------------------------------------------------------------------------------------+
 [HAMI-core Msg(28:140561996502848:multiprocess_memory_limit.c:434)]: Calling exit handler 28
+```

--- a/i18n/zh/docusaurus-plugin-content-docs/version-v2.5.0/installation/prerequisites.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/version-v2.5.0/installation/prerequisites.md
@@ -86,3 +86,4 @@ sudo systemctl daemon-reload && systemctl restart containerd
 
 ```bash
 kubectl label nodes {nodeid} gpu=on
+```

--- a/i18n/zh/docusaurus-plugin-content-docs/version-v2.5.1/contributor/lifted.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/version-v2.5.1/contributor/lifted.md
@@ -5,6 +5,10 @@ translated: true
 
 本文档解释了如何管理提升的代码。此任务的一个常见用户案例是开发人员从其他代码库中提升代码到 `pkg/util/lifted` 目录。
 
+- [提升代码的步骤](#提升代码的步骤)
+- [如何编写提升注释](#如何编写提升注释)
+- [示例](#示例)
+
 ## 提升代码的步骤
 
 - 从另一个代码库中复制代码并将其保存到 `pkg/util/lifted` 下的一个 go 文件中。
@@ -115,3 +119,4 @@ type Visitor func(name string) (shouldContinue bool)
 | 提升文件 | 源文件 | 常量/变量/类型/函数 | 更改 |
 | ----------- | ----------- | ------------------- | ------- |
 | visitpod.go | https://github.com/kubernetes/kubernetes/blob/release-1.23/pkg/api/v1/pod/util.go#L82-L83 | type Visitor | N |
+```

--- a/i18n/zh/docusaurus-plugin-content-docs/version-v2.5.1/developers/build.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/version-v2.5.1/developers/build.md
@@ -93,3 +93,4 @@ The push refers to repository [docker.io/projecthami/hami]
 ```bash
 git clone https://github.com/Project-HAMi/HAMi-core.git
 docker build . -f dockerfiles/Dockerfile.{arch}
+```

--- a/i18n/zh/docusaurus-plugin-content-docs/version-v2.5.1/get-started/nginx-example.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/version-v2.5.1/get-started/nginx-example.md
@@ -175,3 +175,4 @@ Wed Apr 10 09:28:58 2024
 |  No running processes found                                                             |
 +-----------------------------------------------------------------------------------------+
 [HAMI-core Msg(28:140561996502848:multiprocess_memory_limit.c:434)]: Calling exit handler 28
+```

--- a/i18n/zh/docusaurus-plugin-content-docs/version-v2.5.1/installation/prerequisites.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/version-v2.5.1/installation/prerequisites.md
@@ -86,3 +86,4 @@ sudo systemctl daemon-reload && systemctl restart containerd
 
 ```bash
 kubectl label nodes {nodeid} gpu=on
+```

--- a/i18n/zh/docusaurus-plugin-content-docs/version-v2.5.1/userguide/nvidia-device/specify-device-type-to-use.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/version-v2.5.1/userguide/nvidia-device/specify-device-type-to-use.md
@@ -19,3 +19,4 @@ metadata:
 metadata:
   annotations:
     nvidia.com/nouse-gputype: "1080,2080" # 为此作业指定黑名单卡类型，使用逗号分隔，不会在指定的卡上启动作业
+```

--- a/i18n/zh/docusaurus-plugin-content-docs/version-v2.6.0/contributor/lifted.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/version-v2.6.0/contributor/lifted.md
@@ -5,6 +5,10 @@ translated: true
 
 本文档解释了如何管理提升的代码。此任务的一个常见用户案例是开发人员从其他代码库中提升代码到 `pkg/util/lifted` 目录。
 
+- [提升代码的步骤](#提升代码的步骤)
+- [如何编写提升注释](#如何编写提升注释)
+- [示例](#示例)
+
 ## 提升代码的步骤
 
 - 从另一个代码库中复制代码并将其保存到 `pkg/util/lifted` 下的一个 go 文件中。
@@ -115,3 +119,4 @@ type Visitor func(name string) (shouldContinue bool)
 | 提升文件 | 源文件 | 常量/变量/类型/函数 | 更改 |
 | ----------- | ----------- | ------------------- | ------- |
 | visitpod.go | https://github.com/kubernetes/kubernetes/blob/release-1.23/pkg/api/v1/pod/util.go#L82-L83 | type Visitor | N |
+```

--- a/i18n/zh/docusaurus-plugin-content-docs/version-v2.6.0/developers/build.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/version-v2.6.0/developers/build.md
@@ -93,3 +93,4 @@ The push refers to repository [docker.io/projecthami/hami]
 ```bash
 git clone https://github.com/Project-HAMi/HAMi-core.git
 docker build . -f dockerfiles/Dockerfile.{arch}
+```

--- a/i18n/zh/docusaurus-plugin-content-docs/version-v2.6.0/get-started/nginx-example.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/version-v2.6.0/get-started/nginx-example.md
@@ -175,3 +175,4 @@ Wed Apr 10 09:28:58 2024
 |  No running processes found                                                             |
 +-----------------------------------------------------------------------------------------+
 [HAMI-core Msg(28:140561996502848:multiprocess_memory_limit.c:434)]: Calling exit handler 28
+```

--- a/i18n/zh/docusaurus-plugin-content-docs/version-v2.6.0/userguide/nvidia-device/specify-device-type-to-use.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/version-v2.6.0/userguide/nvidia-device/specify-device-type-to-use.md
@@ -19,3 +19,4 @@ metadata:
 metadata:
   annotations:
     nvidia.com/nouse-gputype: "1080,2080" # 为此作业指定黑名单卡类型，使用逗号分隔，不会在指定的卡上启动作业
+```

--- a/i18n/zh/docusaurus-plugin-content-docs/version-v2.7.0/contributor/lifted.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/version-v2.7.0/contributor/lifted.md
@@ -5,6 +5,10 @@ translated: true
 
 本文档解释了如何管理提升的代码。此任务的一个常见用户案例是开发人员从其他代码库中提升代码到 `pkg/util/lifted` 目录。
 
+- [提升代码的步骤](#提升代码的步骤)
+- [如何编写提升注释](#如何编写提升注释)
+- [示例](#示例)
+
 ## 提升代码的步骤
 
 - 从另一个代码库中复制代码并将其保存到 `pkg/util/lifted` 下的一个 go 文件中。
@@ -115,3 +119,4 @@ type Visitor func(name string) (shouldContinue bool)
 | 提升文件 | 源文件 | 常量/变量/类型/函数 | 更改 |
 | ----------- | ----------- | ------------------- | ------- |
 | visitpod.go | https://github.com/kubernetes/kubernetes/blob/release-1.23/pkg/api/v1/pod/util.go#L82-L83 | type Visitor | N |
+```

--- a/i18n/zh/docusaurus-plugin-content-docs/version-v2.7.0/developers/build.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/version-v2.7.0/developers/build.md
@@ -93,3 +93,4 @@ The push refers to repository [docker.io/projecthami/hami]
 ```bash
 git clone https://github.com/Project-HAMi/HAMi-core.git
 docker build . -f dockerfiles/Dockerfile.{arch}
+```

--- a/i18n/zh/docusaurus-plugin-content-docs/version-v2.7.0/installation/prerequisites.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/version-v2.7.0/installation/prerequisites.md
@@ -64,3 +64,4 @@ sudo systemctl daemon-reload && systemctl restart containerd
 
 ```bash
 kubectl label nodes {nodeid} gpu=on
+```

--- a/i18n/zh/docusaurus-plugin-content-docs/version-v2.7.0/userguide/nvidia-device/specify-device-type-to-use.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/version-v2.7.0/userguide/nvidia-device/specify-device-type-to-use.md
@@ -19,3 +19,4 @@ metadata:
 metadata:
   annotations:
     nvidia.com/nouse-gputype: "1080,2080" # 为此作业指定黑名单卡类型，使用逗号分隔，不会在指定的卡上启动作业
+```

--- a/i18n/zh/docusaurus-plugin-content-docs/version-v2.8.0/contributor/lifted.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/version-v2.8.0/contributor/lifted.md
@@ -115,3 +115,4 @@ type Visitor func(name string) (shouldContinue bool)
 | 提升文件 | 源文件 | 常量/变量/类型/函数 | 更改 |
 | ----------- | ----------- | ------------------- | ------- |
 | visitpod.go | https://github.com/kubernetes/kubernetes/blob/release-1.23/pkg/api/v1/pod/util.go#L82-L83 | type Visitor | N |
+```

--- a/i18n/zh/docusaurus-plugin-content-docs/version-v2.8.0/developers/build.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/version-v2.8.0/developers/build.md
@@ -93,3 +93,4 @@ The push refers to repository [docker.io/projecthami/hami]
 ```bash
 git clone https://github.com/Project-HAMi/HAMi-core.git
 docker build . -f dockerfiles/Dockerfile.{arch}
+```

--- a/i18n/zh/docusaurus-plugin-content-docs/version-v2.8.0/installation/prerequisites.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/version-v2.8.0/installation/prerequisites.md
@@ -66,3 +66,4 @@ sudo systemctl daemon-reload && systemctl restart containerd
 
 ```bash
 kubectl label nodes {nodeid} gpu=on
+```

--- a/i18n/zh/docusaurus-plugin-content-docs/version-v2.8.0/userguide/nvidia-device/specify-device-type-to-use.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/version-v2.8.0/userguide/nvidia-device/specify-device-type-to-use.md
@@ -20,3 +20,4 @@ metadata:
 metadata:
   annotations:
     nvidia.com/nouse-gputype: "1080,2080" # 为此作业指定黑名单卡类型，使用逗号分隔，不会在指定的卡上启动作业
+```


### PR DESCRIPTION
Several zh versioned doc snapshots (v2.5.0 through v2.8.0) end mid file with an unclosed code fence, likely because the truncation carried forward every time a new version was cut from the prior one. Verified each file against its english source, content otherwise matches, just missing the closing fence. lifted.md also had a 3 line table of contents missing near the top in versions where the english source has it.

Files: contributor/lifted.md, developers/build.md, get-started/nginx-example.md, installation/prerequisites.md, userguide/nvidia-device/specify-device-type-to-use.md across v2.5.0 to v2.8.0 where applicable.

Note: userguide/nvidia-device/dynamic-mig-support.md v2.5.1 was checked and is not actually broken, false positive from the original scan (closing fence was just indented).

Note: developers/protocol.md v2.7.0 and v2.8.0 also looked truncated but turned out to be a much deeper issue, not fixed here, reporting separately.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated several Chinese documentation pages across versions 2.5.0–2.8.0 with improved navigation links, clearer section separation, and corrected example formatting.
  * Fixed multiple code block endings and spacing issues so command examples and sample outputs render properly.
  * Added small clarifications or extra lines in build, installation, and NVIDIA device selection guides for better readability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->