### PR TITLE
docs: add Volcano vGPU Gang scheduling and Queue lab

### DIFF
--- a/i18n/zh/docusaurus-plugin-content-docs-tutorials/current/labs/volcano-vgpu-gang-queue.md
+++ b/i18n/zh/docusaurus-plugin-content-docs-tutorials/current/labs/volcano-vgpu-gang-queue.md
@@ -1,0 +1,635 @@
+---
+title: "实验 8：Volcano vGPU、Gang 调度与队列限制"
+description: "使用 Volcano vGPU 共享单张 GPU，并验证 Gang 调度和队列级 vGPU 资源限制。"
+sidebar_label: "实验 8：Volcano vGPU"
+lab:
+  level: Advanced
+  duration: 约 60 分钟
+  environment: 带 NVIDIA GPU 和 Volcano 的单节点 Kubernetes 集群
+  authors:
+    - bolin-dai
+  verified: "2026-06-08"
+tags:
+  - volcano
+  - vgpu
+  - gang-scheduling
+  - queue
+toc_max_heading_level: 2
+---
+
+本实验组合了 AI 基础设施中经常同时出现的两类能力：
+
+- Volcano vGPU 与 HAMi-core 负责共享一张物理 NVIDIA GPU，并向容器提供显存和算力限制。
+- Volcano Scheduler 提供批任务调度语义，包括 Gang 调度和队列级资源上限。
+
+你将先验证一个 vGPU Pod，然后运行一个双 worker VolcanoJob；接着故意制造 Gang 资源不足场景；最后证明即使节点本身还有足够资源，Queue 也能通过 `capability` 限制 vGPU 用量。
+
+本文输出采集自一套单节点集群：一张 NVIDIA GeForce RTX 3070 Ti（8 GiB）、NVIDIA 驱动 580.159.03、Volcano Scheduler，以及以 HAMi-core 模式运行的 Volcano vGPU device plugin。其他 GPU 上的资源数值会有所不同。
+
+:::important
+
+本实验使用的是 **Volcano vGPU 路线**，不是标准 HAMi Helm 安装路线。不要在同一个 GPU 节点上同时安装标准 HAMi device plugin。一个 GPU 节点在同一时间应只由一种 device-plugin 路线管理。
+
+:::
+
+## 你将学到什么
+
+完成本实验后，你将能够：
+
+- 区分标准 HAMi 资源与 Volcano vGPU 资源；
+- 为 Volcano 开启用于 vGPU 调度的 `deviceshare` 插件；
+- 在 GPU 节点上注册 `volcano.sh/vgpu-*` 资源；
+- 验证 HAMi-core 向容器注入显存和算力限制；
+- 使用 `minAvailable` 为 VolcanoJob 设置 Gang 调度语义；
+- 识别 Gang 无法满足时符合预期的 `Inqueue` 状态；
+- 使用 Queue `capability` 限制 vGPU 数量、显存和算力；
+- 区分 Queue 上限导致的失败和节点容量不足导致的失败。
+
+## 标准 HAMi 与 Volcano vGPU
+
+两条路线都使用 HAMi-core 实现用户态 GPU 隔离，但调度器、device plugin 和资源名不同。
+
+| 路线 | 调度器与 device plugin | Pod 资源名 |
+| --- | --- | --- |
+| 标准 HAMi | HAMi scheduler、webhook 和 HAMi device plugin | `nvidia.com/gpu`、`nvidia.com/gpumem`、`nvidia.com/gpucores` |
+| Volcano vGPU | Volcano Scheduler、`deviceshare` 和 `volcano-vgpu-device-plugin` | `volcano.sh/vgpu-number`、`volcano.sh/vgpu-memory`、`volcano.sh/vgpu-cores` |
+
+本实验的每个 Pod 和 VolcanoJob 都显式设置：
+
+```yaml
+schedulerName: volcano
+```
+
+并且只申请 `volcano.sh/vgpu-*` 资源。不要在同一个工作负载中混用两套资源模型。
+
+## 架构
+
+```mermaid
+flowchart LR
+    Job["Pod 或 VolcanoJob"] -->|"schedulerName: volcano"| Scheduler["Volcano Scheduler"]
+    Scheduler --> DeviceShare["deviceshare 插件"]
+    DeviceShare -->|"选择 GPU 份额"| Kubelet["kubelet"]
+    Kubelet --> Plugin["Volcano vGPU device plugin"]
+    Plugin -->|"注入限制"| Core["容器内的 HAMi-core"]
+    Core --> GPU["物理 NVIDIA GPU"]
+    Queue["Volcano Queue capability"] --> Scheduler
+    Gang["PodGroup / minAvailable"] --> Scheduler
+```
+
+Volcano Scheduler 决定工作负载能否运行以及运行在哪个节点；device plugin 注册 vGPU 资源并处理设备分配；HAMi-core 执行容器可见的 GPU 显存和算力设置。Queue 和 Gang 约束由调度器判断，不能替代容器自己的 `resources.limits`。
+
+## 实验概览
+
+| 步骤 | 目标 | 成功证据 |
+| --- | --- | --- |
+| 1. 记录基线 | 确认集群、GPU runtime 和 Volcano 健康 | 节点 `Ready`、宿主机 `nvidia-smi` 正常、Volcano Pod 正常 |
+| 2. 开启 vGPU 调度 | 配置 `deviceshare` 插件 | Scheduler rollout 成功 |
+| 3. 安装 device plugin | 注册 Volcano vGPU 扩展资源 | 节点出现 `volcano.sh/vgpu-*` capacity |
+| 4. 测试单 Pod | 验证分配和 HAMi-core 注入 | 环境变量出现 2000 MiB/30% 限制；`nvidia-smi` 显示 2000 MiB |
+| 5. 测试 Gang | 将两个 worker 作为整体启动 | VolcanoJob、PodGroup 和两个 worker 都是 `Running` |
+| 6. 制造 GPU 资源不足 | 让完整 Gang 的申请超过单卡容量 | PodGroup 保持 `Inqueue` 并显示 `NotEnoughResources` |
+| 7. 限制 Queue | 对比 Queue 上限以内和以上的 Job | 合规 Job 运行；超限 Job 在节点仍有容量时保持 `Pending` |
+
+## 前提条件
+
+- Kubernetes 1.16 或更高版本，并有一个健康的 NVIDIA GPU 节点。
+- NVIDIA 驱动高于 440；宿主机执行 `nvidia-smi` 必须成功。
+- NVIDIA container runtime 已配置为默认 runtime。
+- 已安装 Volcano 1.9～1.15。本实验固定使用 vGPU plugin v1.11.0；该项目的兼容矩阵说明 v1.12.0 及更早版本与 Volcano 1.15.0 及更早版本兼容。
+- `kubectl` 账号有权修改 Volcano Scheduler ConfigMap、创建集群级 Queue，并在 `kube-system` 中安装 DaemonSet。
+- 已获取 [`tutorials/labs/examples/08-volcano-vgpu/`](https://github.com/Project-HAMi/website/tree/master/tutorials/labs/examples/08-volcano-vgpu/) 中的清单。
+
+:::warning device plugin 互斥
+
+如果已经有其他组件管理同一个 GPU 节点，请不要继续，例如 NVIDIA 官方 device plugin、标准 HAMi device plugin 或另一个 Volcano vGPU device plugin。多个插件可能注册冲突资源，使实验结果无法解释。
+
+:::
+
+下面的资源值针对 8 GiB GPU 设计：
+
+- 成功 Gang 申请 `2 × 2000 MiB = 4000 MiB`；
+- 资源不足 Gang 申请 `2 × 6000 MiB = 12000 MiB`；
+- Queue 上限为 4000 MiB；
+- Queue 负例申请 6000 MiB，高于 Queue 上限，但低于空闲节点约 8192 MiB 的容量。
+
+如果你的 GPU 显存不同，调整清单时需要保持这些大小关系。
+
+## 步骤 1：记录环境基线
+
+设置一次节点名称：
+
+```bash
+export NODE_NAME=$(kubectl get nodes -o jsonpath='{.items[0].metadata.name}')
+echo "NODE_NAME=${NODE_NAME}"
+```
+
+检查 Kubernetes 和节点：
+
+```bash
+kubectl version
+kubectl get node "${NODE_NAME}" -o wide
+```
+
+确认宿主机驱动正常：
+
+```bash
+nvidia-smi
+```
+
+确认 Volcano 控制面和默认 Queue：
+
+```bash
+kubectl get pods -n volcano-system
+kubectl get queue
+```
+
+你应该能看到 Volcano admission controller、controllers、scheduler 和 `default` Queue。未显式指定 Queue 的 VolcanoJob 会进入 `default`，但本实验始终写出 Queue 名称，使调度路径更加清楚。
+
+记录组件精确版本，便于复现：
+
+```bash
+kubectl -n volcano-system get deploy volcano-scheduler \
+  -o jsonpath='{.spec.template.spec.containers[*].image}'; echo
+
+kubectl -n kube-system get daemonset \
+  -o custom-columns=NAME:.metadata.name,IMAGES:.spec.template.spec.containers[*].image
+```
+
+检查现有 GPU device plugin：
+
+```bash
+kubectl -n kube-system get daemonset | grep -Ei 'nvidia|hami|volcano' || true
+```
+
+如果 NVIDIA 或标准 HAMi device plugin 已经管理该节点，请使用新集群，或按照对应组件的卸载流程移除它，再继续本实验。
+
+创建实验命名空间：
+
+```bash
+kubectl create namespace volcano-demo
+```
+
+## 步骤 2：开启 Volcano vGPU 调度
+
+修改前先备份 Scheduler 配置：
+
+```bash
+kubectl get configmap volcano-scheduler-configmap -n volcano-system -o yaml \
+  > /tmp/volcano-scheduler-configmap.before-vgpu.yaml
+```
+
+打开 ConfigMap：
+
+```bash
+kubectl edit configmap volcano-scheduler-configmap -n volcano-system
+```
+
+确认第二个 scheduler tier 中包含开启 vGPU 的 `deviceshare`：
+
+```yaml
+data:
+  volcano-scheduler.conf: |
+    actions: "enqueue, allocate, backfill"
+    tiers:
+    - plugins:
+      - name: priority
+      - name: gang
+      - name: conformance
+    - plugins:
+      - name: drf
+      - name: deviceshare
+        arguments:
+          deviceshare.VGPUEnable: true
+          deviceshare.SchedulePolicy: binpack
+      - name: predicates
+      - name: proportion
+      - name: nodeorder
+      - name: binpack
+```
+
+`deviceshare.VGPUEnable` 开启 Volcano vGPU 调度；`binpack` 倾向于集中放置 GPU 份额。在单 GPU 节点上，无论策略如何，放置结果都是确定的。
+
+重启并检查 Scheduler：
+
+```bash
+kubectl rollout restart deployment/volcano-scheduler -n volcano-system
+kubectl rollout status deployment/volcano-scheduler -n volcano-system --timeout=120s
+kubectl get pods -n volcano-system
+```
+
+只有 Scheduler 处于 `Running` 且 rollout 成功后才能继续。
+
+## 步骤 3：安装 Volcano vGPU device plugin
+
+安装固定版本 v1.11.0 的清单：
+
+```bash
+kubectl apply -f \
+  https://raw.githubusercontent.com/Project-HAMi/volcano-vgpu-device-plugin/v1.11.0/volcano-vgpu-device-plugin.yml
+```
+
+部分旧教程使用的未固定版本 URL 已经不在 `main` 根目录。使用已发布版本的固定清单，可以避免未来仓库目录变化导致实验失效。
+
+等待 DaemonSet 就绪：
+
+```bash
+kubectl rollout status daemonset/volcano-device-plugin \
+  -n kube-system --timeout=180s
+
+kubectl get daemonset -n kube-system | grep volcano
+kubectl get pods -n kube-system -o wide | grep volcano-device-plugin
+```
+
+确认镜像版本：
+
+```bash
+kubectl get daemonset volcano-device-plugin -n kube-system \
+  -o jsonpath='{.spec.template.spec.containers[*].image}'; echo
+```
+
+查看节点注册的资源：
+
+```bash
+kubectl get node "${NODE_NAME}" \
+  -o custom-columns='NAME:.metadata.name,NUMBER:.status.allocatable.volcano\.sh/vgpu-number,MEMORY:.status.allocatable.volcano\.sh/vgpu-memory,CORES:.status.allocatable.volcano\.sh/vgpu-cores'
+```
+
+在 8 GiB RTX 3070 Ti 上采集到的等价输出为：
+
+```text
+NAME        NUMBER   MEMORY   CORES
+master-01   10       8192     100
+```
+
+需要正确理解这些值：
+
+- `vgpu-number: 10` 不代表十张物理 GPU，而是该卡对外提供的可调度 vGPU 份额数。
+- `vgpu-memory` 单位为 MiB，表示插件注册的显存容量。
+- `vgpu-cores` 表示可分配算力容量。
+
+后续负例应以你自己节点注册的值进行调整。
+
+## 步骤 4：验证单个 vGPU Pod
+
+检查 `01-single-pod.yaml` 的关键字段：
+
+```yaml
+spec:
+  schedulerName: volcano
+  containers:
+    - name: cuda
+      resources:
+        limits:
+          volcano.sh/vgpu-number: 1
+          volcano.sh/vgpu-memory: 2000
+          volcano.sh/vgpu-cores: 30
+```
+
+创建 Pod 并等待就绪：
+
+```bash
+kubectl apply -f tutorials/labs/examples/08-volcano-vgpu/01-single-pod.yaml
+kubectl wait -n volcano-demo --for=condition=Ready \
+  pod/volcano-vgpu-single --timeout=180s
+```
+
+检查注入的环境变量：
+
+```bash
+kubectl exec -n volcano-demo volcano-vgpu-single -- \
+  env | grep -E 'CUDA_DEVICE|NVIDIA_VISIBLE_DEVICES|VGPU|VOLCANO'
+```
+
+采集输出：
+
+```text
+CUDA_DEVICE_MEMORY_LIMIT_0=2000m
+CUDA_DEVICE_SM_LIMIT=30
+CUDA_DEVICE_MEMORY_SHARED_CACHE=/tmp/vgpu/6446d246-5917-419d-bdc3-1a119044f857.cache
+```
+
+前两个值对应申请的 2000 MiB 显存和 30% 算力限制。
+
+检查容器内 GPU 视图：
+
+```bash
+kubectl exec -n volcano-demo volcano-vgpu-single -- nvidia-smi
+```
+
+相关采集输出：
+
+```text
+[HAMI-core Msg(...:libvgpu.c:870)]: Initializing.....
+|   0  NVIDIA GeForce RTX 3070 Ti ... |       0MiB /   2000MiB |      0%      Default |
+```
+
+HAMi-core 初始化日志和 2000 MiB 总显存说明 vGPU 设置已经进入容器，并改变了容器看到的 GPU 视图。
+
+:::note 该证据的边界
+
+本步骤证明资源分配和限制注入成功，但没有运行超过上限的 CUDA 显存分配程序，因此不能单独证明 OOM 的执行边界。更强的隔离验证请参考实验 3 或实验 7。
+
+:::
+
+进入 Gang 测试前删除单 Pod，避免它占用显存基线：
+
+```bash
+kubectl delete pod volcano-vgpu-single -n volcano-demo
+```
+
+## 步骤 5：运行双 worker Gang
+
+成功 VolcanoJob 创建两个 worker。每个 worker 申请一个 vGPU 份额、2000 MiB 显存和 30% 算力，因此完整 Gang 总共需要 4000 MiB 和 60% 算力。
+
+形成 Gang 约束的关键字段是：
+
+```yaml
+spec:
+  schedulerName: volcano
+  queue: default
+  minAvailable: 2
+  tasks:
+    - name: vgpu-worker
+      replicas: 2
+```
+
+创建 Job：
+
+```bash
+kubectl apply -f tutorials/labs/examples/08-volcano-vgpu/02-gang-job.yaml
+```
+
+检查 Job、自动生成的 PodGroup 和 Pod：
+
+```bash
+kubectl get vcjob,podgroup,pod -n volcano-demo
+```
+
+采集输出：
+
+```text
+NAME                                      STATUS    MINAVAILABLE   RUNNINGS
+job.batch.volcano.sh/vcjob-vgpu-gang     Running   2              2
+
+NAME                                                        STATUS    MINMEMBER   RUNNINGS
+podgroup.scheduling.volcano.sh/vcjob-vgpu-gang-...          Running   2           2
+
+NAME                                    READY   STATUS
+pod/vcjob-vgpu-gang-vgpu-worker-0       1/1     Running
+pod/vcjob-vgpu-gang-vgpu-worker-1       1/1     Running
+```
+
+`MINAVAILABLE=2`、`RUNNINGS=2` 和两个 `Running` worker 说明完整 Gang 可以放入集群并获得准入。
+
+检查其中一个 worker 的 GPU 视图：
+
+```bash
+kubectl exec -n volcano-demo vcjob-vgpu-gang-vgpu-worker-0 -- nvidia-smi
+```
+
+采集结果同样显示 2000 MiB GPU 份额和 HAMi-core 初始化日志。
+
+创建资源不足场景前删除成功 Job：
+
+```bash
+kubectl delete vcjob vcjob-vgpu-gang -n volcano-demo
+kubectl wait -n volcano-demo --for=delete pod \
+  -l volcano.sh/job-name=vcjob-vgpu-gang --timeout=120s || true
+```
+
+## 步骤 6：证明 Gang 调度会阻止部分启动
+
+下一个 Job 仍需要两个 worker，但每个申请 6000 MiB。在空闲的 8 GiB 节点上，一个 worker 能放下，两个 worker 无法同时放下：
+
+```text
+单个 worker： 6000 MiB <= 8192 MiB
+完整 Gang：  12000 MiB > 8192 MiB
+```
+
+创建 Job：
+
+```bash
+kubectl apply -f tutorials/labs/examples/08-volcano-vgpu/03-gang-insufficient.yaml
+sleep 15
+kubectl get vcjob,podgroup,pod -n volcano-demo
+```
+
+自动生成的 PodGroup 应保持 `Inqueue`，两个 Pod 都应保持 `Pending`。
+
+获取 PodGroup 名称并检查条件：
+
+```bash
+export PG_NAME=$(kubectl get podgroup -n volcano-demo \
+  -o jsonpath='{.items[0].metadata.name}')
+
+kubectl describe podgroup "${PG_NAME}" -n volcano-demo
+```
+
+相关采集条件：
+
+```text
+Message: 1/2 tasks in gang unschedulable: pod group is not ready,
+         2 Pending, 2 minAvailable; Pending: 1 Schedulable, 1 Unschedulable
+Reason:  NotEnoughResources
+Type:    Unschedulable
+Phase:   Inqueue
+```
+
+关键证据是 `1 Schedulable, 1 Unschedulable` 与 `minAvailable: 2` 同时出现：Volcano 单独看可以放置一个 worker，但因为完整的双成员 Gang 无法满足，所以没有只启动其中一部分。
+
+开始 Queue 测试前删除这个负例：
+
+```bash
+kubectl delete vcjob vcjob-vgpu-gang-insufficient -n volcano-demo
+```
+
+确认没有实验 Pod 继续占用 vGPU：
+
+```bash
+kubectl get pods -n volcano-demo
+```
+
+## 步骤 7：执行 Queue 级 vGPU 上限
+
+本步骤需要刻意区分 Queue 容量和节点容量。开始前节点必须没有本实验留下的 vGPU 工作负载。
+
+创建一个最多允许两个 vGPU 份额、4000 MiB 和 60% 算力的 Queue：
+
+```bash
+kubectl apply -f tutorials/labs/examples/08-volcano-vgpu/04-queue.yaml
+kubectl get queue gpu-small-queue -o yaml
+```
+
+相关上限为：
+
+```yaml
+capability:
+  volcano.sh/vgpu-number: "2"
+  volcano.sh/vgpu-memory: "4000"
+  volcano.sh/vgpu-cores: "60"
+```
+
+Queue `capability` 是该 Queue 中所有 Job 资源总用量的硬上限。它不会自行分配 GPU；每个 worker 仍需设置自己的 `resources.limits`。
+
+### Queue 上限以内的 Job
+
+合规 Job 包含两个 worker，每个申请 1000 MiB 和 30% 算力，总计 2000 MiB 和 60% 算力：
+
+```bash
+kubectl apply -f tutorials/labs/examples/08-volcano-vgpu/05-queue-fit-job.yaml
+kubectl get vcjob,podgroup,pod -n volcano-demo
+```
+
+因为总申请未超过 Queue capability，两个 worker 都应该进入 `Running`。
+
+删除合规 Job 并等待资源释放：
+
+```bash
+kubectl delete vcjob vcjob-vgpu-queue-fit -n volcano-demo
+kubectl wait -n volcano-demo --for=delete pod \
+  -l volcano.sh/job-name=vcjob-vgpu-queue-fit --timeout=120s || true
+```
+
+### 超过 Queue 上限的 Job
+
+超限 Job 包含两个 worker，每个申请 3000 MiB：
+
+```text
+Job 总申请：     6000 MiB
+Queue 上限：     4000 MiB
+空闲节点容量：约 8192 MiB
+```
+
+该 Job 能放入空闲节点，但不能放入 `gpu-small-queue`。
+
+创建 Job：
+
+```bash
+kubectl apply -f tutorials/labs/examples/08-volcano-vgpu/06-queue-exceeds-job.yaml
+sleep 15
+kubectl get vcjob,podgroup,pod -n volcano-demo
+```
+
+采集结果：
+
+```text
+NAME                                             READY   STATUS
+vcjob-vgpu-queue-exceeds-vgpu-worker-0           0/1     Pending
+vcjob-vgpu-queue-exceeds-vgpu-worker-1           0/1     Pending
+
+NAME                                             STATUS    MINMEMBER
+vcjob-vgpu-queue-exceeds-...                     Inqueue   2
+```
+
+检查 PodGroup 和 Queue：
+
+```bash
+export PG_NAME=$(kubectl get podgroup -n volcano-demo \
+  -o jsonpath='{.items[0].metadata.name}')
+
+kubectl describe podgroup "${PG_NAME}" -n volcano-demo
+kubectl describe queue gpu-small-queue
+```
+
+PodGroup 指向 `gpu-small-queue`，保持 `Inqueue` 并报告 `NotEnoughResources`。因为前面的 vGPU 工作负载已经全部删除，而 6000 MiB Job 可以放入约 8192 MiB 的节点，所以剩余的限制边界就是 Queue 的 4000 MiB capability。
+
+:::tip 在其他 GPU 上复现
+
+需要选择满足 `Queue 上限 < Job 总申请 <= 节点当前空闲容量` 的数值。如果 Job 总申请也超过节点空闲容量，就无法单独证明 Queue 限制。
+
+:::
+
+## 故障排查
+
+### 节点没有 `volcano.sh/vgpu-*` 资源
+
+检查 plugin Pod、日志和 runtime：
+
+```bash
+kubectl get pods -n kube-system -o wide | grep volcano-device-plugin
+kubectl logs -n kube-system daemonset/volcano-device-plugin --all-containers --tail=200
+kubectl get node "${NODE_NAME}" -o yaml | grep 'volcano.sh/'
+```
+
+确认 NVIDIA 驱动正常、NVIDIA runtime 是默认 runtime，并检查是否有第二个 GPU device plugin 管理该节点。
+
+### Pod 被默认调度器处理
+
+确认清单包含：
+
+```yaml
+schedulerName: volcano
+```
+
+然后检查 Pod 事件：
+
+```bash
+kubectl describe pod -n volcano-demo <pod-name> | sed -n '/Events:/,$p'
+```
+
+### Gang 保持 `Inqueue`
+
+在负例中，`Inqueue` 和 `NotEnoughResources` 是预期行为。判断为安装故障前，应检查 `minAvailable`、每个 worker 的申请、节点当前分配和所属 Queue。
+
+### Queue 测试因为错误原因失败
+
+删除之前所有实验 Job 和 Pod，并确认节点有足够的空闲 vGPU 显存容纳超限 Job。Job 必须超过 Queue capability，同时仍能放入节点。
+
+### 容器看到完整 GPU 显存
+
+如果缺少 `CUDA_DEVICE_MEMORY_LIMIT_0`，且 `nvidia-smi` 显示完整显存，说明 HAMi-core 没有注入。检查 device plugin 日志，并确认 NVIDIA runtime 是默认 runtime。
+
+### 资源名不一致
+
+不要从其他教程推断资源名，应读取节点实际注册结果：
+
+```bash
+kubectl get node "${NODE_NAME}" -o yaml | grep 'volcano.sh/'
+```
+
+本实验要求 `volcano.sh/vgpu-number`、`volcano.sh/vgpu-memory` 和 `volcano.sh/vgpu-cores`。
+
+## 清理
+
+删除实验工作负载、Queue 和命名空间：
+
+```bash
+kubectl delete vcjob --all -n volcano-demo --ignore-not-found
+kubectl delete pod --all -n volcano-demo --ignore-not-found
+kubectl delete queue gpu-small-queue --ignore-not-found
+kubectl delete namespace volcano-demo
+```
+
+如果这是专用实验集群，删除 vGPU plugin：
+
+```bash
+kubectl delete -f \
+  https://raw.githubusercontent.com/Project-HAMi/volcano-vgpu-device-plugin/v1.11.0/volcano-vgpu-device-plugin.yml
+```
+
+只有当备份确实来自本实验，并且没有其他用户依赖 vGPU 配置时，才恢复 Scheduler ConfigMap：
+
+```bash
+kubectl apply -f /tmp/volcano-scheduler-configmap.before-vgpu.yaml
+kubectl rollout restart deployment/volcano-scheduler -n volcano-system
+kubectl rollout status deployment/volcano-scheduler -n volcano-system --timeout=120s
+```
+
+## 本实验验证了什么
+
+| 结论 | 证据 |
+| --- | --- |
+| Volcano 注册了可共享 GPU 资源 | 节点 allocatable 出现 `volcano.sh/vgpu-number`、`vgpu-memory` 和 `vgpu-cores` |
+| HAMi-core 设置进入了容器 | 环境变量包含 `CUDA_DEVICE_MEMORY_LIMIT_0=2000m` 和 `CUDA_DEVICE_SM_LIMIT=30` |
+| 容器只看到申请的 GPU 份额 | 容器内 `nvidia-smi` 显示 2000 MiB，而不是完整 8 GiB |
+| 完整双 worker Gang 可以运行 | VolcanoJob 和 PodGroup 为 `Running`，两个 worker 都为 `Running` |
+| Volcano 阻止了 Gang 部分启动 | 2 × 6000 MiB Job 保持 `Inqueue`；条件显示 `1 Schedulable, 1 Unschedulable` 且 `minAvailable: 2` |
+| Queue 接受上限以内的 Job | 2 × 1000 MiB、60% 算力的 Job 在 `gpu-small-queue` 中运行 |
+| Queue 阻止超过上限的 Job | 空闲 8 GiB 节点上，6000 MiB Job 在 4000 MiB Queue 上限下保持 `Pending`/`Inqueue` |
+
+## 后续学习
+
+- 运行[实验 3：HAMi GPU 切分](/zh/tutorials/labs/gpu-partitioning)或[实验 7：k3s GPU 隔离](/zh/tutorials/labs/hami-isolation-k3s)，使用真实 CUDA OOM 测试证明显存上限。
+- 阅读 [Volcano Gang 插件文档](https://volcano.sh/docs/scheduler/plugins/gang/)，了解双 worker Job 之外的 Gang 调度语义。
+- 阅读 [Volcano Queue 资源管理文档](https://volcano.sh/docs/keyfeatures/queueresourcemanagement/)，了解 `deserved`、`guarantee`、回收和层级 Queue。
+- 升级前查看 [Volcano vGPU device plugin 仓库](https://github.com/Project-HAMi/volcano-vgpu-device-plugin)，确保 plugin 与 Volcano 版本符合已发布的兼容矩阵。

--- a/i18n/zh/docusaurus-plugin-content-docs-tutorials/current/overview.md
+++ b/i18n/zh/docusaurus-plugin-content-docs-tutorials/current/overview.md
@@ -19,4 +19,4 @@ import LabCardGridAuto from '@site/src/components/labs/LabCardGridAuto';
 
 <LabCardGridAuto />
 
-每个实验都列出了各自的前提条件。实验 3 和 4 直接复用实验 1 搭建的集群，一次开机即可完成全部三个实验；实验 2 可在任意笔记本上运行，无需 GPU。实验 7 在租用的 GPU 虚拟机上自行搭建单节点 k3s 集群，不使用 GPU Operator。
+每个实验都列出了各自的前提条件。实验 3 和 4 直接复用实验 1 搭建的集群，一次开机即可完成全部三个实验；实验 2 可在任意笔记本上运行，无需 GPU。实验 7 在租用的 GPU 虚拟机上自行搭建单节点 k3s 集群，不使用 GPU Operator。实验 8 需要已有的 Volcano GPU 集群，用于验证 Volcano vGPU、Gang 调度和队列级资源限制。

--- a/sidebars-tutorials.js
+++ b/sidebars-tutorials.js
@@ -46,6 +46,11 @@ module.exports = {
           id: "labs/hami-isolation-k3s",
           customProps: { level: "Intermediate", duration: "about 45 minutes" },
         },
+        {
+          type: "doc",
+          id: "labs/volcano-vgpu-gang-queue",
+          customProps: { level: "Advanced", duration: "about 60 minutes" },
+        },
       ],
     },
   ],

--- a/tutorials/labs/examples/08-volcano-vgpu/01-single-pod.yaml
+++ b/tutorials/labs/examples/08-volcano-vgpu/01-single-pod.yaml
@@ -1,0 +1,26 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: volcano-vgpu-single
+  namespace: volcano-demo
+spec:
+  schedulerName: volcano
+  restartPolicy: Never
+  containers:
+    - name: cuda
+      image: nvidia/cuda:11.0.3-base-ubuntu18.04
+      imagePullPolicy: IfNotPresent
+      command:
+        - bash
+        - -lc
+        - |
+          echo "===== GPU ENV ====="
+          env | grep -E 'CUDA_DEVICE|NVIDIA_VISIBLE_DEVICES|VGPU|VOLCANO' || true
+          echo "===== NVIDIA SMI ====="
+          nvidia-smi
+          sleep 3600
+      resources:
+        limits:
+          volcano.sh/vgpu-number: 1
+          volcano.sh/vgpu-memory: 2000
+          volcano.sh/vgpu-cores: 30

--- a/tutorials/labs/examples/08-volcano-vgpu/02-gang-job.yaml
+++ b/tutorials/labs/examples/08-volcano-vgpu/02-gang-job.yaml
@@ -1,0 +1,35 @@
+apiVersion: batch.volcano.sh/v1alpha1
+kind: Job
+metadata:
+  name: vcjob-vgpu-gang
+  namespace: volcano-demo
+spec:
+  schedulerName: volcano
+  queue: default
+  minAvailable: 2
+  maxRetry: 1
+  tasks:
+    - name: vgpu-worker
+      replicas: 2
+      template:
+        spec:
+          restartPolicy: Never
+          containers:
+            - name: cuda
+              image: nvidia/cuda:11.0.3-base-ubuntu18.04
+              imagePullPolicy: IfNotPresent
+              command:
+                - bash
+                - -lc
+                - |
+                  echo "worker: $(hostname)"
+                  echo "===== GPU ENV ====="
+                  env | grep -E 'CUDA_DEVICE|NVIDIA_VISIBLE_DEVICES|VGPU|VOLCANO' || true
+                  echo "===== NVIDIA SMI ====="
+                  nvidia-smi
+                  sleep 3600
+              resources:
+                limits:
+                  volcano.sh/vgpu-number: 1
+                  volcano.sh/vgpu-memory: 2000
+                  volcano.sh/vgpu-cores: 30

--- a/tutorials/labs/examples/08-volcano-vgpu/03-gang-insufficient.yaml
+++ b/tutorials/labs/examples/08-volcano-vgpu/03-gang-insufficient.yaml
@@ -1,0 +1,26 @@
+apiVersion: batch.volcano.sh/v1alpha1
+kind: Job
+metadata:
+  name: vcjob-vgpu-gang-insufficient
+  namespace: volcano-demo
+spec:
+  schedulerName: volcano
+  queue: default
+  minAvailable: 2
+  maxRetry: 1
+  tasks:
+    - name: vgpu-worker
+      replicas: 2
+      template:
+        spec:
+          restartPolicy: Never
+          containers:
+            - name: cuda
+              image: nvidia/cuda:11.0.3-base-ubuntu18.04
+              imagePullPolicy: IfNotPresent
+              command: ["bash", "-lc", "nvidia-smi; sleep 3600"]
+              resources:
+                limits:
+                  volcano.sh/vgpu-number: 1
+                  volcano.sh/vgpu-memory: 6000
+                  volcano.sh/vgpu-cores: 30

--- a/tutorials/labs/examples/08-volcano-vgpu/04-queue.yaml
+++ b/tutorials/labs/examples/08-volcano-vgpu/04-queue.yaml
@@ -1,0 +1,13 @@
+apiVersion: scheduling.volcano.sh/v1beta1
+kind: Queue
+metadata:
+  name: gpu-small-queue
+spec:
+  weight: 1
+  reclaimable: false
+  capability:
+    cpu: "2"
+    memory: "4Gi"
+    volcano.sh/vgpu-number: "2"
+    volcano.sh/vgpu-memory: "4000"
+    volcano.sh/vgpu-cores: "60"

--- a/tutorials/labs/examples/08-volcano-vgpu/05-queue-fit-job.yaml
+++ b/tutorials/labs/examples/08-volcano-vgpu/05-queue-fit-job.yaml
@@ -1,0 +1,27 @@
+apiVersion: batch.volcano.sh/v1alpha1
+kind: Job
+metadata:
+  name: vcjob-vgpu-queue-fit
+  namespace: volcano-demo
+spec:
+  schedulerName: volcano
+  queue: gpu-small-queue
+  minAvailable: 2
+  tasks:
+    - name: vgpu-worker
+      replicas: 2
+      policies:
+        - event: TaskCompleted
+          action: CompleteJob
+      template:
+        spec:
+          restartPolicy: Never
+          containers:
+            - name: cuda
+              image: nvidia/cuda:11.0.3-base-ubuntu18.04
+              command: ["bash", "-lc", "nvidia-smi; sleep 60"]
+              resources:
+                limits:
+                  volcano.sh/vgpu-number: 1
+                  volcano.sh/vgpu-memory: 1000
+                  volcano.sh/vgpu-cores: 30

--- a/tutorials/labs/examples/08-volcano-vgpu/06-queue-exceeds-job.yaml
+++ b/tutorials/labs/examples/08-volcano-vgpu/06-queue-exceeds-job.yaml
@@ -1,0 +1,24 @@
+apiVersion: batch.volcano.sh/v1alpha1
+kind: Job
+metadata:
+  name: vcjob-vgpu-queue-exceeds
+  namespace: volcano-demo
+spec:
+  schedulerName: volcano
+  queue: gpu-small-queue
+  minAvailable: 2
+  tasks:
+    - name: vgpu-worker
+      replicas: 2
+      template:
+        spec:
+          restartPolicy: Never
+          containers:
+            - name: cuda
+              image: nvidia/cuda:11.0.3-base-ubuntu18.04
+              command: ["bash", "-lc", "nvidia-smi; sleep 60"]
+              resources:
+                limits:
+                  volcano.sh/vgpu-number: 1
+                  volcano.sh/vgpu-memory: 3000
+                  volcano.sh/vgpu-cores: 30

--- a/tutorials/labs/volcano-vgpu-gang-queue.md
+++ b/tutorials/labs/volcano-vgpu-gang-queue.md
@@ -1,0 +1,635 @@
+---
+title: "Lab 8: Volcano vGPU with Gang Scheduling and Queues"
+description: "Share one GPU with Volcano vGPU, then verify Gang scheduling and queue-level vGPU limits."
+sidebar_label: "Lab 8: Volcano vGPU"
+lab:
+  level: Advanced
+  duration: about 60 minutes
+  environment: single-node Kubernetes cluster with an NVIDIA GPU and Volcano
+  authors:
+    - bolin-dai
+  verified: "2026-06-08"
+tags:
+  - volcano
+  - vgpu
+  - gang-scheduling
+  - queue
+toc_max_heading_level: 2
+---
+
+This lab combines two capabilities that commonly appear together in AI infrastructure:
+
+- Volcano vGPU and HAMi-core share one physical NVIDIA GPU and expose per-container memory and compute limits.
+- Volcano Scheduler adds batch scheduling semantics, including Gang scheduling and queue-level resource limits.
+
+You will first verify a single vGPU Pod, then run a two-worker VolcanoJob, deliberately create a Gang scheduling failure, and finally prove that a Queue can cap vGPU resources even when the node itself still has enough capacity.
+
+The captured outputs in this lab come from a single-node cluster with one NVIDIA GeForce RTX 3070 Ti (8 GiB), NVIDIA driver 580.159.03, Volcano Scheduler, and the Volcano vGPU device plugin in HAMi-core mode. Resource values on other GPUs will differ.
+
+:::important
+
+This lab uses the **Volcano vGPU path**, not a standard HAMi Helm installation. Do not install the standard HAMi device plugin on the same GPU node. One GPU node should be managed by one device-plugin path at a time.
+
+:::
+
+## What You'll Learn
+
+After completing this lab, you will be able to:
+
+- distinguish standard HAMi resources from Volcano vGPU resources;
+- enable Volcano's `deviceshare` plugin for vGPU scheduling;
+- register `volcano.sh/vgpu-*` resources on a GPU node;
+- verify that HAMi-core injects a memory and compute limit into a container;
+- use `minAvailable` to give a VolcanoJob Gang scheduling semantics;
+- recognize the expected `Inqueue` state when a Gang cannot fit;
+- set a Queue `capability` for vGPU number, memory, and cores; and
+- separate a queue-limit failure from a node-capacity failure.
+
+## Standard HAMi vs. Volcano vGPU
+
+Both paths use HAMi-core for userspace GPU isolation, but they use different schedulers, device plugins, and resource names.
+
+| Path | Scheduler and device plugin | Pod resources |
+| --- | --- | --- |
+| Standard HAMi | HAMi scheduler, webhook, and HAMi device plugin | `nvidia.com/gpu`, `nvidia.com/gpumem`, `nvidia.com/gpucores` |
+| Volcano vGPU | Volcano Scheduler, `deviceshare`, and `volcano-vgpu-device-plugin` | `volcano.sh/vgpu-number`, `volcano.sh/vgpu-memory`, `volcano.sh/vgpu-cores` |
+
+In this lab every Pod and VolcanoJob sets:
+
+```yaml
+schedulerName: volcano
+```
+
+and requests only `volcano.sh/vgpu-*` resources. Do not mix the two resource models in one workload.
+
+## Architecture
+
+```mermaid
+flowchart LR
+    Job["Pod or VolcanoJob"] -->|"schedulerName: volcano"| Scheduler["Volcano Scheduler"]
+    Scheduler --> DeviceShare["deviceshare plugin"]
+    DeviceShare -->|"selects a GPU slice"| Kubelet["kubelet"]
+    Kubelet --> Plugin["volcano-vGPU device plugin"]
+    Plugin -->|"injects limits"| Core["HAMi-core in container"]
+    Core --> GPU["Physical NVIDIA GPU"]
+    Queue["Volcano Queue capability"] --> Scheduler
+    Gang["PodGroup / minAvailable"] --> Scheduler
+```
+
+Volcano Scheduler decides whether and where the workload can run. The device plugin registers vGPU resources and performs allocation. HAMi-core enforces the container-visible GPU memory and compute settings. Queue and Gang constraints are evaluated by the scheduler; they do not replace the per-container `resources.limits` block.
+
+## Lab Overview
+
+| Step | Goal | Success evidence |
+| --- | --- | --- |
+| 1. Record the baseline | Confirm the cluster, GPU runtime, and Volcano are healthy | Node `Ready`, host `nvidia-smi` works, Volcano Pods run |
+| 2. Enable vGPU scheduling | Configure the `deviceshare` scheduler plugin | Scheduler rollout succeeds |
+| 3. Install the device plugin | Register Volcano vGPU extended resources | Node shows `volcano.sh/vgpu-*` capacity |
+| 4. Test one Pod | Verify allocation and HAMi-core injection | Environment has 2000 MiB/30% limits; `nvidia-smi` shows 2000 MiB |
+| 5. Test a Gang | Start two workers as one group | VolcanoJob and PodGroup are `Running`; both workers run |
+| 6. Exhaust the GPU | Request more than one card can provide to the full Gang | PodGroup remains `Inqueue` with `NotEnoughResources` |
+| 7. Limit a Queue | Compare a Job below and above Queue capability | Fit Job runs; over-cap Job stays `Pending` while the node has capacity |
+
+## Prerequisites
+
+- Kubernetes 1.16 or later with a healthy NVIDIA GPU node.
+- NVIDIA driver newer than 440; `nvidia-smi` must work on the host.
+- NVIDIA container runtime configured as the default runtime.
+- Volcano 1.9 through 1.15 installed. The pinned vGPU plugin used here is v1.11.0; the project's compatibility matrix lists v1.12.0 and earlier with Volcano 1.15.0 and earlier.
+- `kubectl` access with permission to edit the Volcano scheduler ConfigMap, create cluster-scoped Queue resources, and install a DaemonSet in `kube-system`.
+- The manifests from [`tutorials/labs/examples/08-volcano-vgpu/`](https://github.com/Project-HAMi/website/tree/master/tutorials/labs/examples/08-volcano-vgpu/).
+
+:::warning Device-plugin exclusivity
+
+Do not continue if another component already owns the same GPU node—for example the NVIDIA device plugin, the standard HAMi device plugin, or a second Volcano vGPU device plugin. Multiple plugins can register conflicting resources and make the results impossible to interpret.
+
+:::
+
+The resource values below are chosen for an 8 GiB card:
+
+- the successful Gang requests `2 × 2000 MiB = 4000 MiB`;
+- the insufficient Gang requests `2 × 6000 MiB = 12000 MiB`;
+- the Queue cap is 4000 MiB; and
+- the Queue-negative Job requests 6000 MiB, which is above the Queue cap but below the empty node's roughly 8192 MiB capacity.
+
+If your GPU has a different memory size, preserve those relationships when adjusting the manifests.
+
+## Step 1: Record the Baseline
+
+Set the node name once:
+
+```bash
+export NODE_NAME=$(kubectl get nodes -o jsonpath='{.items[0].metadata.name}')
+echo "NODE_NAME=${NODE_NAME}"
+```
+
+Check Kubernetes and the node:
+
+```bash
+kubectl version
+kubectl get node "${NODE_NAME}" -o wide
+```
+
+Confirm the host driver is healthy:
+
+```bash
+nvidia-smi
+```
+
+Confirm Volcano's control plane and default Queue:
+
+```bash
+kubectl get pods -n volcano-system
+kubectl get queue
+```
+
+You should see the Volcano admission controller, controllers, scheduler, and a `default` Queue. Volcano automatically assigns Jobs without an explicit Queue to `default`, but this lab always writes the Queue name so the scheduling path is obvious.
+
+Record the exact component versions for reproducibility:
+
+```bash
+kubectl -n volcano-system get deploy volcano-scheduler \
+  -o jsonpath='{.spec.template.spec.containers[*].image}'; echo
+
+kubectl -n kube-system get daemonset \
+  -o custom-columns=NAME:.metadata.name,IMAGES:.spec.template.spec.containers[*].image
+```
+
+Inspect existing GPU device plugins:
+
+```bash
+kubectl -n kube-system get daemonset | grep -Ei 'nvidia|hami|volcano' || true
+```
+
+If an NVIDIA or standard HAMi device plugin is already managing this node, use a fresh cluster or remove that plugin according to its own uninstall procedure before continuing.
+
+Create the lab namespace:
+
+```bash
+kubectl create namespace volcano-demo
+```
+
+## Step 2: Enable Volcano vGPU Scheduling
+
+Back up the current scheduler configuration before editing it:
+
+```bash
+kubectl get configmap volcano-scheduler-configmap -n volcano-system -o yaml \
+  > /tmp/volcano-scheduler-configmap.before-vgpu.yaml
+```
+
+Open the ConfigMap:
+
+```bash
+kubectl edit configmap volcano-scheduler-configmap -n volcano-system
+```
+
+Ensure that the second scheduler tier includes `deviceshare` with vGPU enabled:
+
+```yaml
+data:
+  volcano-scheduler.conf: |
+    actions: "enqueue, allocate, backfill"
+    tiers:
+    - plugins:
+      - name: priority
+      - name: gang
+      - name: conformance
+    - plugins:
+      - name: drf
+      - name: deviceshare
+        arguments:
+          deviceshare.VGPUEnable: true
+          deviceshare.SchedulePolicy: binpack
+      - name: predicates
+      - name: proportion
+      - name: nodeorder
+      - name: binpack
+```
+
+`deviceshare.VGPUEnable` activates Volcano vGPU scheduling. `binpack` prefers to consolidate slices; on this single-GPU node the placement result is deterministic either way.
+
+Restart and verify the scheduler:
+
+```bash
+kubectl rollout restart deployment/volcano-scheduler -n volcano-system
+kubectl rollout status deployment/volcano-scheduler -n volcano-system --timeout=120s
+kubectl get pods -n volcano-system
+```
+
+Do not continue until the scheduler is `Running` and the rollout succeeds.
+
+## Step 3: Install the Volcano vGPU Device Plugin
+
+Install the pinned v1.11.0 manifest:
+
+```bash
+kubectl apply -f \
+  https://raw.githubusercontent.com/Project-HAMi/volcano-vgpu-device-plugin/v1.11.0/volcano-vgpu-device-plugin.yml
+```
+
+The unversioned URL used by older tutorials is no longer present on `main`; pinning the released manifest prevents a future repository layout change from breaking the lab.
+
+Wait for the DaemonSet:
+
+```bash
+kubectl rollout status daemonset/volcano-device-plugin \
+  -n kube-system --timeout=180s
+
+kubectl get daemonset -n kube-system | grep volcano
+kubectl get pods -n kube-system -o wide | grep volcano-device-plugin
+```
+
+Verify the image is the expected version:
+
+```bash
+kubectl get daemonset volcano-device-plugin -n kube-system \
+  -o jsonpath='{.spec.template.spec.containers[*].image}'; echo
+```
+
+Now inspect the resources registered on the node:
+
+```bash
+kubectl get node "${NODE_NAME}" \
+  -o custom-columns='NAME:.metadata.name,NUMBER:.status.allocatable.volcano\.sh/vgpu-number,MEMORY:.status.allocatable.volcano\.sh/vgpu-memory,CORES:.status.allocatable.volcano\.sh/vgpu-cores'
+```
+
+Captured output on the 8 GiB RTX 3070 Ti was equivalent to:
+
+```text
+NAME        NUMBER   MEMORY   CORES
+master-01   10       8192     100
+```
+
+Interpret the values carefully:
+
+- `vgpu-number: 10` does not mean ten physical GPUs. It is the number of schedulable vGPU shares exposed for the card.
+- `vgpu-memory` is in MiB and reflects the card memory registered by the plugin.
+- `vgpu-cores` is the compute capacity available for allocation.
+
+Use the values registered by your own node when sizing the later negative tests.
+
+## Step 4: Verify a Single vGPU Pod
+
+Review the key fields in `01-single-pod.yaml`:
+
+```yaml
+spec:
+  schedulerName: volcano
+  containers:
+    - name: cuda
+      resources:
+        limits:
+          volcano.sh/vgpu-number: 1
+          volcano.sh/vgpu-memory: 2000
+          volcano.sh/vgpu-cores: 30
+```
+
+Create the Pod and wait for it to become ready:
+
+```bash
+kubectl apply -f tutorials/labs/examples/08-volcano-vgpu/01-single-pod.yaml
+kubectl wait -n volcano-demo --for=condition=Ready \
+  pod/volcano-vgpu-single --timeout=180s
+```
+
+Inspect the injected environment:
+
+```bash
+kubectl exec -n volcano-demo volcano-vgpu-single -- \
+  env | grep -E 'CUDA_DEVICE|NVIDIA_VISIBLE_DEVICES|VGPU|VOLCANO'
+```
+
+Captured output:
+
+```text
+CUDA_DEVICE_MEMORY_LIMIT_0=2000m
+CUDA_DEVICE_SM_LIMIT=30
+CUDA_DEVICE_MEMORY_SHARED_CACHE=/tmp/vgpu/6446d246-5917-419d-bdc3-1a119044f857.cache
+```
+
+The first two values match the requested 2000 MiB memory and 30% compute limits.
+
+Inspect the GPU view inside the container:
+
+```bash
+kubectl exec -n volcano-demo volcano-vgpu-single -- nvidia-smi
+```
+
+Relevant captured output:
+
+```text
+[HAMI-core Msg(...:libvgpu.c:870)]: Initializing.....
+|   0  NVIDIA GeForce RTX 3070 Ti ... |       0MiB /   2000MiB |      0%      Default |
+```
+
+The HAMi-core initialization message and the 2000 MiB total show that the vGPU settings reached the container and changed its GPU view.
+
+:::note Scope of this proof
+
+This step proves allocation and limit injection. It does not run a CUDA allocator past the limit, so it does not independently prove the OOM enforcement boundary. See Lab 3 or Lab 7 for that stronger isolation test.
+
+:::
+
+Delete the Pod before the Gang tests so it does not consume part of the memory baseline:
+
+```bash
+kubectl delete pod volcano-vgpu-single -n volcano-demo
+```
+
+## Step 5: Run a Two-Worker Gang
+
+The successful VolcanoJob creates two workers. Each requests one vGPU share, 2000 MiB, and 30% cores. The complete Gang therefore needs 4000 MiB and 60% cores.
+
+The two fields that create the Gang contract are:
+
+```yaml
+spec:
+  schedulerName: volcano
+  queue: default
+  minAvailable: 2
+  tasks:
+    - name: vgpu-worker
+      replicas: 2
+```
+
+Create the Job:
+
+```bash
+kubectl apply -f tutorials/labs/examples/08-volcano-vgpu/02-gang-job.yaml
+```
+
+Inspect the Job, generated PodGroup, and Pods:
+
+```bash
+kubectl get vcjob,podgroup,pod -n volcano-demo
+```
+
+Captured output:
+
+```text
+NAME                                      STATUS    MINAVAILABLE   RUNNINGS
+job.batch.volcano.sh/vcjob-vgpu-gang     Running   2              2
+
+NAME                                                        STATUS    MINMEMBER   RUNNINGS
+podgroup.scheduling.volcano.sh/vcjob-vgpu-gang-...          Running   2           2
+
+NAME                                    READY   STATUS
+pod/vcjob-vgpu-gang-vgpu-worker-0       1/1     Running
+pod/vcjob-vgpu-gang-vgpu-worker-1       1/1     Running
+```
+
+`MINAVAILABLE=2`, `RUNNINGS=2`, and both workers in `Running` show that the complete Gang fit and was admitted.
+
+Check one worker's GPU view:
+
+```bash
+kubectl exec -n volcano-demo vcjob-vgpu-gang-vgpu-worker-0 -- nvidia-smi
+```
+
+The captured worker output again reported a 2000 MiB GPU slice and HAMi-core initialization.
+
+Delete the successful Job before creating the insufficient case:
+
+```bash
+kubectl delete vcjob vcjob-vgpu-gang -n volcano-demo
+kubectl wait -n volcano-demo --for=delete pod \
+  -l volcano.sh/job-name=vcjob-vgpu-gang --timeout=120s || true
+```
+
+## Step 6: Prove Gang Scheduling Blocks a Partial Start
+
+The next Job still needs two workers, but each asks for 6000 MiB. On an empty 8 GiB node, one worker can fit and two workers cannot:
+
+```text
+one worker:   6000 MiB <= 8192 MiB
+full Gang:   12000 MiB > 8192 MiB
+```
+
+Create it:
+
+```bash
+kubectl apply -f tutorials/labs/examples/08-volcano-vgpu/03-gang-insufficient.yaml
+sleep 15
+kubectl get vcjob,podgroup,pod -n volcano-demo
+```
+
+The generated PodGroup should remain `Inqueue` and both Pods should remain `Pending`.
+
+Get the PodGroup name and inspect its conditions:
+
+```bash
+export PG_NAME=$(kubectl get podgroup -n volcano-demo \
+  -o jsonpath='{.items[0].metadata.name}')
+
+kubectl describe podgroup "${PG_NAME}" -n volcano-demo
+```
+
+Relevant captured condition:
+
+```text
+Message: 1/2 tasks in gang unschedulable: pod group is not ready,
+         2 Pending, 2 minAvailable; Pending: 1 Schedulable, 1 Unschedulable
+Reason:  NotEnoughResources
+Type:    Unschedulable
+Phase:   Inqueue
+```
+
+The key evidence is `1 Schedulable, 1 Unschedulable` together with `minAvailable: 2`: Volcano could place one worker in isolation, but it did not partially start the Job because the whole two-member Gang could not fit.
+
+Delete the negative case before testing Queue capability:
+
+```bash
+kubectl delete vcjob vcjob-vgpu-gang-insufficient -n volcano-demo
+```
+
+Confirm that no lab Pod is still holding vGPU resources:
+
+```bash
+kubectl get pods -n volcano-demo
+```
+
+## Step 7: Enforce a Queue-Level vGPU Limit
+
+This step deliberately separates Queue capacity from node capacity. The node must be empty before you begin.
+
+Create a Queue capped at two vGPU shares, 4000 MiB, and 60% cores:
+
+```bash
+kubectl apply -f tutorials/labs/examples/08-volcano-vgpu/04-queue.yaml
+kubectl get queue gpu-small-queue -o yaml
+```
+
+The relevant capability is:
+
+```yaml
+capability:
+  volcano.sh/vgpu-number: "2"
+  volcano.sh/vgpu-memory: "4000"
+  volcano.sh/vgpu-cores: "60"
+```
+
+Queue `capability` is a hard upper bound for total resource use by Jobs in the Queue. It does not allocate a GPU by itself; each worker still needs its own `resources.limits`.
+
+### A Job Within the Queue Capability
+
+The fit Job requests two workers at 1000 MiB and 30% cores each, for a total of 2000 MiB and 60% cores:
+
+```bash
+kubectl apply -f tutorials/labs/examples/08-volcano-vgpu/05-queue-fit-job.yaml
+kubectl get vcjob,podgroup,pod -n volcano-demo
+```
+
+Both workers should reach `Running` because the total request does not exceed the Queue capability.
+
+Delete the fit Job and wait for its resources to be released:
+
+```bash
+kubectl delete vcjob vcjob-vgpu-queue-fit -n volcano-demo
+kubectl wait -n volcano-demo --for=delete pod \
+  -l volcano.sh/job-name=vcjob-vgpu-queue-fit --timeout=120s || true
+```
+
+### A Job Above the Queue Capability
+
+The over-cap Job requests two workers at 3000 MiB each:
+
+```text
+Job total:       6000 MiB
+Queue cap:       4000 MiB
+Empty node:   about 8192 MiB
+```
+
+The Job is small enough for the empty node, but too large for `gpu-small-queue`.
+
+Create it:
+
+```bash
+kubectl apply -f tutorials/labs/examples/08-volcano-vgpu/06-queue-exceeds-job.yaml
+sleep 15
+kubectl get vcjob,podgroup,pod -n volcano-demo
+```
+
+Captured result:
+
+```text
+NAME                                             READY   STATUS
+vcjob-vgpu-queue-exceeds-vgpu-worker-0           0/1     Pending
+vcjob-vgpu-queue-exceeds-vgpu-worker-1           0/1     Pending
+
+NAME                                             STATUS    MINMEMBER
+vcjob-vgpu-queue-exceeds-...                     Inqueue   2
+```
+
+Inspect the PodGroup and Queue:
+
+```bash
+export PG_NAME=$(kubectl get podgroup -n volcano-demo \
+  -o jsonpath='{.items[0].metadata.name}')
+
+kubectl describe podgroup "${PG_NAME}" -n volcano-demo
+kubectl describe queue gpu-small-queue
+```
+
+The PodGroup identifies `gpu-small-queue`, stays `Inqueue`, and reports `NotEnoughResources`. Because all earlier vGPU workloads were deleted and the 6000 MiB Job fits within the node's roughly 8192 MiB capacity, the remaining limiting boundary is the Queue's 4000 MiB capability.
+
+:::tip Adapting this proof to another GPU
+
+Choose values that satisfy `Queue cap < Job total <= currently free node capacity`. If `Job total` is also larger than the free node, the result does not isolate the Queue constraint.
+
+:::
+
+## Troubleshooting
+
+### The node has no `volcano.sh/vgpu-*` resources
+
+Check the plugin Pod, logs, and runtime:
+
+```bash
+kubectl get pods -n kube-system -o wide | grep volcano-device-plugin
+kubectl logs -n kube-system daemonset/volcano-device-plugin --all-containers --tail=200
+kubectl get node "${NODE_NAME}" -o yaml | grep 'volcano.sh/'
+```
+
+Verify that the NVIDIA driver works and that the NVIDIA runtime is the default. Also check that no second GPU device plugin owns the node.
+
+### The Pod is handled by the default scheduler
+
+Confirm the manifest contains:
+
+```yaml
+schedulerName: volcano
+```
+
+Then inspect Pod events:
+
+```bash
+kubectl describe pod -n volcano-demo <pod-name> | sed -n '/Events:/,$p'
+```
+
+### A Gang stays `Inqueue`
+
+`Inqueue` with `NotEnoughResources` is expected in the negative test. Check `minAvailable`, each worker request, current node allocations, and the assigned Queue before treating it as an installation failure.
+
+### The Queue test fails for the wrong reason
+
+Delete all earlier lab Jobs and Pods, then verify the node has enough free vGPU memory for the over-cap Job. The Job must exceed the Queue capability while still fitting the node.
+
+### The container sees the full GPU memory
+
+If `CUDA_DEVICE_MEMORY_LIMIT_0` is missing and `nvidia-smi` shows the full card, HAMi-core was not injected. Check the device-plugin logs and confirm the NVIDIA runtime is the default runtime.
+
+### The resource names do not match
+
+Never infer the names from another tutorial. Read the actual node registration:
+
+```bash
+kubectl get node "${NODE_NAME}" -o yaml | grep 'volcano.sh/'
+```
+
+This lab expects `volcano.sh/vgpu-number`, `volcano.sh/vgpu-memory`, and `volcano.sh/vgpu-cores`.
+
+## Cleanup
+
+Delete the lab workloads, Queue, and namespace:
+
+```bash
+kubectl delete vcjob --all -n volcano-demo --ignore-not-found
+kubectl delete pod --all -n volcano-demo --ignore-not-found
+kubectl delete queue gpu-small-queue --ignore-not-found
+kubectl delete namespace volcano-demo
+```
+
+If this was a dedicated lab cluster, remove the vGPU plugin:
+
+```bash
+kubectl delete -f \
+  https://raw.githubusercontent.com/Project-HAMi/volcano-vgpu-device-plugin/v1.11.0/volcano-vgpu-device-plugin.yml
+```
+
+Restore the scheduler ConfigMap only if the backup belongs to this lab and no other user depends on the vGPU configuration:
+
+```bash
+kubectl apply -f /tmp/volcano-scheduler-configmap.before-vgpu.yaml
+kubectl rollout restart deployment/volcano-scheduler -n volcano-system
+kubectl rollout status deployment/volcano-scheduler -n volcano-system --timeout=120s
+```
+
+## What This Lab Proved
+
+| Claim | Evidence |
+| --- | --- |
+| Volcano registered shareable GPU resources | Node allocatable contained `volcano.sh/vgpu-number`, `vgpu-memory`, and `vgpu-cores` |
+| HAMi-core settings reached the container | Environment contained `CUDA_DEVICE_MEMORY_LIMIT_0=2000m` and `CUDA_DEVICE_SM_LIMIT=30` |
+| The container saw its requested slice | In-container `nvidia-smi` reported 2000 MiB total instead of the full 8 GiB card |
+| A complete two-worker Gang could run | VolcanoJob and PodGroup were `Running`; both workers were `Running` |
+| Volcano avoided a partial Gang start | The 2 × 6000 MiB Job remained `Inqueue`; condition showed `1 Schedulable, 1 Unschedulable` with `minAvailable: 2` |
+| A Queue accepted a Job within its limit | The 2 × 1000 MiB, 60-core Job ran in `gpu-small-queue` |
+| A Queue blocked a Job above its limit | The 6000 MiB Job remained `Pending`/`Inqueue` with an empty 8 GiB node and a 4000 MiB Queue cap |
+
+## Next Steps
+
+- Run [Lab 3: GPU Partitioning](/tutorials/labs/gpu-partitioning) or [Lab 7: k3s Isolation](/tutorials/labs/hami-isolation-k3s) to prove the memory ceiling with an actual CUDA OOM test.
+- Read the [Volcano Gang plugin documentation](https://volcano.sh/docs/scheduler/plugins/gang/) for scheduling semantics beyond a two-worker Job.
+- Read the [Volcano Queue resource management documentation](https://volcano.sh/docs/keyfeatures/queueresourcemanagement/) for `deserved`, `guarantee`, reclaim, and hierarchical Queues.
+- Review the [Volcano vGPU device plugin repository](https://github.com/Project-HAMi/volcano-vgpu-device-plugin) before upgrading; keep the plugin and Volcano versions within the published compatibility matrix.

--- a/tutorials/overview.md
+++ b/tutorials/overview.md
@@ -17,4 +17,4 @@ Background knowledge that the labs build on.
 
 ## Labs
 
-<LabCardGridAuto /> Each lab lists its own prerequisites. Labs 3 and 4 continue from the cluster Lab 1 builds, so a single session covers all three; Lab 2 runs on any laptop with no GPU required. Lab 7 brings up its own single-node k3s cluster on a rented GPU VM, without the GPU Operator.
+<LabCardGridAuto /> Each lab lists its own prerequisites. Labs 3 and 4 continue from the cluster Lab 1 builds, so a single session covers all three; Lab 2 runs on any laptop with no GPU required. Lab 7 brings up its own single-node k3s cluster on a rented GPU VM, without the GPU Operator. Lab 8 requires an existing Volcano GPU cluster and validates Volcano vGPU, Gang scheduling, and queue-level limits.


### PR DESCRIPTION
## What changed

- add Lab 8 for Volcano vGPU on a single NVIDIA GPU
- cover single-Pod allocation, Gang scheduling success and failure, and Queue capability limits
- add six reusable Kubernetes manifests
- add the Chinese translation
- register the lab in the Tutorials sidebar and overview pages

## Why

This turns a community-tested Volcano vGPU walkthrough into a reproducible HAMi hands-on lab with captured outputs, explicit success evidence, cleanup steps, and troubleshooting guidance.

## Important review notes

- the device plugin manifest is pinned to v1.11.0 because the older unversioned root URL now returns 404
- Queue tests clear earlier workloads first so node capacity does not mask the Queue capability result
- the memory-limit evidence is described as injection and container-visible slicing; the lab does not claim an OOM enforcement test

## Validation

- parsed all six Kubernetes YAML files successfully
- parsed English and Chinese frontmatter successfully
- ran the repository Markdown lint rules: 0 errors
- checked English and Chinese heading/code-block parity
- checked `sidebars-tutorials.js` with `node --check`

## AI assistance

Codex helped restructure and translate the author's existing experiment into the HAMi Lab format. This is a Draft PR so the author and maintainers can validate the environment/version details and captured outputs before marking it ready for review.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Advanced Lab 8: Volcano vGPU, Gang scheduling, and queue-level resource limits.
  * Added step-by-step validation for vGPU allocation, GPU limits, successful Gang scheduling, insufficient resources, and queue capacity enforcement.
  * Added executable Kubernetes examples for single workloads, Gang jobs, resource constraints, and queue limits.
  * Updated tutorial overviews and navigation to include the new lab.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->