### PR TITLE
docs: correct vendor resource names to match device plugins

### DIFF
--- a/docs/installation/how-to-use-volcano-vgpu.md
+++ b/docs/installation/how-to-use-volcano-vgpu.md
@@ -80,7 +80,7 @@ status:
     hugepages-2Mi: "0"
     memory: 8174332Ki
     pods: "110"
-    volcano.sh/gpu-number: "10" # vGPU resource
+    volcano.sh/vgpu-number: "10" # vGPU resource
   capacity:
     cpu: "4"
     ephemeral-storage: 123722704Ki
@@ -88,8 +88,8 @@ status:
     hugepages-2Mi: "0"
     memory: 8174332Ki
     pods: "110"
-    volcano.sh/gpu-memory: "89424"
-    volcano.sh/gpu-number: "10" # vGPU resource
+    volcano.sh/vgpu-memory: "89424"
+    volcano.sh/vgpu-number: "10" # vGPU resource
 ```
 
 ### Running vGPU Jobs

--- a/docs/userguide/awsneuron-device/enable-awsneuron-managing.md
+++ b/docs/userguide/awsneuron-device/enable-awsneuron-managing.md
@@ -101,9 +101,9 @@ metadata:
   name: poddemo
   annotations:
     # Use specific Neuron devices (comma-separated list)
-    aws.amazon.com/use-gpuuuid: "node1-AWSNeuron-0,node1-AWSNeuron-1"
+    aws.amazon.com/use-neuron-uuid: "node1-AWSNeuron-0,node1-AWSNeuron-1"
     # Or exclude specific Neuron devices (comma-separated list)
-    aws.amazon.com/nouse-gpuuuid: "node1-AWSNeuron-2,node1-AWSNeuron-3"
+    aws.amazon.com/nouse-neuron-uuid: "node1-AWSNeuron-2,node1-AWSNeuron-3"
 spec:
   # ... rest of pod spec
 ```

--- a/docs/userguide/cambricon-device/enable-cambricon-mlu-sharing.md
+++ b/docs/userguide/cambricon-device/enable-cambricon-mlu-sharing.md
@@ -89,7 +89,7 @@ spec:
 
 1. **Init containers are not supported for MLU sharing.**
 
-   Pods with the `cambricon.com/mlumem` resource specified in an init container will not be scheduled.
+   Pods with the `cambricon.com/mlu.smlu.vmemory` resource specified in an init container will not be scheduled.
 
 2. **Resource constraints only apply to shared mode (`vmlu=1`).**
 

--- a/docs/userguide/metax-device/metax-gpu/enable-metax-gpu-schedule.md
+++ b/docs/userguide/metax-device/metax-gpu/enable-metax-gpu-schedule.md
@@ -2,7 +2,7 @@
 title: Enable MetaX GPU topology-aware scheduling
 ---
 
-**HAMi now supports metax.com/gpu by implementing topo-awareness among metax GPUs.**
+**HAMi now supports metax-tech.com/gpu by implementing topo-awareness among metax GPUs.**
 
 When multiple GPUs are configured on a single server, the GPU cards are connected to the same PCIe Switch or MetaXLink. Depending on the connection type, a near-far relationship is formed among the GPUs. Together, these connections define the topology of the GPU cards on the server, as shown below:
 

--- a/docs/userguide/metax-device/metax-sgpu/enable-metax-gpu-sharing.md
+++ b/docs/userguide/metax-device/metax-sgpu/enable-metax-gpu-sharing.md
@@ -3,7 +3,7 @@ title: Enable MetaX GPU sharing
 translated: true
 ---
 
-**HAMi now supports metax.com/gpu by implementing most device-sharing features as NVIDIA GPUs**, device-sharing features include the following:
+**HAMi now supports metax-tech.com/gpu by implementing most device-sharing features as NVIDIA GPUs**, device-sharing features include the following:
 
 - **GPU Sharing**: Tasks can request a fraction of a GPU rather than the entire GPU card, allowing multiple tasks to share the same GPU.
 

--- a/docs/userguide/volcano-vgpu/nvidia-gpu/how-to-use-volcano-vgpu.md
+++ b/docs/userguide/volcano-vgpu/nvidia-gpu/how-to-use-volcano-vgpu.md
@@ -80,7 +80,7 @@ status:
     hugepages-2Mi: "0"
     memory: 8174332Ki
     pods: "110"
-    volcano.sh/gpu-number: "10" # vGPU resource
+    volcano.sh/vgpu-number: "10" # vGPU resource
   capacity:
     cpu: "4"
     ephemeral-storage: 123722704Ki
@@ -88,8 +88,8 @@ status:
     hugepages-2Mi: "0"
     memory: 8174332Ki
     pods: "110"
-    volcano.sh/gpu-memory: "89424"
-    volcano.sh/gpu-number: "10" # vGPU resource
+    volcano.sh/vgpu-memory: "89424"
+    volcano.sh/vgpu-number: "10" # vGPU resource
 ```
 
 ### Running vGPU Jobs

--- a/i18n/zh/docusaurus-plugin-content-docs/current/installation/how-to-use-volcano-vgpu.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/current/installation/how-to-use-volcano-vgpu.md
@@ -77,7 +77,7 @@ status:
     hugepages-2Mi: "0"
     memory: 8174332Ki
     pods: "110"
-    volcano.sh/gpu-number: "10"    # vGPU 资源
+    volcano.sh/vgpu-number: "10"    # vGPU 资源
   capacity:
     cpu: "4"
     ephemeral-storage: 123722704Ki
@@ -85,8 +85,8 @@ status:
     hugepages-2Mi: "0"
     memory: 8174332Ki
     pods: "110"
-    volcano.sh/gpu-memory: "89424"
-    volcano.sh/gpu-number: "10"   # vGPU 资源
+    volcano.sh/vgpu-memory: "89424"
+    volcano.sh/vgpu-number: "10"   # vGPU 资源
 ```
 
 ### 运行 vGPU 作业

