### PR TITLE
docs: add language specifier to gpu-topology-scheduling code fence

### DIFF
--- a/docs/developers/gpu-topology-scheduling.md
+++ b/docs/developers/gpu-topology-scheduling.md
@@ -38,7 +38,7 @@ metadata:
 
 After submitting the Pod, check the logs of `hami-scheduler` (log level must be greater than 5):
 
-```
+```plaintext
 I0703 08:34:27.032644  1 device.go:708] "device allocate success" pod="default/testpod" best device combination={"NVIDIA":[{"Idx":7,"UUID":"GPU-dsaf","Type":"NVIDIA","Usedmem":1024,"Usedcores":0},{"Idx":5,"UUID":"GPU-gads","Type":"NVIDIA","Usedmem":1024,"Usedcores":0}]}
 ```
 

--- a/i18n/zh/docusaurus-plugin-content-docs/current/developers/gpu-topology-scheduling.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/current/developers/gpu-topology-scheduling.md
@@ -38,7 +38,7 @@ metadata:
 
 提交 Pod 后，检查 `hami-scheduler` 的日志（日志级别需大于 5）：
 
-```
+```plaintext
 I0703 08:34:27.032644  1 device.go:708] "device allocate success" pod="default/testpod" best device combination={"NVIDIA":[{"Idx":7,"UUID":"GPU-dsaf","Type":"NVIDIA","Usedmem":1024,"Usedcores":0},{"Idx":5,"UUID":"GPU-gads","Type":"NVIDIA","Usedmem":1024,"Usedcores":0}]}
 ```
 

--- a/i18n/zh/docusaurus-plugin-content-docs/version-v2.9.0/developers/gpu-topology-scheduling.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/version-v2.9.0/developers/gpu-topology-scheduling.md
@@ -38,7 +38,7 @@ metadata:
 
 提交 Pod 后，检查 `hami-scheduler` 的日志（日志级别需大于 5）：
 
-```
+```plaintext
 I0703 08:34:27.032644  1 device.go:708] "device allocate success" pod="default/testpod" best device combination={"NVIDIA":[{"Idx":7,"UUID":"GPU-dsaf","Type":"NVIDIA","Usedmem":1024,"Usedcores":0},{"Idx":5,"UUID":"GPU-gads","Type":"NVIDIA","Usedmem":1024,"Usedcores":0}]}
 ```
 

--- a/versioned_docs/version-v2.9.0/developers/gpu-topology-scheduling.md
+++ b/versioned_docs/version-v2.9.0/developers/gpu-topology-scheduling.md
@@ -38,7 +38,7 @@ metadata:
 
 After submitting the Pod, check the logs of `hami-scheduler` (log level must be greater than 5):
 
-```
+```plaintext
 I0703 08:34:27.032644  1 device.go:708] "device allocate success" pod="default/testpod" best device combination={"NVIDIA":[{"Idx":7,"UUID":"GPU-dsaf","Type":"NVIDIA","Usedmem":1024,"Usedcores":0},{"Idx":5,"UUID":"GPU-gads","Type":"NVIDIA","Usedmem":1024,"Usedcores":0}]}
 ```
 


### PR DESCRIPTION
Adds plaintext to the scheduler log output block in gpu-topology-scheduling.md, across docs, the v2.9.0 versioned copy, and both zh translations.