### PR TITLE
fix: add page description to community page

### DIFF
--- a/src/pages/community.js
+++ b/src/pages/community.js
@@ -198,7 +198,14 @@ export default function CommunityPage() {
     },
   ];
   return (
-    <Layout title={isZh ? "HAMi 社区" : "HAMi Community"}>
+    <Layout
+      title={isZh ? "HAMi 社区" : "HAMi Community"}
+      description={
+        isZh
+          ? "参与 HAMi 开源社区，通过讨论、会议和贡献推动异构 AI 基础设施的发展。"
+          : "Join the HAMi open-source community and advance heterogeneous AI infrastructure through discussions, meetings, and contributions."
+      }
+    >
       <main className={styles.page}>
         <section className={styles.hero}>
           <div className="container">


### PR DESCRIPTION
Community page had no description prop, unlike the homepage and case-studies page, so it fell back to the generic site description. Used the existing subtitle text for both locales.