### PR TITLE
fix: retry linkinator on crash without JSON output

### DIFF
--- a/scripts/check-links.sh
+++ b/scripts/check-links.sh
@@ -175,18 +175,31 @@ curl -fsS "${root_url}/" >/dev/null 2>&1 || {
 
 mapfile -t skip_args < "${tmpdir}/skip-args.txt"
 
-set +e
+run_linkinator() {
+  node "${linkinator_cli}" "${root_url}" \
+    --recurse \
+    --concurrency 10 \
+    --retry-errors \
+    --retry-errors-count 2 \
+    --verbosity none \
+    --format json \
+    "${skip_args[@]}" > "${tmpdir}/linkinator.json" 2> "${tmpdir}/linkinator.stderr"
+}
+
 # The human-readable formatter can fail without surfacing the offender URL under Node 20.
 # Use the direct CLI + JSON path and print our own summary instead.
-node "${linkinator_cli}" "${root_url}" \
-  --recurse \
-  --concurrency 10 \
-  --retry-errors \
-  --retry-errors-count 2 \
-  --verbosity none \
-  --format json \
-  "${skip_args[@]}" > "${tmpdir}/linkinator.json" 2> "${tmpdir}/linkinator.stderr"
-linkinator_exit=$?
+set +e
+for attempt in 1 2 3; do
+  run_linkinator
+  linkinator_exit=$?
+  # linkinator can crash before writing any JSON (e.g. an unsettled top-level await
+  # in its own CLI). That crash is unrelated to real links, so retry a few times
+  # instead of failing the whole check on tool flakiness.
+  if [[ "${linkinator_exit}" -eq 0 ]] || [[ -s "${tmpdir}/linkinator.json" ]]; then
+    break
+  fi
+  echo "Linkinator produced no output on attempt ${attempt}, retrying..."
+done
 set -e
 
 if [[ "${linkinator_exit}" -ne 0 ]]; then


### PR DESCRIPTION
Linkinator sometimes crashes with an unsettled top-level await before writing any output, exit code 13, no actual broken links. Reproduced this locally multiple times, same content passes most runs and fails others with zero real link problems. Now retries up to 3 times when linkinator produces no JSON output, only fails for real when it actually reports something.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved link checking reliability by retrying failed or incomplete checks up to three times.
  * Preserved existing error reporting and summary behavior when link validation ultimately fails.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->