### PR TITLE
fix: remove duplicate canonical and description meta tags

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -125,21 +125,6 @@ module.exports = {
         "window.dataLayer=window.dataLayer||[];if(typeof window.gtag!=='function'){window.gtag=function(){window.dataLayer.push(arguments);};}",
     },
     {
-      tagName: "meta",
-      attributes: {
-        name: "description",
-        content:
-          "HAMi is an open-source Kubernetes-native virtualization middleware for heterogeneous AI accelerators.",
-      },
-    },
-    {
-      tagName: "link",
-      attributes: {
-        rel: "canonical",
-        href: `${siteUrl}/`,
-      },
-    },
-    {
       tagName: "link",
       attributes: {
         rel: "apple-touch-icon",


### PR DESCRIPTION
docusaurus.config.js had a hardcoded canonical link and description meta tag in headTags, on top of the ones Docusaurus already generates per page. Every inner page ended up with 2 canonical tags and 2 description tags, and the hardcoded canonical always pointed at the homepage, wrong for every other page. Removed the hardcoded ones, kept the real per page tags.