### PR TITLE
fix: drop leftover jekyll frontmatter keys in zh blog post

### DIFF
--- a/i18n/zh/docusaurus-plugin-content-blog/2024-12-31-post/index.md
+++ b/i18n/zh/docusaurus-plugin-content-blog/2024-12-31-post/index.md
@@ -1,8 +1,6 @@
 ---
-layout: post
 title: HAMi 项目 GPU Pod 调度流程源码走读
 slug: hami-gpu-scheduling-source-code
-catalog: true
 tags: [Kubernetes, GPU, AI, Source Code, 调度]
 authors: [elrond_wang]
 ---


### PR DESCRIPTION
layout: post and catalog: true in the zh translation of the GPU pod scheduling walkthrough post are Jekyll frontmatter keys, not used by Docusaurus, and are absent from the English source.