### PR TITLE
docs: fix deploy instructions to match actual netlify hosting

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -81,13 +81,9 @@ npm run build:fast    # build English locale only (skips zh, for quick iteration
 
 CI (`.github/workflows/docs-health.yml`) runs `lint`, `format:check`, and `build` on every PR.
 
-### Deploy to GitHub Pages
+### Deployment
 
-```bash
-GIT_USER=<Your GitHub username> USE_SSH=true npm run deploy
-```
-
-Builds and deploys the website to the `gh-pages` branch for GitHub Pages hosting.
+The site deploys automatically to Netlify on every merge to `master` (see `netlify.toml`). No manual deploy step is needed.
 
 ## Commit Convention
 

--- a/README.md
+++ b/README.md
@@ -107,11 +107,7 @@ See [BUILD_OPTIMIZATION.md](./BUILD_OPTIMIZATION.md) for details on optimization
 
 ## Deployment
 
-For GitHub Pages (requires appropriate permissions):
-
-```bash
-GIT_USER=<your_github_username> USE_SSH=true npm run deploy
-```
+The site deploys automatically to Netlify on every merge to `master` (see `netlify.toml`). No manual deploy step is needed.
 
 For other hosting services, deploy the `build/` directory as a static site.
 
@@ -170,7 +166,7 @@ To contribute translations, update the corresponding files in `i18n/zh/`.
 - **Compiler**: SWC
 - **Runtime**: Node.js v20+
 - **Package Manager**: npm
-- **Hosting**: GitHub Pages / Netlify
+- **Hosting**: Netlify
 
 ## Maintainers
 


### PR DESCRIPTION
README.md and AGENTS.md both documented npm run deploy for GitHub Pages as the deployment step, and README listed GitHub Pages as a hosting option. No workflow runs gh-pages and the site only deploys through Netlify. Fixed both files to describe the real deploy path.
