### PR TITLE
chore: bump github actions to latest majors in ci

### DIFF
--- a/.github/workflows/docs-health.yml
+++ b/.github/workflows/docs-health.yml
@@ -15,10 +15,10 @@ jobs:
     name: Lint, Format, Build & Links
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: 20
           cache: npm


### PR DESCRIPTION
checkout was pinned to v4, setup-node to v4, both several majors behind. Bumped to the latest major (checkout v7, setup-node v6). Checked setup-node v6 docs, explicit cache: npm input still works the same, only auto-detection changed for workflows that omit the cache input.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the documentation health workflow to use newer versions of core GitHub Actions.
  * No user-facing behavior changed; build, lint, format, and link-check steps remain the same.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->