### PR TITLE
fix: add missing lab 8 tags to zh tutorials tags.yml

### DIFF
--- a/i18n/zh/docusaurus-plugin-content-docs-tutorials/current/tags.yml
+++ b/i18n/zh/docusaurus-plugin-content-docs-tutorials/current/tags.yml
@@ -7,6 +7,9 @@
 "alibaba-cloud":
   label: "alibaba-cloud"
   permalink: "/alibaba-cloud"
+"gang-scheduling":
+  label: "gang-scheduling"
+  permalink: "/gang-scheduling"
 "hami":
   label: "hami"
   permalink: "/hami"
@@ -22,9 +25,18 @@
 "nvml-mock":
   label: "nvml-mock"
   permalink: "/nvml-mock"
+"queue":
+  label: "queue"
+  permalink: "/queue"
+"vgpu":
+  label: "vgpu"
+  permalink: "/vgpu"
 "vllm":
   label: "vllm"
   permalink: "/vllm"
+"volcano":
+  label: "volcano"
+  permalink: "/volcano"
 "安装":
   label: "安装"
   permalink: "/installation"


### PR DESCRIPTION
Lab 8 uses tags volcano, vgpu, gang-scheduling, queue, none were listed in the zh tags.yml, causing 4 build warnings.
