### PR TITLE
fix: enable IP anonymization in gtag config

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -421,7 +421,7 @@ module.exports = {
         docs: false,
         gtag: {
           trackingID: "G-MK932R9NMD",
-          anonymizeIP: false,
+          anonymizeIP: true,
         },
         blog: false,
         theme: {


### PR DESCRIPTION
anonymizeIP was set to false, so visitor IPs went to Google Analytics unmasked. This project has an EU and CNCF facing audience, anonymizing IPs is the safer default. If this was set intentionally, feel free to close.