### PR TITLE
fix: remove em dash in lab 8 device-plugin warning

### DIFF
--- a/tutorials/labs/volcano-vgpu-gang-queue.md
+++ b/tutorials/labs/volcano-vgpu-gang-queue.md
@@ -101,7 +101,7 @@ Volcano Scheduler decides whether and where the workload can run. The device plu
 
 :::warning Device-plugin exclusivity
 
-Do not continue if another component already owns the same GPU node—for example the NVIDIA device plugin, the standard HAMi device plugin, or a second Volcano vGPU device plugin. Multiple plugins can register conflicting resources and make the results impossible to interpret.
+Do not continue if another component already owns the same GPU node, for example the NVIDIA device plugin, the standard HAMi device plugin, or a second Volcano vGPU device plugin. Multiple plugins can register conflicting resources and make the results impossible to interpret.
 
 :::
 


### PR DESCRIPTION
One em dash in the device-plugin exclusivity warning.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified the warning about avoiding multiple GPU device-plugin paths on the same node.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->