### PR TITLE
docs: fix stale info in readme and build optimization docs

### DIFF
--- a/BUILD_OPTIMIZATION.md
+++ b/BUILD_OPTIMIZATION.md
@@ -105,7 +105,7 @@ npm run clear
 1. **首次构建**: 首次构建或清理缓存后，构建时间会稍长，后续构建会利用缓存加速
 2. **开发环境**: 开发环境 (`npm start`) 也会从这些优化中受益
 3. **CI/CD**: 确保 CI/CD 环境有足够的内存和 CPU 资源
-4. **版本兼容**: 这些优化基于 Docusaurus 3.9.2+
+4. **版本兼容**: 这些优化基于 Docusaurus 3.10.1+
 
 ## 持续优化建议
 
@@ -134,10 +134,10 @@ npm run clear
 
 ## 技术栈
 
-- **框架**: Docusaurus 3.9.2
+- **框架**: Docusaurus 3.10.1
 - **打包工具**: Rspack (通过 @docusaurus/faster)
 - **编译器**: SWC
-- **Node.js**: v25.4.0
+- **Node.js**: v20+
 - **包管理器**: npm
 
 ---

--- a/README.md
+++ b/README.md
@@ -142,7 +142,7 @@ This adds the DCO signature: `Signed-off-by: Your Name <your.email@example.com>`
 | Command                      | Description                                  |
 | ---------------------------- | -------------------------------------------- |
 | `npm start`                  | Start development server with hot-reload     |
-| `npm start:network`          | Start dev server accessible on local network |
+| `npm run start:network`      | Start dev server accessible on local network |
 | `npm run build`              | Build full production site (all languages)   |
 | `npm run build:fast`         | Build English only (faster for testing)      |
 | `npm run serve`              | Serve production build locally               |


### PR DESCRIPTION
README build scripts table used npm start:network which is invalid npm syntax, custom scripts need npm run. BUILD_OPTIMIZATION.md still listed Docusaurus 3.9.2 and Node v25.4.0, actual pins are 3.10.1 and Node 20 per package.json and CI.