--- a/i18n/zh/docusaurus-plugin-content-docs/current/userguide/awsneuron-device/enable-awsneuron-managing.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/current/userguide/awsneuron-device/enable-awsneuron-managing.md
@@ -100,9 +100,9 @@ metadata:
   name: poddemo
   annotations:
     # 指定使用的 Neuron 设备 (逗号分隔列表)
-    aws.amazon.com/use-gpuuuid: "node1-AWSNeuron-0,node1-AWSNeuron-1"
+    aws.amazon.com/use-neuron-uuid: "node1-AWSNeuron-0,node1-AWSNeuron-1"
     # 或排除特定 Neuron 设备 (逗号分隔列表)
-    aws.amazon.com/nouse-gpuuuid: "node1-AWSNeuron-2,node1-AWSNeuron-3"
+    aws.amazon.com/nouse-neuron-uuid: "node1-AWSNeuron-2,node1-AWSNeuron-3"
 spec:
   # ... 其他 pod 配置
 ```

--- a/i18n/zh/docusaurus-plugin-content-docs/current/userguide/metax-device/metax-gpu/enable-metax-gpu-schedule.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/current/userguide/metax-device/metax-gpu/enable-metax-gpu-schedule.md
@@ -4,7 +4,7 @@ sidebar_label: 拓扑感知调度
 translated: true
 ---
 
-**HAMi 现在通过在沐曦 GPU 之间实现拓扑感知来支持 metax.com/gpu**：
+**HAMi 现在通过在沐曦 GPU 之间实现拓扑感知来支持 metax-tech.com/gpu**：
 
 当在单个服务器上配置多个 GPU 时，GPU 卡根据它们是否连接到同一个 PCIe 交换机或 MetaXLink 而存在远近关系。这在服务器上的所有卡之间形成了一个拓扑，如下图所示：
 

--- a/i18n/zh/docusaurus-plugin-content-docs/current/userguide/volcano-vgpu/nvidia-gpu/how-to-use-volcano-vgpu.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/current/userguide/volcano-vgpu/nvidia-gpu/how-to-use-volcano-vgpu.md
@@ -88,7 +88,7 @@ status:
     hugepages-2Mi: "0"
     memory: 8174332Ki
     pods: "110"
-    volcano.sh/gpu-number: "10" # vGPU 资源
+    volcano.sh/vgpu-number: "10" # vGPU 资源
   capacity:
     cpu: "4"
     ephemeral-storage: 123722704Ki
@@ -96,8 +96,8 @@ status:
     hugepages-2Mi: "0"
     memory: 8174332Ki
     pods: "110"
-    volcano.sh/gpu-memory: "89424"
-    volcano.sh/gpu-number: "10" # vGPU 资源
+    volcano.sh/vgpu-memory: "89424"
+    volcano.sh/vgpu-number: "10" # vGPU 资源
 ```
 
 ### 运行 vGPU 作业


### PR DESCRIPTION
## What this PR does / why we need it

A few device docs show resource names that don't match what the device plugin actually registers, so copying the example gives an unschedulable pod. Each fix is backed by the plugin's own source/docs and by the same document's other examples:

- **Volcano vGPU** (`how-to-use-volcano-vgpu.md`) — the node-status example uses `volcano.sh/gpu-number` / `volcano.sh/gpu-memory`, but the plugin registers `volcano.sh/vgpu-number` / `volcano.sh/vgpu-memory`. Source: `Project-HAMi/volcano-vgpu-device-plugin` `doc/config.md` (defaults `volcano.sh/vgpu-number` / `-memory` / `-cores`) and its `README.md` / `examples/*.yml`. The same page's own request example and the line "it is ok if `volcano.sh/vgpu-number` is included in the allocatable resources" already use the `vgpu-*` form.
- **AWS Neuron** (`enable-awsneuron-managing.md`) — UUID annotations are `aws.amazon.com/use-neuron-uuid` / `nouse-neuron-uuid`, not `use-gpuuuid` / `nouse-gpuuuid`. Source: `Project-HAMi/HAMi` `pkg/device/awsneuron/device.go` (`AWSNeuronUseUUID` / `AWSNeuronNoUseUUID`).
- **MetaX** (`enable-metax-gpu-schedule.md`, `enable-metax-gpu-sharing.md`) — the intro sentence says `metax.com/gpu`; the resource is `metax-tech.com/gpu`, which is what every example in the same two docs already uses.
- **Cambricon** (`enable-cambricon-mlu-sharing.md`) — `cambricon.com/mlumem` does not exist; the shared-memory resource is `cambricon.com/mlu.smlu.vmemory`, used elsewhere in the same doc.

Both the `docs/` version and the `i18n/zh` mirror are updated.

## Verification

- `npm run check:all` (markdownlint + prettier + build + linkinator) passes locally.
- Each name was checked against the plugin source cited above and cross-checked with the same document's existing examples.

## AI assistance

Drafted with AI assistance (Claude Code) and reviewed and verified by me, including the source cross-checks above.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated vGPU examples to use the correct vGPU resource names.
  * Corrected AWS Neuron device-selection annotation examples.
  * Clarified MLU sharing scheduling guidance for init containers.
  * Standardized MetaX GPU resource references across English and Chinese guides.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->