### PR TITLE
docs: add language specifiers to profiling-scheduler code fences

### DIFF
--- a/docs/developers/profiling-scheduler.md
+++ b/docs/developers/profiling-scheduler.md
@@ -54,7 +54,7 @@ go tool pprof --seconds 120 https+insecure://<POD_IP>/debug/pprof/profile
 
 Example output:
 
-```
+```bash
 root@hami-pprof-76cfcb66f6-jpjnm:/# go tool pprof --seconds 120 https+insecure://10.42.0.24/debug/pprof/profile
 Fetching profile over HTTP from https+insecure://10.42.0.24/debug/pprof/profile?seconds=120
 Please wait... (2m0s)
@@ -98,7 +98,7 @@ go tool pprof https+insecure://<POD_IP>/debug/pprof/allocs
 
 Example output from the allocation profile:
 
-```
+```bash
 root@hami-scheduler-ffd687cb7-7gqm2:/# /usr/local/go/bin/go tool pprof --seconds 120 https+insecure://10.42.0.24/debug/pprof/allocs
 Fetching profile over HTTP from https+insecure://10.42.0.24/debug/pprof/allocs?seconds=120
 Saved profile in /root/pprof/pprof.scheduler.alloc_objects.alloc_space.inuse_objects.inuse_space.041.pb.gz

--- a/i18n/zh/docusaurus-plugin-content-docs/current/developers/profiling-scheduler.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/current/developers/profiling-scheduler.md
@@ -68,7 +68,7 @@ go tool pprof https+insecure://<POD_IP>/debug/pprof/allocs
 
 分配性能分析的示例输出：
 
-```
+```bash
 root@hami-scheduler-ffd687cb7-7gqm2:/# /usr/local/go/bin/go tool pprof --seconds 120 https+insecure://10.42.0.24/debug/pprof/allocs
 Fetching profile over HTTP from https+insecure://10.42.0.24/debug/pprof/allocs?seconds=120
 Saved profile in /root/pprof/pprof.scheduler.alloc_objects.alloc_space.inuse_objects.inuse_space.041.pb.gz

--- a/versioned_docs/version-v2.9.0/developers/profiling-scheduler.md
+++ b/versioned_docs/version-v2.9.0/developers/profiling-scheduler.md
@@ -54,7 +54,7 @@ go tool pprof --seconds 120 https+insecure://<POD_IP>/debug/pprof/profile
 
 Example output:
 
-```
+```bash
 root@hami-pprof-76cfcb66f6-jpjnm:/# go tool pprof --seconds 120 https+insecure://10.42.0.24/debug/pprof/profile
 Fetching profile over HTTP from https+insecure://10.42.0.24/debug/pprof/profile?seconds=120
 Please wait... (2m0s)
@@ -98,7 +98,7 @@ go tool pprof https+insecure://<POD_IP>/debug/pprof/allocs
 
 Example output from the allocation profile:
 
-```
+```bash
 root@hami-scheduler-ffd687cb7-7gqm2:/# /usr/local/go/bin/go tool pprof --seconds 120 https+insecure://10.42.0.24/debug/pprof/allocs
 Fetching profile over HTTP from https+insecure://10.42.0.24/debug/pprof/allocs?seconds=120
 Saved profile in /root/pprof/pprof.scheduler.alloc_objects.alloc_space.inuse_objects.inuse_space.041.pb.gz


### PR DESCRIPTION
Adds bash to the pprof command output blocks in profiling-scheduler.md, across docs, the v2.9.0 versioned copy, and the zh current translation. The zh v2.9.0 copy already had language tags on every fence.