### PR TITLE
fix: capitalize MIG in remaining zh aws install pages

### DIFF
--- a/i18n/zh/docusaurus-plugin-content-docs/version-v2.8.0/installation/aws-installation.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/version-v2.8.0/installation/aws-installation.md
@@ -53,4 +53,4 @@ kubectl get pods -n kube-system
 - [使用独占 GPU](/zh/docs/userguide/nvidia-device/examples/use-exclusive-card)
 - [为容器分配特定设备显存](/zh/docs/userguide/nvidia-device/examples/allocate-device-memory)
 - [为容器分配设备核心资源](/zh/docs/userguide/nvidia-device/examples/allocate-device-core)
-- [将任务分配给 mig 实例](/zh/docs/userguide/nvidia-device/examples/dynamic-mig-example)
+- [将任务分配给 MIG 实例](/zh/docs/userguide/nvidia-device/examples/dynamic-mig-example)

--- a/i18n/zh/docusaurus-plugin-content-docs/version-v2.9.0/installation/aws-installation.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/version-v2.9.0/installation/aws-installation.md
@@ -52,4 +52,4 @@ kubectl get pods -n kube-system
 - [使用独占 GPU](/zh/docs/userguide/nvidia-device/examples/use-exclusive-card)
 - [为容器分配特定设备显存](/zh/docs/userguide/nvidia-device/examples/allocate-device-memory)
 - [为容器分配设备核心资源](/zh/docs/userguide/nvidia-device/examples/allocate-device-core)
-- [将任务分配给 mig 实例](/zh/docs/userguide/nvidia-device/examples/dynamic-mig-example)
+- [将任务分配给 MIG 实例](/zh/docs/userguide/nvidia-device/examples/dynamic-mig-example)


### PR DESCRIPTION
PR #562 fixed MIG casing in current and v2.7.0 but missed v2.8.0 and v2.9.0. v2.9.0 is the live default version. Same one-line fix applied to both.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the NVIDIA device example text in the Chinese installation docs to use “MIG” with the correct capitalization.
  * Kept the existing documentation links unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->