### PR TITLE
docs: fix stale check-links comment in AGENTS.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -74,8 +74,8 @@ Extracts translatable strings for i18n.
 npm run lint          # markdownlint on docs/tutorials/blog/i18n
 npm run format:check  # prettier --check . (CI runs this)
 npm run format        # prettier --write .
-npm run check-links   # build + linkinator on ./build
-npm run check:all     # lint && format:check && build
+npm run check-links   # build then check links on a local server
+npm run check:all     # lint && format:check && check-links
 npm run build:fast    # build English locale only (skips zh, for quick iteration)
 ```
 


### PR DESCRIPTION
check-links no longer scans ./build with linkinator directly, it builds then checks links on a local server. check:all also runs check-links now, not just build. Comments did not match.