### PR TITLE
style: fix code fence indent in zh dynamic-mig-support.md

### DIFF
--- a/i18n/zh/docusaurus-plugin-content-docs/version-v2.5.1/userguide/nvidia-device/dynamic-mig-support.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/version-v2.5.1/userguide/nvidia-device/dynamic-mig-support.md
@@ -132,7 +132,7 @@ HAMi 目前有一个 [内置的 MIG 配置](https://github.com/Project-HAMi/HAMi
           - name: 7g.79gb
             memory: 80896
             count: 1
-  ```
+```
 
 :::note
 


### PR DESCRIPTION
Closing code fence had a 2 space indent while the opening fence has none. Renders fine but inconsistent with the rest of the file.