### PR TITLE
docs: add missing subsection headings to zh architecture page

### DIFF
--- a/i18n/zh/docusaurus-plugin-content-docs/current/core-concepts/architecture.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/current/core-concepts/architecture.md
@@ -14,10 +14,18 @@ HAMi 由以下组件组成：
 - 设备插件 (HAMi-device-plugin)
 - 容器内资源控制 (HAMi-Core)
 
+## HAMi MutatingWebhook {#hami-mutatingwebhook}
+
 HAMi MutatingWebhook 检查该任务是否可以由 HAMi 处理，它扫描每个提交的 Pod 的资源字段，如果这些 Pod 所需的每个资源是 'cpu'、'memory' 或 HAMi 资源，则会将该 Pod 的 schedulerName 字段设置为 'HAMi-scheduler'。
+
+## HAMi 调度器 {#hami-scheduler}
 
 HAMi 调度器负责将任务分配给适当的节点和设备。同时，调度器需要维护异构计算设备的全局视图以进行监控。
 
+## 设备插件 {#device-plugin}
+
 设备插件层从任务的注释字段获取调度结果，并将相应的设备映射到容器。
+
+## HAMi-Core {#hami-core}
 
 容器内资源控制负责监控容器内的资源使用情况，并提供硬隔离能力。


### PR DESCRIPTION
English architecture.md has 4 subsection headings with anchors (HAMi MutatingWebhook, HAMi Scheduler, Device Plugin, HAMi-Core). The zh page ran the same prose as plain paragraphs with no headings at all, so the page had no in-page navigation for these sections. Added the headings with matching anchor ids.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Reorganized the architecture guide into clearer subsections for the main HAMi components.
  * Added anchor links for easier navigation within the page.
  * Improved the component hierarchy so each section is labeled consistently.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->