### PR TITLE
fix: correct casing and code style in mthreads doc

### DIFF
--- a/docs/userguide/mthreads-device/enable-mthreads-gpu-sharing.md
+++ b/docs/userguide/mthreads-device/enable-mthreads-gpu-sharing.md
@@ -37,7 +37,7 @@ You can remove `mt-mutating-webhook` and `mt-gpu-scheduler` after installation (
 
 :::
 
-- set the 'devices.mthreads.enabled = true' when installing hami
+- Set `devices.mthreads.enabled=true` when installing HAMi
 
 ```bash
 helm install hami hami-charts/hami --set scheduler.kubeScheduler.image.tag={your kubernetes version} --set devices.mthreads.enabled=true -n kube-system

--- a/i18n/zh/docusaurus-plugin-content-docs/current/userguide/mthreads-device/enable-mthreads-gpu-sharing.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/current/userguide/mthreads-device/enable-mthreads-gpu-sharing.md
@@ -39,7 +39,7 @@ translated: true
 
 :::
 
-- 在安装 HAMi 时配置'devices.mthreads.enabled = true'参数
+- 在安装 HAMi 时配置参数 `devices.mthreads.enabled=true`
 
 ```bash
 helm install hami hami-charts/hami --set scheduler.kubeScheduler.image.tag={your kubernetes version} --set devices.mthreads.enabled=true -n kube-system


### PR DESCRIPTION
Lowercase hami and single-quoted flag value did not match the convention used in every other device guide (Set `devices.x.enabled=true` when installing HAMi). Fixed in English and zh.