### PR TITLE
docs: fix awsneuron link typo and gpumem memory-unit comment

### DIFF
--- a/docs/key-features/device-resource-isolation.md
+++ b/docs/key-features/device-resource-isolation.md
@@ -8,7 +8,7 @@ A simple demonstration for device isolation: A task with the following resources
 resources:
   limits:
     nvidia.com/gpu: 1 # requesting 1 vGPU
-    nvidia.com/gpumem: 3000 # Each vGPU contains 3000m device memory
+    nvidia.com/gpumem: 3000 # Each vGPU contains 3000 MiB device memory
 ```
 
 will see 3G device memory inside container

--- a/docs/userguide/awsneuron-device/enable-awsneuron-managing.md
+++ b/docs/userguide/awsneuron-device/enable-awsneuron-managing.md
@@ -19,7 +19,7 @@ HAMi now integrates with the [Neuron scheduler extension](https://awsdocs-neuron
 
 ## Enabling Neuron-sharing Support
 
-- Deploy neuron-device-plugin on EC2 neuron nodes according to the AWS document: [Neuro Device Plugin](https://awsdocs-neuron.readthedocs-hosted.com/en/latest/containers/kubernetes-getting-started.html#neuron-device-plugin)
+- Deploy neuron-device-plugin on EC2 neuron nodes according to the AWS document: [Neuron Device Plugin](https://awsdocs-neuron.readthedocs-hosted.com/en/latest/containers/kubernetes-getting-started.html#neuron-device-plugin)
 
 - Deploy HAMi
 

--- a/docs/userguide/nvidia-device/specify-device-memory-usage.md
+++ b/docs/userguide/nvidia-device/specify-device-memory-usage.md
@@ -9,7 +9,7 @@ Allocate a certain size of device memory by specifying resources such as `nvidia
 resources:
   limits:
     nvidia.com/gpu: 1 # requesting 1 GPU
-    nvidia.com/gpumem: 3000 # Each GPU contains 3000m device memory
+    nvidia.com/gpumem: 3000 # Each GPU contains 3000 MiB device memory
 ```
 
 Allocate a percentage of device memory by specifying resource `nvidia.com/gpumem-percentage`. Optional, each unit of `nvidia.com/gpumem-percentage` equals 1% of device memory.

--- a/i18n/zh/docusaurus-plugin-content-docs/current/key-features/device-resource-isolation.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/current/key-features/device-resource-isolation.md
@@ -9,7 +9,7 @@ translated: true
 resources:
   limits:
     nvidia.com/gpu: 1 # 请求 1 个 vGPU
-    nvidia.com/gpumem: 3000 # 每个 vGPU 包含 3000m 设备显存
+    nvidia.com/gpumem: 3000 # 每个 vGPU 包含 3000 MiB 设备显存
 ```
 
 将在容器内看到 3G 设备显存。

--- a/i18n/zh/docusaurus-plugin-content-docs/current/userguide/nvidia-device/specify-device-memory-usage.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/current/userguide/nvidia-device/specify-device-memory-usage.md
@@ -10,7 +10,7 @@ translated: true
 resources:
   limits:
     nvidia.com/gpu: 1 # 请求 1 个 GPU
-    nvidia.com/gpumem: 3000 # 每个 GPU 包含 3000m 设备显存
+    nvidia.com/gpumem: 3000 # 每个 GPU 包含 3000 MiB 设备显存
 ```
 
 通过指定资源 `nvidia.com/gpumem-percentage` 来分配设备显存的百分比。可选项，每个 `nvidia.com/gpumem-percentage` 单位等于设备显存的 1% 百分比。


### PR DESCRIPTION
## What this PR does / why we need it

Two small correctness fixes:

- **AWS Neuron link typo** (`awsneuron-device/enable-awsneuron-managing.md`) — the link text reads `Neuro Device Plugin`; it should be `Neuron Device Plugin`. The link's own URL anchor is `#neuron-device-plugin` and the same sentence refers to `neuron-device-plugin` on `neuron` nodes.
- **`gpumem` memory-unit comment** (`nvidia-device/specify-device-memory-usage.md`, `key-features/device-resource-isolation.md`) — the comment says `3000m device memory`. `m` is the Kubernetes milli suffix, which is misleading here. The doc itself states "each unit of `nvidia.com/gpumem` equals 1 MiB", so `nvidia.com/gpumem: 3000` is `3000 MiB` (the nearby text also says "will see 3G device memory"). Changed the comment to `3000 MiB`.

Both the `docs/` version and the `i18n/zh` mirror are updated.

## Verification

`npm run check:all` (markdownlint + prettier + build + linkinator) passes locally.

## AI assistance

Drafted with AI assistance (Claude Code) and reviewed and verified by me.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified NVIDIA GPU memory examples to consistently specify values in MiB.
  * Corrected the AWS Neuron plugin name in the setup instructions.
  * Updated equivalent Chinese documentation for clearer device memory guidance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->