### PR TITLE
docs: fix check:all description in contributing guide

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -78,7 +78,7 @@ npm run build:fast
 npm run check:all
 ```
 
-This runs lint → format check → build in sequence.
+This runs lint, format check, build, and link check in sequence.
 
 ## CI
 


### PR DESCRIPTION
npm run check:all runs lint, format:check, and check-links (which itself builds the site and checks links), so describing it as just lint, format check, build in sequence leaves out the actual link check step.