### PR TITLE
fix: remove em dash and stale version claim in zh troubleshooting

### DIFF
--- a/i18n/zh/docusaurus-plugin-content-docs/current/troubleshooting/troubleshooting.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/current/troubleshooting/troubleshooting.md
@@ -7,10 +7,10 @@ translated: true
 
 如果容器超过了 `nvidia.com/gpumem` 限制，请检查以下原因：
 
-- **设置了 `CUDA_DISABLE_CONTROL=true`** — 完全禁用 HAMi-core 的限制功能。请从生产工作负载中移除该设置。
-- **Docker-in-Docker (DinD)** — 内层容器不会继承 `/etc/ld.so.preload` hostPath 挂载。HAMi 的限制在 DinD 内部不生效。
-- **直接调用驱动 API** — 直接调用 NVML 或 CUDA Driver API 的工作负载会绕过 `libvgpu.so`。
-- **`nvidia-container-runtime` 未设为默认运行时** — 使用以下命令验证：
+- **设置了 `CUDA_DISABLE_CONTROL=true`**：完全禁用 HAMi-core 的限制功能。请从生产工作负载中移除该设置。
+- **Docker-in-Docker (DinD)**：内层容器不会继承 `/etc/ld.so.preload` hostPath 挂载。HAMi 的限制在 DinD 内部不生效。
+- **直接调用驱动 API**：直接调用 NVML 或 CUDA Driver API 的工作负载会绕过 `libvgpu.so`。
+- **`nvidia-container-runtime` 未设为默认运行时**：使用以下命令验证：
 
   ```bash
   containerd config dump | grep default_runtime_name
@@ -22,6 +22,6 @@ translated: true
 - 目前，A100 MIG 仅支持 "none" 和 "mixed" 模式。
 - 目前无法调度带有 "nodeName" 字段的任务；请改用 "nodeSelector"。
 - 目前仅支持计算任务；不支持视频编解码处理。
-- 我们将 `device-plugin` 环境变量名称从 `NodeName` 更改为 `NODE_NAME`，如果你使用镜像版本 `v2.3.9`，可能会遇到 `device-plugin` 无法启动的情况，有两种方法可以解决：
+- 从 v2.3.10 起，HAMi 将 `device-plugin` 环境变量名称从 `NodeName` 更改为 `NODE_NAME`。如果你使用早于 v2.3.10 的镜像版本，`device-plugin` 可能无法启动，有两种方法可以解决：
   - 手动执行 `kubectl edit daemonset` 修改 `device-plugin` 环境变量从 `NodeName` 为 `NODE_NAME`。
-  - 使用 helm 升级到最新版本，`device-plugin` 镜像的最新版本是 `v2.3.10`，执行 `helm upgrade hami hami/hami -n kube-system`，它将自动修复。
+  - 使用 Helm 升级到最新版本：执行 `helm upgrade hami hami/hami -n kube-system`，它将自动修复。


### PR DESCRIPTION
Two issues in the zh troubleshooting page:

- Em dash used in four bullet points, against this repo's style rule.
- Said v2.3.10 is the latest device-plugin version. Current HAMi is v2.9.0, that claim is years stale. Reworded to match the english source, which states the change happened since v2.3.10 without claiming it is the latest.

## Test plan
- npm run lint:md passes
- prettier check passes
- npm run build succeeds for both locales

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified the troubleshooting guide for GPU memory limits not taking effect, improving the presentation of possible causes while keeping the original guidance.
  * Updated the version boundary for the `device-plugin` environment variable change and added clearer recovery steps for manual and Helm-based fixes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->