### PR TITLE
fix(i18n): point edit links at localized docs

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -3,6 +3,11 @@ const lightTheme = themes.github;
 const darkTheme = themes.dracula;
 const defaultLocale = "en";
 const siteUrl = (process.env.DOCUSAURUS_SITE_URL || "https://project-hami.io").replace(/\/$/, "");
+const githubEditBaseUrl = "https://github.com/Project-HAMi/website/edit/master/";
+
+function getDocEditUrl(versionDocsDirPath, docPath) {
+  return `${githubEditBaseUrl}${[versionDocsDirPath, docPath].filter(Boolean).join("/")}`;
+}
 
 async function localizedBlogPlugin(context, opts) {
   const p = await require("@docusaurus/plugin-content-blog").default(context, opts);
@@ -206,8 +211,8 @@ module.exports = {
       "./src/plugins/docs/index.js",
       {
         sidebarPath: require.resolve("./sidebars.js"),
-        editUrl: function ({ locale, docPath }) {
-          return `https://github.com/Project-HAMi/website/edit/master/docs/${docPath}`;
+        editUrl: function ({ versionDocsDirPath, docPath }) {
+          return getDocEditUrl(versionDocsDirPath, docPath);
         },
         showLastUpdateAuthor: false,
         showLastUpdateTime: true,
@@ -225,8 +230,8 @@ module.exports = {
         path: "tutorials",
         routeBasePath: "tutorials",
         sidebarPath: require.resolve("./sidebars-tutorials.js"),
-        editUrl: function ({ locale, docPath }) {
-          return `https://github.com/Project-HAMi/website/edit/master/tutorials/${docPath}`;
+        editUrl: function ({ versionDocsDirPath, docPath }) {
+          return getDocEditUrl(versionDocsDirPath, docPath);
         },
         showLastUpdateTime: true,
         numberPrefixParser: false,


### PR DESCRIPTION
**Most of this Pull Request was generated or revised with the assistance of AI tools, including Codex and Raft(Slock). I have reviewed the resulting content and take full responsibility for its accuracy, security, licensing compliance, and inclusion in this project.**

## Summary
- fix docs/tutorials edit links to use `versionDocsDirPath` instead of hardcoded English-only source roots
- preserve correct localized edit targets for Chinese current docs, versioned docs, and tutorials
- leave English edit targets unchanged

## Verification
- verified zh current docs edit links resolve to `i18n/zh/docusaurus-plugin-content-docs/current/...`
- verified zh versioned docs edit links resolve to `i18n/zh/docusaurus-plugin-content-docs/version-v2.8.0/...`
- verified zh tutorials edit links resolve to `i18n/zh/docusaurus-plugin-content-docs-tutorials/current/...`
- `prettier --check docusaurus.config.js`

## Notes
- full `npm run build -- --locale zh` still hits pre-existing broken links unrelated to this change


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved documentation “Edit this page” links to consistently direct contributors to the correct versioned source files on GitHub.
  * Updated documentation and tutorial links to use a shared, reliable URL format.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->