### PR TITLE
docs: remove manual kubeScheduler image tag specification

### DIFF
--- a/docs/get-started/deploy-with-helm.md
+++ b/docs/get-started/deploy-with-helm.md
@@ -109,14 +109,7 @@ Add the Helm repository:
 ```bash
 helm repo add hami-charts https://project-hami.github.io/HAMi/
 helm repo update
-```
-
-During installation, set the Kubernetes scheduler image to match your cluster version. For example, if your cluster version is 1.29.0:
-
-```bash
-helm install hami hami-charts/hami \
-  --set scheduler.kubeScheduler.imageTag=v1.29.0 \
-  -n kube-system
+helm install hami hami-charts/hami -n kube-system
 ```
 
 If successful, both `hami-device-plugin` and `hami-scheduler` pods should be in the `Running` state.

--- a/i18n/zh/docusaurus-plugin-content-docs/version-v2.7.0/get-started/deploy-with-helm.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/version-v2.7.0/get-started/deploy-with-helm.md
@@ -112,14 +112,8 @@ kubectl version
 
 ```bash
 helm repo add hami-charts https://project-hami.github.io/HAMi/
-```
-
-安装时需设置 Kubernetes 调度器镜像版本与集群版本匹配。例如集群版本为 1.16.8 时，使用以下命令部署：
-
-```bash
-helm install hami hami-charts/hami \
-  --set scheduler.kubeScheduler.imageTag=v1.16.8 \
-  -n kube-system
+helm repo update
+helm install hami hami-charts/hami -n kube-system
 ```
 
 若一切正常，可见 vgpu-device-plugin 和 vgpu-scheduler 的 Pod 均处于 Running 状态。

--- a/i18n/zh/docusaurus-plugin-content-docs/version-v2.8.0/get-started/deploy-with-helm.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/version-v2.8.0/get-started/deploy-with-helm.md
@@ -112,14 +112,8 @@ kubectl version
 
 ```bash
 helm repo add hami-charts https://project-hami.github.io/HAMi/
-```
-
-安装时需设置 Kubernetes 调度器镜像版本与集群版本匹配。例如集群版本为 1.16.8 时，使用以下命令部署：
-
-```bash
-helm install hami hami-charts/hami \
-  --set scheduler.kubeScheduler.imageTag=v1.16.8 \
-  -n kube-system
+helm repo update
+helm install hami hami-charts/hami -n kube-system
 ```
 
 若一切正常，可见 vgpu-device-plugin 和 vgpu-scheduler 的 Pod 均处于 Running 状态。

--- a/i18n/zh/docusaurus-plugin-content-docs/version-v2.9.0/get-started/deploy-with-helm.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/version-v2.9.0/get-started/deploy-with-helm.md
@@ -108,14 +108,8 @@ kubectl version
 
 ```bash
 helm repo add hami-charts https://project-hami.github.io/HAMi/
-```
-
-安装时需设置 Kubernetes 调度器镜像版本与集群版本匹配。例如集群版本为 1.16.8 时，使用以下命令部署：
-
-```bash
-helm install hami hami-charts/hami \
-  --set scheduler.kubeScheduler.imageTag=v1.16.8 \
-  -n kube-system
+helm repo update
+helm install hami hami-charts/hami -n kube-system
 ```
 
 若一切正常，可见 vgpu-device-plugin 和 vgpu-scheduler 的 Pod 均处于 Running 状态。

--- a/versioned_docs/version-v2.7.0/get-started/deploy-with-helm.md
+++ b/versioned_docs/version-v2.7.0/get-started/deploy-with-helm.md
@@ -118,18 +118,8 @@ Then, add the HAMi repo in helm
 ```bash
 helm repo add hami-charts https://project-hami.github.io/HAMi/
 helm repo update
+helm install hami hami-charts/hami -n kube-system
 ```
-
-During installation, set the Kubernetes scheduler image version to match your
-Kubernetes server version. For instance, if your cluster server version is
-1.16.8, use the following command for deployment:
-
-```bash
-helm install hami hami-charts/hami \
-  --set scheduler.kubeScheduler.imageTag=v1.16.8 \
-  -n kube-system
-```
-
 If everything goes well, you will see both vgpu-device-plugin and vgpu-scheduler pods are in the Running state
 
 ### Demo {#demo}

--- a/versioned_docs/version-v2.8.0/get-started/deploy-with-helm.md
+++ b/versioned_docs/version-v2.8.0/get-started/deploy-with-helm.md
@@ -109,14 +109,7 @@ Add the Helm repository:
 ```bash
 helm repo add hami-charts https://project-hami.github.io/HAMi/
 helm repo update
-```
-
-During installation, set the Kubernetes scheduler image to match your cluster version. For example, if your cluster version is 1.29.0:
-
-```bash
-helm install hami hami-charts/hami \
-  --set scheduler.kubeScheduler.imageTag=v1.29.0 \
-  -n kube-system
+helm install hami hami-charts/hami -n kube-system
 ```
 
 If successful, both `hami-device-plugin` and `hami-scheduler` pods should be in the `Running` state.

--- a/versioned_docs/version-v2.9.0/get-started/deploy-with-helm.md
+++ b/versioned_docs/version-v2.9.0/get-started/deploy-with-helm.md
@@ -109,14 +109,7 @@ Add the Helm repository:
 ```bash
 helm repo add hami-charts https://project-hami.github.io/HAMi/
 helm repo update
-```
-
-During installation, set the Kubernetes scheduler image to match your cluster version. For example, if your cluster version is 1.29.0:
-
-```bash
-helm install hami hami-charts/hami \
-  --set scheduler.kubeScheduler.imageTag=v1.29.0 \
-  -n kube-system
+helm install hami hami-charts/hami -n kube-system
 ```
 
 If successful, both `hami-device-plugin` and `hami-scheduler` pods should be in the `Running` state.


### PR DESCRIPTION
The Kubernetes version is automatically detected by Helm during installation and does not need to be manually specified. 

fix https://github.com/Project-HAMi/HAMi/issues/1991

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the Helm install guide to include a complete baseline install command after refreshing the Helm repository.
  * Clarified the setup flow so users can run a plain install first, then follow the version-specific example when needed.
  * Applied the same documentation update across all supported language and versioned guides.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->