### PR TITLE
fix: remove em dash from enflame gcu sharing doc

### DIFF
--- a/docs/userguide/enflame-device/enable-enflame-gcu-sharing.md
+++ b/docs/userguide/enflame-device/enable-enflame-gcu-sharing.md
@@ -10,7 +10,7 @@ DRS is a hard-slice mode similar to NVIDIA MIG and Ascend VNPU templates.
 
 ## Prerequisites
 
-- Enflame gcushare-device-plugin >= 2.2.14 (please consult your device provider; only `gcushare-device-plugin` is needed — do not install `gcushare-scheduler-plugin`)
+- Enflame gcushare-device-plugin >= 2.2.14 (please consult your device provider; only `gcushare-device-plugin` is needed, do not install `gcushare-scheduler-plugin`)
 - driver version >= 1.8.7
 - kubernetes >= 1.24
 - enflame-container-toolkit >= 2.0.50


### PR DESCRIPTION
One line used an em dash in prose, against this repo's own style rule of using regular hyphens.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified the setup prerequisites for Enflame GCU sharing.
  * Updated wording around the `gcushare-device-plugin` requirement and the related installation note for better readability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->