### PR TITLE
docs: fix zh mindmap title and clarify scope

### DIFF
--- a/docs/developers/mindmap.md
+++ b/docs/developers/mindmap.md
@@ -4,4 +4,6 @@ title: HAMi mind map
 
 ## Mind map
 
+This mind map covers HAMi's NVIDIA vGPU scheduling internals in detail. It does not yet cover other accelerator backends (Cambricon MLU, Hygon DCU, Kunlunxin XPU, MetaX GPU, Ascend NPU, Iluvatar Corex).
+
 ![HAMi VGPU mind map showing project structure and components](/img/docs/en/mindmap/hami-vgpu-mind-map-en.png)

--- a/i18n/zh/docusaurus-plugin-content-docs/current/developers/mindmap.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/current/developers/mindmap.md
@@ -1,8 +1,10 @@
 ---
-title: HAMi 路线图
+title: HAMi 思维导图
 translated: true
 ---
 
 ## 思维导图
+
+本思维导图详细展示了 HAMi 的 NVIDIA vGPU 调度内部机制，尚未涵盖其他加速器后端（寒武纪 MLU、海光 DCU、昆仑芯 XPU、沐曦 GPU、昇腾 NPU、天数智芯 Corex）。
 
 ![HAMi VGPU 思维导图，显示项目结构和组件](/img/docs/zh/mindmap/hami-vgpu-mind-map-zh.png)

--- a/i18n/zh/docusaurus-plugin-content-docs/version-v2.5.0/developers/mindmap.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/version-v2.5.0/developers/mindmap.md
@@ -1,5 +1,5 @@
 ---
-title: HAMi 路线图
+title: HAMi 思维导图
 translated: true
 ---
 

--- a/i18n/zh/docusaurus-plugin-content-docs/version-v2.5.1/developers/mindmap.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/version-v2.5.1/developers/mindmap.md
@@ -1,5 +1,5 @@
 ---
-title: HAMi 路线图
+title: HAMi 思维导图
 translated: true
 ---
 

--- a/i18n/zh/docusaurus-plugin-content-docs/version-v2.6.0/developers/mindmap.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/version-v2.6.0/developers/mindmap.md
@@ -1,5 +1,5 @@
 ---
-title: HAMi 路线图
+title: HAMi 思维导图
 translated: true
 ---
 

--- a/i18n/zh/docusaurus-plugin-content-docs/version-v2.7.0/developers/mindmap.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/version-v2.7.0/developers/mindmap.md
@@ -1,5 +1,5 @@
 ---
-title: HAMi 路线图
+title: HAMi 思维导图
 translated: true
 ---
 

--- a/i18n/zh/docusaurus-plugin-content-docs/version-v2.8.0/developers/mindmap.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/version-v2.8.0/developers/mindmap.md
@@ -1,5 +1,5 @@
 ---
-title: HAMi 路线图
+title: HAMi 思维导图
 translated: true
 ---
 

--- a/i18n/zh/docusaurus-plugin-content-docs/version-v2.9.0/developers/mindmap.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/version-v2.9.0/developers/mindmap.md
@@ -1,5 +1,5 @@
 ---
-title: HAMi 路线图
+title: HAMi 思维导图
 translated: true
 ---
 


### PR DESCRIPTION
Closes #414

## Audit summary

Located every mindmap in the repo: only one exists, developers/mindmap.md, in English and Chinese, present in docs/, i18n/zh/current/, and all versioned snapshots (v1.3.0 through v2.9.0).

Actions taken:
- Fixed a real bug: the zh title said "HAMi 路线图" (HAMi Roadmap) starting from v2.5.0 through v2.9.0 and current. This is wrong, the page is a mind map, not a roadmap (this repo already has a separate roadmap page). v1.3.0 still had the correct English placeholder title, so the wrong translation got introduced once and was copied forward unfixed into every later version. Fixed all 6 affected files.
- Added a one line scope note to the current en and zh pages: the mind map covers NVIDIA vGPU scheduling internals only, not the other device backends HAMi now supports (MLU, DCU, XPU, MetaX, Ascend, Corex). This was flagged in diagrams-inventory.md as a known limitation but the page itself never said so.
- Did not touch older versioned title text (v1.3.0), it already reads correctly as a placeholder from before translation existed.

Flagged, not fixed here: the mind map's actual content (both images) is still technically accurate for what it covers, but expanding it to cover every device backend equally is a real redesign needing architecture knowledge I do not have. Opening a separate issue for that per the note in #414 ("if a mindmap requires significant redesign, open a separate issue rather than blocking this one").
