### PR TITLE
fix: add missing useBaseUrl import in featuresList

### DIFF
--- a/src/components/featuresList.js
+++ b/src/components/featuresList.js
@@ -1,4 +1,5 @@
 import React from "react";
+import useBaseUrl from "@docusaurus/useBaseUrl";
 import styles from "../pages/styles.module.css";
 
 function Feature({ imgUrl, title, description }) {


### PR DESCRIPTION
Feature component calls useBaseUrl but never imports it. Not used anywhere yet so it does not break the build now, but throws as soon as someone renders it.