### PR TITLE
fix: correct Helm template syntax in dynamic-mig documentation

### DIFF
--- a/docs/userguide/nvidia-device/dynamic-mig-support.md
+++ b/docs/userguide/nvidia-device/dynamic-mig-support.md
@@ -57,21 +57,22 @@ You can customize the MIG configuration by following the steps below:
 
 ### Edit `device-configmap.yaml` in charts/hami/templates/scheduler
 
+<!-- prettier-ignore -->
 ```yaml
 nvidia:
-  resourceCountName: { { .Values.resourceName } }
-  resourceMemoryName: { { .Values.resourceMem } }
-  resourceMemoryPercentageName: { { .Values.resourceMemPercentage } }
-  resourceCoreName: { { .Values.resourceCores } }
-  resourcePriorityName: { { .Values.resourcePriority } }
+  resourceCountName: {{ .Values.resourceName }}
+  resourceMemoryName: {{ .Values.resourceMem }}
+  resourceMemoryPercentageName: {{ .Values.resourceMemPercentage }}
+  resourceCoreName: {{ .Values.resourceCores }}
+  resourcePriorityName: {{ .Values.resourcePriority }}
   overwriteEnv: false
   defaultMemory: 0
   defaultCores: 0
   defaultGPUNum: 1
   memoryFactor: 1
-  deviceSplitCount: { { .Values.devicePlugin.deviceSplitCount } }
-  deviceMemoryScaling: { { .Values.devicePlugin.deviceMemoryScaling } }
-  deviceCoreScaling: { { .Values.devicePlugin.deviceCoreScaling } }
+  deviceSplitCount: {{ .Values.devicePlugin.deviceSplitCount }}
+  deviceMemoryScaling: {{ .Values.devicePlugin.deviceMemoryScaling }}
+  deviceCoreScaling: {{ .Values.devicePlugin.deviceCoreScaling }}
   knownMigGeometries:
     - models: ["A30"]
       allowedGeometries:

--- a/i18n/zh/docusaurus-plugin-content-docs/current/userguide/nvidia-device/dynamic-mig-support.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/current/userguide/nvidia-device/dynamic-mig-support.md
@@ -60,21 +60,22 @@ HAMi 目前有一个 [内置的 MIG 配置](https://github.com/Project-HAMi/HAMi
 
 ### 更改 charts/hami/templates/scheduler 中 'device-configmap.yaml'
 
+<!-- prettier-ignore -->
 ```yaml
 nvidia:
-  resourceCountName: { { .Values.resourceName } }
-  resourceMemoryName: { { .Values.resourceMem } }
-  resourceMemoryPercentageName: { { .Values.resourceMemPercentage } }
-  resourceCoreName: { { .Values.resourceCores } }
-  resourcePriorityName: { { .Values.resourcePriority } }
+  resourceCountName: {{ .Values.resourceName }}
+  resourceMemoryName: {{ .Values.resourceMem }}
+  resourceMemoryPercentageName: {{ .Values.resourceMemPercentage }}
+  resourceCoreName: {{ .Values.resourceCores }}
+  resourcePriorityName: {{ .Values.resourcePriority }}
   overwriteEnv: false
   defaultMemory: 0
   defaultCores: 0
   defaultGPUNum: 1
   memoryFactor: 1
-  deviceSplitCount: { { .Values.devicePlugin.deviceSplitCount } }
-  deviceMemoryScaling: { { .Values.devicePlugin.deviceMemoryScaling } }
-  deviceCoreScaling: { { .Values.devicePlugin.deviceCoreScaling } }
+  deviceSplitCount: {{ .Values.devicePlugin.deviceSplitCount }}
+  deviceMemoryScaling: {{ .Values.devicePlugin.deviceMemoryScaling }}
+  deviceCoreScaling: {{ .Values.devicePlugin.deviceCoreScaling }}
   knownMigGeometries:
     - models: ["A30"]
       allowedGeometries:

