### PR TITLE
fix: create fake-gpu-pod inline instead of applying missing file

### DIFF
--- a/i18n/zh/docusaurus-plugin-content-docs-tutorials/current/labs/local-fake-gpu.md
+++ b/i18n/zh/docusaurus-plugin-content-docs-tutorials/current/labs/local-fake-gpu.md
@@ -579,9 +579,10 @@ DCGM_FI_DEV_GPU_UTIL{..., device="nvidia0", ..., modelName="Tesla-K80", ...} => 
 
 ### 5.1 创建测试 Pod
 
-先看一下 Pod YAML：
+创建 Pod：
 
-```yaml
+```bash
+kubectl apply -f - <<EOF
 apiVersion: v1
 kind: Pod
 metadata:
@@ -609,6 +610,7 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: spec.nodeName
+EOF
 ```
 
 > YAML 要点：
@@ -617,12 +619,6 @@ spec:
 > - `run.ai/simulated-gpu-utilization: "10-30"` 注解：fake-gpu-operator 会让 `nvidia-smi` 报告 10%-30% 的 GPU 利用率
 > - `resources.limits.nvidia.com/gpu: 1`：申请 1 块 GPU
 > - `sleep 3600`：让容器保持运行 1 小时，方便我们进入容器观察
-
-创建 Pod：
-
-```bash
-kubectl apply -f fake-gpu-pod.yaml
-```
 
 ```plaintext
 pod/fake-gpu-pod created

--- a/tutorials/labs/local-fake-gpu.md
+++ b/tutorials/labs/local-fake-gpu.md
@@ -572,9 +572,10 @@ Since this lab does not enable the HAMi device-plugin, the test Pod explicitly b
 
 ### 5.1 Create a Test Pod
 
-Review the Pod YAML before applying:
+Apply the Pod:
 
-```yaml
+```bash
+kubectl apply -f - <<EOF
 apiVersion: v1
 kind: Pod
 metadata:
@@ -602,6 +603,11 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: spec.nodeName
+EOF
+```
+
+```plaintext
+pod/fake-gpu-pod created
 ```
 
 > YAML key points:
@@ -610,16 +616,6 @@ spec:
 > - `run.ai/simulated-gpu-utilization: "10-30"`: fake-gpu-operator will make `nvidia-smi` report 10%–30% GPU utilization
 > - `resources.limits.nvidia.com/gpu: 1`: Requests 1 GPU
 > - `sleep 3600`: Keeps the container running for 1 hour for observation
-
-Apply the Pod:
-
-```bash
-kubectl apply -f fake-gpu-pod.yaml
-```
-
-```plaintext
-pod/fake-gpu-pod created
-```
 
 ### 5.2 Wait for the Pod to Run
 


### PR DESCRIPTION
The lab showed the Pod YAML then ran kubectl apply -f fake-gpu-pod.yaml, but that file is never created anywhere in the lab. Switched to kubectl apply -f - <<EOF, the same heredoc pattern used elsewhere in this lab and in nvml-mock.md. Fixed in English and zh.