### PR TITLE
fix: add missing pages to v2.8.0 sidebar

### DIFF
--- a/versioned_sidebars/version-v2.8.0-sidebars.json
+++ b/versioned_sidebars/version-v2.8.0-sidebars.json
@@ -54,6 +54,7 @@
           "label": "Monitoring",
           "items": [
             "userguide/monitoring/device-allocation",
+            "userguide/monitoring/real-time-usage",
             "userguide/monitoring/real-time-device-usage"
           ]
         },
@@ -318,6 +319,8 @@
       "label": "Contributor Guide",
       "items": [
         "contributor/contributing",
+        "contributor/contribute-docs",
+        "contributor/github-workflow",
         "contributor/governance",
         "contributor/ladder"
       ]


### PR DESCRIPTION
userguide/monitoring/real-time-usage.md, contributor/contribute-docs.md, and contributor/github-workflow.md exist in v2.8.0 versioned_docs but are not listed in the v2.8.0 sidebar, so they are unreachable from navigation. v2.9.0 already lists all three. Added them in the same order.