### PR TITLE
fix: add missing k3s tag to zh tutorials tags.yml

### DIFF
--- a/i18n/zh/docusaurus-plugin-content-docs-tutorials/current/tags.yml
+++ b/i18n/zh/docusaurus-plugin-content-docs-tutorials/current/tags.yml
@@ -13,6 +13,9 @@
 "inference":
   label: "inference"
   permalink: "/inference"
+"k3s":
+  label: "k3s"
+  permalink: "/k-3-s"
 "nvidia":
   label: "nvidia"
   permalink: "/nvidia"


### PR DESCRIPTION
Lab 7 uses the k3s tag but it was not listed in the zh tags.yml, causing a build warning.