### PR TITLE
fix: remove em dashes from zh v2.9.0 versioned docs

### DIFF
--- a/i18n/zh/docusaurus-plugin-content-docs/version-v2.9.0/contributor/contribute-docs.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/version-v2.9.0/contributor/contribute-docs.md
@@ -59,7 +59,7 @@ website
 
 `docs/` 目录是**未发布的开发版**（托管在 `/docs/next/*`），**不是**「当前/最新稳定版本」。最新稳定版本是 `versions.json` 的第一项（如 v2.9.0），托管在 `/docs`。
 
-`current` 是 Docusaurus 对这个开发版目录的内部约定名（`CURRENT_VERSION_NAME`），标签显示为「Next / 下一个」，容易和「当前稳定版」混淆——它们是两个不同的东西。
+`current` 是 Docusaurus 对这个开发版目录的内部约定名（`CURRENT_VERSION_NAME`），标签显示为「Next / 下一个」，容易和「当前稳定版」混淆，它们是两个不同的东西。
 
 贡献者主要编辑 `docs/`，为下一个版本贡献文档。
 

--- a/i18n/zh/docusaurus-plugin-content-docs/version-v2.9.0/diagrams-inventory.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/version-v2.9.0/diagrams-inventory.md
@@ -5,7 +5,7 @@ translated: true
 
 本页面编目了仓库中的所有图表：`docs/`、`blog/`、`i18n/`、`versioned_docs/` 和 `static/`。它是 [#421](https://github.com/Project-HAMi/website/issues/421) 中跟踪的图表重绘工作的输入依据。
 
-**范围说明：** 博客中的活动照片（KubeCon 展位照、主题演讲照片、演讲者照片）被排除在外——它们是照片，而非技术图表。此处仅列出了传达架构、流程或系统行为的图片。
+**范围说明：** 博客中的活动照片（KubeCon 展位照、主题演讲照片、演讲者照片）被排除在外，它们是照片，而非技术图表。此处仅列出了传达架构、流程或系统行为的图片。
 
 ---
 
@@ -75,7 +75,7 @@ translated: true
 | `static/img/docs/common/developers/protocol/device-registration.png` | PNG | `i18n/zh/.../developers/protocol.md`（仅中文） | none | unknown | not separated |
 | `static/img/docs/common/developers/protocol/task-dispatch.png` | PNG | `i18n/zh/.../developers/protocol.md`（仅中文） | none | unknown | not separated |
 
-**发现的不一致：** 英文版 `docs/developers/protocol.md` 仅引用了 `protocol-register.png`。中文版引用了 `device-registration.png` 和 `task-dispatch.png`——这是两个不同的文件，它们并未出现在英文文档中。英文文档似乎缺少了任务分派图。这一不一致必须在重绘之前解决。
+**发现的不一致：** 英文版 `docs/developers/protocol.md` 仅引用了 `protocol-register.png`。中文版引用了 `device-registration.png` 和 `task-dispatch.png`：这是两个不同的文件，它们并未出现在英文文档中。英文文档似乎缺少了任务分派图。这一不一致必须在重绘之前解决。
 
 ---
 

--- a/i18n/zh/docusaurus-plugin-content-docs/version-v2.9.0/faq/faq.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/version-v2.9.0/faq/faq.md
@@ -211,7 +211,7 @@ HAMi 作为 [scheduler extender](https://github.com/kubernetes/design-proposals-
 
 ## HAMi 是否兼容 NVIDIA GPU Operator 和 DCGM 指标？
 
-HAMi 的设备插件和 GPU Operator 的设备插件都向 kubelet 上报 `nvidia.com/gpu`——在同一节点上同时运行会导致冲突。需禁用 GPU Operator 的设备插件：
+HAMi 的设备插件和 GPU Operator 的设备插件都向 kubelet 上报 `nvidia.com/gpu`，在同一节点上同时运行会导致冲突。需禁用 GPU Operator 的设备插件：
 
 ```yaml
 devicePlugin:

--- a/i18n/zh/docusaurus-plugin-content-docs/version-v2.9.0/troubleshooting/troubleshooting.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/version-v2.9.0/troubleshooting/troubleshooting.md
@@ -7,10 +7,10 @@ translated: true
 
 如果容器超过了 `nvidia.com/gpumem` 限制，请检查以下原因：
 
-- **设置了 `CUDA_DISABLE_CONTROL=true`** — 完全禁用 HAMi-core 的限制功能。请从生产工作负载中移除该设置。
-- **Docker-in-Docker (DinD)** — 内层容器不会继承 `/etc/ld.so.preload` hostPath 挂载。HAMi 的限制在 DinD 内部不生效。
-- **直接调用驱动 API** — 直接调用 NVML 或 CUDA Driver API 的工作负载会绕过 `libvgpu.so`。
-- **`nvidia-container-runtime` 未设为默认运行时** — 使用以下命令验证：
+- **设置了 `CUDA_DISABLE_CONTROL=true`**：完全禁用 HAMi-core 的限制功能。请从生产工作负载中移除该设置。
+- **Docker-in-Docker (DinD)**：内层容器不会继承 `/etc/ld.so.preload` hostPath 挂载。HAMi 的限制在 DinD 内部不生效。
+- **直接调用驱动 API**：直接调用 NVML 或 CUDA Driver API 的工作负载会绕过 `libvgpu.so`。
+- **`nvidia-container-runtime` 未设为默认运行时**：使用以下命令验证：
 
   ```bash
   containerd config dump | grep default_runtime_name


### PR DESCRIPTION
Removes leftover em dashes from diagrams-inventory.md, faq.md, troubleshooting.md and contribute-docs.md in the zh version-v2.9.0 versioned docs tree, replaced with commas or colons depending on context. The current docs tree got the same fix in a separate PR; the troubleshooting.md fix here matches the wording already applied to the current tree in a prior commit.