### PR TITLE
fix: add missing date frontmatter in zh blog posts

### DIFF
--- a/i18n/zh/docusaurus-plugin-content-blog/2024-12-18-support-blog-post/index.md
+++ b/i18n/zh/docusaurus-plugin-content-blog/2024-12-18-support-blog-post/index.md
@@ -1,5 +1,6 @@
 ---
 title: 介绍 HAMi
+date: "2024-12-18"
 authors: [hami_community]
 slug: introducing-hami
 tags: [介绍, GPU 共享, Kubernetes]

--- a/i18n/zh/docusaurus-plugin-content-blog/2024-12-31-post/index.md
+++ b/i18n/zh/docusaurus-plugin-content-blog/2024-12-31-post/index.md
@@ -1,6 +1,7 @@
 ---
 layout: post
 title: HAMi 项目 GPU Pod 调度流程源码走读
+date: "2024-12-31"
 slug: hami-gpu-scheduling-source-code
 catalog: true
 tags: [Kubernetes, GPU, AI, Source Code, 调度]

--- a/i18n/zh/docusaurus-plugin-content-blog/hami-core-adopted-by-nvidia-kai-scheduler/index.md
+++ b/i18n/zh/docusaurus-plugin-content-blog/hami-core-adopted-by-nvidia-kai-scheduler/index.md
@@ -1,6 +1,6 @@
 ---
 title: "HAMi-core 被 NVIDIA KAI Scheduler 采用：GPU 共享正式迈入硬隔离时代"
-date: 2026-06-20
+date: "2026-06-20"
 description: "两项核心 PR 已合并进入 NVIDIA KAI Scheduler 主干，HAMi 的 GPU 显存硬隔离能力将成为 KAI Scheduler 下个版本的内置特性。云原生 GPU 资源调度正式从「软共享」迈入「硬隔离」时代。"
 authors: [hami_community]
 tags: ["HAMi", "NVIDIA", "KAI Scheduler", "GPU 共享", "硬隔离", "Kubernetes", "云原生"]


### PR DESCRIPTION
3 zh blog posts had a date issue: one had an unquoted date, two had no date field at all, unlike their English source. Matched the English frontmatter.