--- a/i18n/zh/docusaurus-plugin-content-docs/version-v2.5.0/userguide/nvidia-device/dynamic-mig-support.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/version-v2.5.0/userguide/nvidia-device/dynamic-mig-support.md
@@ -61,20 +61,21 @@ HAMi 目前有一个[内置的 MIG 配置](https://github.com/Project-HAMi/HAMi/
 
 ### 更改 charts/hami/templates/scheduler 中 'device-configmap.yaml'
 
+<!-- prettier-ignore -->
 ```yaml
 nvidia:
-  resourceCountName: { { .Values.resourceName } }
-  resourceMemoryName: { { .Values.resourceMem } }
-  resourceMemoryPercentageName: { { .Values.resourceMemPercentage } }
-  resourceCoreName: { { .Values.resourceCores } }
-  resourcePriorityName: { { .Values.resourcePriority } }
+  resourceCountName: {{ .Values.resourceName }}
+  resourceMemoryName: {{ .Values.resourceMem }}
+  resourceMemoryPercentageName: {{ .Values.resourceMemPercentage }}
+  resourceCoreName: {{ .Values.resourceCores }}
+  resourcePriorityName: {{ .Values.resourcePriority }}
   overwriteEnv: false
   defaultMemory: 0
   defaultCores: 0
   defaultGPUNum: 1
-  deviceSplitCount: { { .Values.devicePlugin.deviceSplitCount } }
-  deviceMemoryScaling: { { .Values.devicePlugin.deviceMemoryScaling } }
-  deviceCoreScaling: { { .Values.devicePlugin.deviceCoreScaling } }
+  deviceSplitCount: {{ .Values.devicePlugin.deviceSplitCount }}
+  deviceMemoryScaling: {{ .Values.devicePlugin.deviceMemoryScaling }}
+  deviceCoreScaling: {{ .Values.devicePlugin.deviceCoreScaling }}
   knownMigGeometries:
     - models: ["A30"]
       allowedGeometries:

--- a/i18n/zh/docusaurus-plugin-content-docs/version-v2.9.0/userguide/nvidia-device/dynamic-mig-support.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/version-v2.9.0/userguide/nvidia-device/dynamic-mig-support.md
@@ -60,21 +60,22 @@ HAMi 目前有一个 [内置的 MIG 配置](https://github.com/Project-HAMi/HAMi
 
 ### 更改 charts/hami/templates/scheduler 中 'device-configmap.yaml'
 
+<!-- prettier-ignore -->
 ```yaml
 nvidia:
-  resourceCountName: { { .Values.resourceName } }
-  resourceMemoryName: { { .Values.resourceMem } }
-  resourceMemoryPercentageName: { { .Values.resourceMemPercentage } }
-  resourceCoreName: { { .Values.resourceCores } }
-  resourcePriorityName: { { .Values.resourcePriority } }
+  resourceCountName: {{ .Values.resourceName }}
+  resourceMemoryName: {{ .Values.resourceMem }}
+  resourceMemoryPercentageName: {{ .Values.resourceMemPercentage }}
+  resourceCoreName: {{ .Values.resourceCores }}
+  resourcePriorityName: {{ .Values.resourcePriority }}
   overwriteEnv: false
   defaultMemory: 0
   defaultCores: 0
   defaultGPUNum: 1
   memoryFactor: 1
-  deviceSplitCount: { { .Values.devicePlugin.deviceSplitCount } }
-  deviceMemoryScaling: { { .Values.devicePlugin.deviceMemoryScaling } }
-  deviceCoreScaling: { { .Values.devicePlugin.deviceCoreScaling } }
+  deviceSplitCount: {{ .Values.devicePlugin.deviceSplitCount }}
+  deviceMemoryScaling: {{ .Values.devicePlugin.deviceMemoryScaling }}
+  deviceCoreScaling: {{ .Values.devicePlugin.deviceCoreScaling }}
   knownMigGeometries:
     - models: ["A30"]
       allowedGeometries:

--- a/versioned_docs/version-v2.5.1/userguide/nvidia-device/dynamic-mig-support.md
+++ b/versioned_docs/version-v2.5.1/userguide/nvidia-device/dynamic-mig-support.md
@@ -62,20 +62,21 @@ You can customize the MIG configuration by following the steps below:
 
 ### Edit `device-configmap.yaml` in charts/hami/templates/scheduler
 
+<!-- prettier-ignore -->
 ```yaml
 nvidia:
-  resourceCountName: { { .Values.resourceName } }
-  resourceMemoryName: { { .Values.resourceMem } }
-  resourceMemoryPercentageName: { { .Values.resourceMemPercentage } }
-  resourceCoreName: { { .Values.resourceCores } }
-  resourcePriorityName: { { .Values.resourcePriority } }
+  resourceCountName: {{ .Values.resourceName }}
+  resourceMemoryName: {{ .Values.resourceMem }}
+  resourceMemoryPercentageName: {{ .Values.resourceMemPercentage }}
+  resourceCoreName: {{ .Values.resourceCores }}
+  resourcePriorityName: {{ .Values.resourcePriority }}
   overwriteEnv: false
   defaultMemory: 0
   defaultCores: 0
   defaultGPUNum: 1
-  deviceSplitCount: { { .Values.devicePlugin.deviceSplitCount } }
-  deviceMemoryScaling: { { .Values.devicePlugin.deviceMemoryScaling } }
-  deviceCoreScaling: { { .Values.devicePlugin.deviceCoreScaling } }
+  deviceSplitCount: {{ .Values.devicePlugin.deviceSplitCount }}
+  deviceMemoryScaling: {{ .Values.devicePlugin.deviceMemoryScaling }}
+  deviceCoreScaling: {{ .Values.devicePlugin.deviceCoreScaling }}
   knownMigGeometries:
     - models: ["A30"]
       allowedGeometries:

--- a/versioned_docs/version-v2.6.0/userguide/nvidia-device/dynamic-mig-support.md
+++ b/versioned_docs/version-v2.6.0/userguide/nvidia-device/dynamic-mig-support.md
@@ -62,20 +62,21 @@ You can customize the MIG configuration by following the steps below:
 
 ### Edit `device-configmap.yaml` in charts/hami/templates/scheduler
 
+<!-- prettier-ignore -->
 ```yaml
 nvidia:
-  resourceCountName: { { .Values.resourceName } }
-  resourceMemoryName: { { .Values.resourceMem } }
-  resourceMemoryPercentageName: { { .Values.resourceMemPercentage } }
-  resourceCoreName: { { .Values.resourceCores } }
-  resourcePriorityName: { { .Values.resourcePriority } }
+  resourceCountName: {{ .Values.resourceName }}
+  resourceMemoryName: {{ .Values.resourceMem }}
+  resourceMemoryPercentageName: {{ .Values.resourceMemPercentage }}
+  resourceCoreName: {{ .Values.resourceCores }}
+  resourcePriorityName: {{ .Values.resourcePriority }}
   overwriteEnv: false
   defaultMemory: 0
   defaultCores: 0
   defaultGPUNum: 1
-  deviceSplitCount: { { .Values.devicePlugin.deviceSplitCount } }
-  deviceMemoryScaling: { { .Values.devicePlugin.deviceMemoryScaling } }
-  deviceCoreScaling: { { .Values.devicePlugin.deviceCoreScaling } }
+  deviceSplitCount: {{ .Values.devicePlugin.deviceSplitCount }}
+  deviceMemoryScaling: {{ .Values.devicePlugin.deviceMemoryScaling }}
+  deviceCoreScaling: {{ .Values.devicePlugin.deviceCoreScaling }}
   knownMigGeometries:
     - models: ["A30"]
       allowedGeometries:

--- a/versioned_docs/version-v2.7.0/userguide/nvidia-device/dynamic-mig-support.md
+++ b/versioned_docs/version-v2.7.0/userguide/nvidia-device/dynamic-mig-support.md
@@ -62,20 +62,21 @@ You can customize the MIG configuration by following the steps below:
 
 ### Edit `device-configmap.yaml` in charts/hami/templates/scheduler
 
+<!-- prettier-ignore -->
 ```yaml
 nvidia:
-  resourceCountName: { { .Values.resourceName } }
-  resourceMemoryName: { { .Values.resourceMem } }
-  resourceMemoryPercentageName: { { .Values.resourceMemPercentage } }
-  resourceCoreName: { { .Values.resourceCores } }
-  resourcePriorityName: { { .Values.resourcePriority } }
+  resourceCountName: {{ .Values.resourceName }}
+  resourceMemoryName: {{ .Values.resourceMem }}
+  resourceMemoryPercentageName: {{ .Values.resourceMemPercentage }}
+  resourceCoreName: {{ .Values.resourceCores }}
+  resourcePriorityName: {{ .Values.resourcePriority }}
   overwriteEnv: false
   defaultMemory: 0
   defaultCores: 0
   defaultGPUNum: 1
-  deviceSplitCount: { { .Values.devicePlugin.deviceSplitCount } }
-  deviceMemoryScaling: { { .Values.devicePlugin.deviceMemoryScaling } }
-  deviceCoreScaling: { { .Values.devicePlugin.deviceCoreScaling } }
+  deviceSplitCount: {{ .Values.devicePlugin.deviceSplitCount }}
+  deviceMemoryScaling: {{ .Values.devicePlugin.deviceMemoryScaling }}
+  deviceCoreScaling: {{ .Values.devicePlugin.deviceCoreScaling }}
   knownMigGeometries:
     - models: ["A30"]
       allowedGeometries:

--- a/versioned_docs/version-v2.9.0/userguide/nvidia-device/dynamic-mig-support.md
+++ b/versioned_docs/version-v2.9.0/userguide/nvidia-device/dynamic-mig-support.md
@@ -57,21 +57,22 @@ You can customize the MIG configuration by following the steps below:
 
 ### Edit `device-configmap.yaml` in charts/hami/templates/scheduler
 
+<!-- prettier-ignore -->
 ```yaml
 nvidia:
-  resourceCountName: { { .Values.resourceName } }
-  resourceMemoryName: { { .Values.resourceMem } }
-  resourceMemoryPercentageName: { { .Values.resourceMemPercentage } }
-  resourceCoreName: { { .Values.resourceCores } }
-  resourcePriorityName: { { .Values.resourcePriority } }
+  resourceCountName: {{ .Values.resourceName }}
+  resourceMemoryName: {{ .Values.resourceMem }}
+  resourceMemoryPercentageName: {{ .Values.resourceMemPercentage }}
+  resourceCoreName: {{ .Values.resourceCores }}
+  resourcePriorityName: {{ .Values.resourcePriority }}
   overwriteEnv: false
   defaultMemory: 0
   defaultCores: 0
   defaultGPUNum: 1
   memoryFactor: 1
-  deviceSplitCount: { { .Values.devicePlugin.deviceSplitCount } }
-  deviceMemoryScaling: { { .Values.devicePlugin.deviceMemoryScaling } }
-  deviceCoreScaling: { { .Values.devicePlugin.deviceCoreScaling } }
+  deviceSplitCount: {{ .Values.devicePlugin.deviceSplitCount }}
+  deviceMemoryScaling: {{ .Values.devicePlugin.deviceMemoryScaling }}
+  deviceCoreScaling: {{ .Values.devicePlugin.deviceCoreScaling }}
   knownMigGeometries:
     - models: ["A30"]
       allowedGeometries:


### PR DESCRIPTION
resourceCountName and related keys in the device-configmap.yaml example used { { .Values.x } } with extra spaces around the braces, which is not valid Helm/Go template syntax (it renders as literal text instead of substituting the value). Changed to {{ .Values.x }} across docs, the current and v2.9.0 zh translations, and the v2.5.1, v2.6.0, v2.7.0, and v2.9.0 versioned copies. Recovered from an old unmerged local branch, the bug was still present in current master.