### PR TITLE
Fix indentations and consistency in benchmark.md

### DIFF
--- a/docs/userguide/benchmark.md
+++ b/docs/userguide/benchmark.md
@@ -17,11 +17,11 @@ Three instances from the vLLM benchmark were used to evaluate vGPU-device-plugin
 
 ## Test Instances
 
-| Instance        |                      Description                      |
-| --------------- | :---------------------------------------------------: |
-| Native          |            k8s + nvidia k8s-device-plugin             |
-| Opensource_v280 | k8s + vGPU k8s-device-plugin, opensource version v280 |
-| Opensource_v290 | k8s + vGPU k8s-device-plugin, opensource version v290 |
+| Instance        |                         Description                          |
+| --------------- | :----------------------------------------------------------: |
+| Native          |            Kubernetes + NVIDIA k8s-device-plugin             |
+| Opensource_v280 | Kubernetes + vGPU k8s-device-plugin, opensource version v280 |
+| Opensource_v290 | Kubernetes + vGPU k8s-device-plugin, opensource version v290 |
 
 ## Test Cases
 
@@ -44,23 +44,23 @@ Three instances from the vLLM benchmark were used to evaluate vGPU-device-plugin
 
 1. Build the benchmark images:
 
-```bash
-cd benchmarks/ai-benchmark
-sh build.sh
-```
+   ```bash
+   cd benchmarks/ai-benchmark
+   sh build.sh
+   ```
 
 1. Run the benchmark job:
 
-```bash
-kubectl apply -f benchmarks/deployments/job-on-nvidia-device-plugin.yml
-kubectl apply -f benchmarks/deployments/job-on-hami.yml
-```
+   ```bash
+   kubectl apply -f benchmarks/deployments/job-on-nvidia-device-plugin.yml
+   kubectl apply -f benchmarks/deployments/job-on-hami.yml
+   ```
 
 1. View the results:
 
-```bash
-kubectl cp <pod-name>:/results ./results
-python3 benchmarks/ai-benchmark/gen_report.py \
-    --dataset native ./results/bench_native.jsonl \
-    --dataset hami ./results/bench_hami.jsonl
-```
+   ```bash
+   kubectl cp <pod-name>:/results ./results
+   python3 benchmarks/ai-benchmark/gen_report.py \
+       --dataset native ./results/bench_native.jsonl \
+       --dataset hami ./results/bench_hami.jsonl
+   ```

--- a/i18n/zh/docusaurus-plugin-content-docs/current/userguide/benchmark.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/current/userguide/benchmark.md
@@ -17,11 +17,11 @@ sidebar_label: 性能测试
 
 ## 测试实例
 
-| 测试名称        |                  测试用例                   |
-| --------------- | :-----------------------------------------: |
-| Native          |     k8s + nvidia 官方 k8s-device-plugin     |
-| Opensource_v280 | k8s + vGPU k8s-device-plugin，开源版本 v280 |
-| Opensource_v290 | k8s + vGPU k8s-device-plugin，开源版本 v290 |
+| 测试名称        |                      测试用例                      |
+| --------------- | :------------------------------------------------: |
+| Native          |     Kubernetes + NVIDIA 官方 k8s-device-plugin     |
+| Opensource_v280 | Kubernetes + vGPU k8s-device-plugin，开源版本 v280 |
+| Opensource_v290 | Kubernetes + vGPU k8s-device-plugin，开源版本 v290 |
 
 ## 测试内容
 
@@ -42,25 +42,25 @@ sidebar_label: 性能测试
 
 1. 安装 k8s-vGPU-scheduler，并配置相应的参数。
 
-2. 构建 benchmark 镜像：
+1. 构建 benchmark 镜像：
 
-```bash
-cd benchmarks/ai-benchmark
-sh build.sh
-```
+   ```bash
+   cd benchmarks/ai-benchmark
+   sh build.sh
+   ```
 
 1. 运行 benchmark 任务：
 
-```bash
-kubectl apply -f benchmarks/deployments/job-on-nvidia-device-plugin.yml
-kubectl apply -f benchmarks/deployments/job-on-hami.yml
-```
+   ```bash
+   kubectl apply -f benchmarks/deployments/job-on-nvidia-device-plugin.yml
+   kubectl apply -f benchmarks/deployments/job-on-hami.yml
+   ```
 
 1. 查看结果：
 
-```bash
-kubectl cp <pod-name>:/results ./results
-python3 benchmarks/ai-benchmark/gen_report.py \
-    --dataset native ./results/bench_native.jsonl \
-    --dataset hami ./results/bench_hami.jsonl
-```
+   ```bash
+   kubectl cp <pod-name>:/results ./results
+   python3 benchmarks/ai-benchmark/gen_report.py \
+       --dataset native ./results/bench_native.jsonl \
+       --dataset hami ./results/bench_hami.jsonl
+   ```

--- a/i18n/zh/docusaurus-plugin-content-docs/version-v2.9.0/userguide/benchmark.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/version-v2.9.0/userguide/benchmark.md
@@ -19,9 +19,9 @@ sidebar_label: 性能测试
 
 | 测试名称        |                  测试用例                   |
 | --------------- | :-----------------------------------------: |
-| Native          |     k8s + nvidia 官方 k8s-device-plugin     |
-| Opensource_v280 | k8s + VGPU k8s-device-plugin，开源版本 v280 |
-| Opensource_v290 | k8s + VGPU k8s-device-plugin，开源版本 v290 |
+| Native          |     Kubernetes + NVIDIA 官方 k8s-device-plugin     |
+| Opensource_v280 | Kubernetes + VGPU k8s-device-plugin，开源版本 v280 |
+| Opensource_v290 | Kubernetes + VGPU k8s-device-plugin，开源版本 v290 |
 
 ## 测试内容
 
@@ -42,25 +42,25 @@ sidebar_label: 性能测试
 
 1. 安装 k8s-vGPU-scheduler，并配置相应的参数。
 
-2. 构建 benchmark 镜像：
+1. 构建 benchmark 镜像：
 
-```bash
-cd benchmarks/ai-benchmark
-sh build.sh
-```
+   ```bash
+   cd benchmarks/ai-benchmark
+   sh build.sh
+   ```
 
 1. 运行 benchmark 任务：
 
-```bash
-kubectl apply -f benchmarks/deployments/job-on-nvidia-device-plugin.yml
-kubectl apply -f benchmarks/deployments/job-on-hami.yml
-```
+   ```bash
+   kubectl apply -f benchmarks/deployments/job-on-nvidia-device-plugin.yml
+   kubectl apply -f benchmarks/deployments/job-on-hami.yml
+   ```
 
 1. 查看结果：
 
-```bash
-kubectl cp <pod-name>:/results ./results
-python3 benchmarks/ai-benchmark/gen_report.py \
-    --dataset native ./results/bench_native.jsonl \
-    --dataset hami ./results/bench_hami.jsonl
-```
+   ```bash
+   kubectl cp <pod-name>:/results ./results
+   python3 benchmarks/ai-benchmark/gen_report.py \
+       --dataset native ./results/bench_native.jsonl \
+       --dataset hami ./results/bench_hami.jsonl
+   ```


### PR DESCRIPTION
- Fix a `1-2-3` list
- Fix several typos for consistency

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated benchmark user guides to use clearer “Test Instances” wording (“Kubernetes + …”).
  * Made open-source instance entries more explicit by labeling them as `opensource version v280` and `opensource version v290`.
  * Reformatted benchmark reproduction instructions into fenced, copy-friendly `bash` code blocks and adjusted the step numbering/structure for consistency across language versions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->