### PR TITLE
fix: close unclosed code fence in zh protocol.md

### DIFF
--- a/i18n/zh/docusaurus-plugin-content-docs/version-v2.7.0/developers/protocol.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/version-v2.7.0/developers/protocol.md
@@ -36,3 +36,4 @@ kube-scheduler 在 `bind` 过程中调用 device-plugin 挂载设备，但仅向
 hami.io/bind-time: 1716199325
 hami.io/vgpu-devices-allocated: GPU-0fc3eda5-e98b-a25b-5b0d-cf5c855d1448,NVIDIA,3000,0:;
 hami.io/vgpu-devices-to-allocate: ;
+```

--- a/i18n/zh/docusaurus-plugin-content-docs/version-v2.8.0/developers/protocol.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/version-v2.8.0/developers/protocol.md
@@ -34,3 +34,4 @@ kube-scheduler 在 `bind` 过程中调用 device-plugin 挂载设备，但仅向
 hami.io/bind-time: 1716199325
 hami.io/vgpu-devices-allocated: GPU-0fc3eda5-e98b-a25b-5b0d-cf5c855d1448,NVIDIA,3000,0:;
 hami.io/vgpu-devices-to-allocate: ;
+```


### PR DESCRIPTION
v2.7.0 and v2.8.0 zh protocol.md end mid code block, no closing fence. Same bug fixed in other files before, these two got missed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Updated Chinese developer protocol examples for versions 2.7.0 and 2.8.0.
  - Completed YAML example formatting and clarified code block boundaries for GPU task scheduling annotations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->