### PR TITLE
docs: fix scheduler policy flag, schedulerName case, and stale link

### DIFF
--- a/concept.md
+++ b/concept.md
@@ -438,4 +438,4 @@ GPU2 得分 = ((1+6)/10 + (20+70)/100 + (1000+6000)/8000) × 10 = 24.75
 
 HAMi 的完整链路：Webhook 将 Pod 引入 hami-scheduler，Scheduler Extender 依据 Node Annotation 中的 GPU 规格做感知调度并将分配结果写回 Pod Annotation，Device Plugin 在 Allocate 时读取 Annotation、注入 libvgpu.so（即 HAMi-Core）和限额环境变量，最终由 HAMi-Core 在容器内拦截 CUDA API 完成软隔离。
 
-HAMi 的调度侧相对轻量，适合在线推理这类单任务独立调度的场景。如果是 AI 训练场景，需要 Gang Scheduling（多 Pod 全部就绪才开始）、队列管理、公平份额等批处理能力，可以考虑 [Volcano](https://github.com/volcano-sh/volcano) 配合 [volcano-vgpu-device-plugin](https://github.com/volcano-sh/devices)，两者的组合在 GPU 虚拟化基础上补齐了批调度能力。
+HAMi 的调度侧相对轻量，适合在线推理这类单任务独立调度的场景。如果是 AI 训练场景，需要 Gang Scheduling（多 Pod 全部就绪才开始）、队列管理、公平份额等批处理能力，可以考虑 [Volcano](https://github.com/volcano-sh/volcano) 配合 [volcano-vgpu-device-plugin](https://github.com/Project-HAMi/volcano-vgpu-device-plugin)，两者的组合在 GPU 虚拟化基础上补齐了批调度能力。

--- a/docs/core-concepts/architecture.md
+++ b/docs/core-concepts/architecture.md
@@ -15,7 +15,7 @@ HAMi consists of the following components:
 
 ## HAMi MutatingWebhook {#hami-mutatingwebhook}
 
-HAMi MutatingWebhook checks if this task can be handled by HAMi. It scans the resource field of each pod submitted. If each resource the pod requires is either 'CPU', 'Memory' or a HAMi-resource, then it will set the schedulerName field of this pod to 'HAMi-scheduler'.
+HAMi MutatingWebhook checks if this task can be handled by HAMi. It scans the resource field of each pod submitted. If each resource the pod requires is either 'CPU', 'Memory' or a HAMi-resource, then it will set the schedulerName field of this pod to 'hami-scheduler'.
 
 ## HAMi Scheduler {#hami-scheduler}
 

--- a/docs/developers/gpu-topology-scheduling.md
+++ b/docs/developers/gpu-topology-scheduling.md
@@ -26,7 +26,7 @@ Set the environment variable `ENABLE_TOPOLOGY_SCORE: 'true'` in the DaemonSet `h
 
 ### 2. Global scheduler settings
 
-Add `gpu-scheduler-policy=topology-aware` when starting `hami-scheduler`.
+Add `--gpu-scheduler-policy=topology-aware` when starting `hami-scheduler`.
 
 ### 3. Pod-level annotation
 

--- a/i18n/zh/docusaurus-plugin-content-docs/current/core-concepts/architecture.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/current/core-concepts/architecture.md
@@ -16,7 +16,7 @@ HAMi 由以下组件组成：
 
 ## HAMi MutatingWebhook {#hami-mutatingwebhook}
 
-HAMi MutatingWebhook 检查该任务是否可以由 HAMi 处理，它扫描每个提交的 Pod 的资源字段，如果这些 Pod 所需的每个资源是 'cpu'、'memory' 或 HAMi 资源，则会将该 Pod 的 schedulerName 字段设置为 'HAMi-scheduler'。
+HAMi MutatingWebhook 检查该任务是否可以由 HAMi 处理，它扫描每个提交的 Pod 的资源字段，如果这些 Pod 所需的每个资源是 'cpu'、'memory' 或 HAMi 资源，则会将该 Pod 的 schedulerName 字段设置为 'hami-scheduler'。
 
 ## HAMi 调度器 {#hami-scheduler}
 

--- a/i18n/zh/docusaurus-plugin-content-docs/current/developers/gpu-topology-scheduling.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/current/developers/gpu-topology-scheduling.md
@@ -26,7 +26,7 @@ helm install hami hami-charts/hami \
 
 ### 2. 调度器全局设置
 
-启动 `hami-scheduler` 时添加 `gpu-scheduler-policy=topology-aware`。
+启动 `hami-scheduler` 时添加 `--gpu-scheduler-policy=topology-aware`。
 
 ### 3. Pod 级别注解
 


### PR DESCRIPTION
## What this PR does / why we need it

Three small correctness fixes in scheduler/concept docs:

- **schedulerName casing** (`core-concepts/architecture.md`) — the MutatingWebhook sets `schedulerName` to `hami-scheduler` (lowercase), not `HAMi-scheduler`. This value is case-sensitive; the same file's own section anchor is `{#hami-scheduler}` and the chart's `scheduler.schedulerName` is `hami-scheduler`.
- **Scheduler policy flag** (`developers/gpu-topology-scheduling.md`) — the topology policy is set via the `--gpu-scheduler-policy` flag (leading `--`), defined in `Project-HAMi/HAMi` `cmd/scheduler/main.go` (`rootCmd.Flags().StringVar(&device.GPUSchedulerPolicy, "gpu-scheduler-policy", ...)`). The doc dropped the `--`.
- **Stale link** (`concept.md`) — the `volcano-vgpu-device-plugin` link pointed at `github.com/volcano-sh/devices`; it should point to `github.com/Project-HAMi/volcano-vgpu-device-plugin`, which is what the other docs on this site already link to.

Both the `docs/` version and the `i18n/zh` mirror are updated.

## Verification

- `npm run check:all` (markdownlint + prettier + build + linkinator) passes locally.
- Values checked against the HAMi chart and `cmd/scheduler` flag definitions.

## AI assistance

Drafted with AI assistance (Claude Code) and reviewed and verified by me, including the source cross-checks above.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Corrected scheduler naming in architecture documentation.
  * Fixed the GPU topology scheduling command example to use the proper CLI flag format.
  * Updated the referenced device plugin link to point to the repository homepage.
  * Applied corresponding corrections to the Chinese documentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->