### PR TITLE
fix: make check-links.sh work on bash 3.2

### DIFF
--- a/scripts/check-links.sh
+++ b/scripts/check-links.sh
@@ -173,7 +173,10 @@ curl -fsS "${root_url}/" >/dev/null 2>&1 || {
   exit 1
 }
 
-mapfile -t skip_args < "${tmpdir}/skip-args.txt"
+skip_args=()
+while IFS= read -r line; do
+  skip_args+=("${line}")
+done < "${tmpdir}/skip-args.txt"
 
 set +e
 # The human-readable formatter can fail without surfacing the offender URL under Node 20.


### PR DESCRIPTION
mapfile needs bash 4+. macOS ships bash 3.2 by default, so npm run check-links fails there with mapfile: command not found. Replaced with a plain read loop.
