### PR TITLE
fix: use full manifest paths in lab apply commands

### DIFF
--- a/i18n/zh/docusaurus-plugin-content-docs-tutorials/current/labs/gpu-partitioning.md
+++ b/i18n/zh/docusaurus-plugin-content-docs-tutorials/current/labs/gpu-partitioning.md
@@ -93,7 +93,7 @@ spec:
 `gpumem-pod-b.yaml` 除了名称不同外完全相同。部署两个 Pod：
 
 ```bash
-kubectl apply -f gpumem-pod-a.yaml -f gpumem-pod-b.yaml
+kubectl apply -f tutorials/labs/examples/03-gpu-partitioning/gpumem-pod-a.yaml -f tutorials/labs/examples/03-gpu-partitioning/gpumem-pod-b.yaml
 kubectl get pods gpumem-pod-a gpumem-pod-b -o wide
 ```
 
@@ -174,7 +174,7 @@ spec:
 ```
 
 ```bash
-kubectl apply -f oom-test-pod.yaml
+kubectl apply -f tutorials/labs/examples/03-gpu-partitioning/oom-test-pod.yaml
 ```
 
 在镜像拉取期间，观察 HAMi 调度器的决策：
@@ -240,7 +240,7 @@ resources:
 ```
 
 ```bash
-kubectl apply -f gpucores-pod.yaml
+kubectl apply -f tutorials/labs/examples/03-gpu-partitioning/gpucores-pod.yaml
 ```
 
 检查 HAMi 注入到容器中的环境变量：

--- a/i18n/zh/docusaurus-plugin-content-docs-tutorials/current/labs/hami-dra.md
+++ b/i18n/zh/docusaurus-plugin-content-docs-tutorials/current/labs/hami-dra.md
@@ -114,8 +114,8 @@ accept-nvidia-visible-devices-as-volume-mounts = true
 驱动以 kubelet 插件 DaemonSet 方式运行。两个清单文件：先 RBAC，再 DaemonSet。
 
 ```bash
-kubectl apply -f rbac.yaml
-kubectl apply -f ds-gpu-operator.yaml
+kubectl apply -f tutorials/labs/examples/04-hami-dra/rbac.yaml
+kubectl apply -f tutorials/labs/examples/04-hami-dra/ds-gpu-operator.yaml
 
 kubectl get pods -n hami-dra-driver
 ```
@@ -192,8 +192,8 @@ spec:
 部署并验证：
 
 ```bash
-kubectl apply -f setup.yaml
-kubectl create -f pod-0.yaml
+kubectl apply -f tutorials/labs/examples/04-hami-dra/setup.yaml
+kubectl create -f tutorials/labs/examples/04-hami-dra/pod-0.yaml
 kubectl get pod pod-0 -n test-dra
 kubectl get resourceclaim single-gpu-0 -n test-dra -o jsonpath='{.status.allocation.devices.results[0]}' | python3 -m json.tool
 ```
@@ -232,7 +232,7 @@ kubectl exec -n test-dra pod-0 -- nvidia-smi | head -11
 `pod-tpl-0.yaml` 使用 `ResourceClaimTemplate`，因此每个 Pod 会获得自动生成的独立 Claim：
 
 ```bash
-kubectl create -f pod-tpl-0.yaml
+kubectl create -f tutorials/labs/examples/04-hami-dra/pod-tpl-0.yaml
 kubectl get pods -n test-dra
 kubectl get resourceclaims -n test-dra
 ```

--- a/i18n/zh/docusaurus-plugin-content-docs-tutorials/current/labs/hami-isolation-k3s.md
+++ b/i18n/zh/docusaurus-plugin-content-docs-tutorials/current/labs/hami-isolation-k3s.md
@@ -217,7 +217,7 @@ spec:
 > `hami-share-b` 除名称外完全相同。使用 `devel` 镜像是因为步骤 6 需要在 Pod 内用 `nvcc` 编译一个小型 CUDA 分配器；镜像较大、拉取较慢是正常的。在 24 GB 显卡上请改用约 4000 MiB 的切片。
 
 ```bash
-kubectl apply -f share-two-pods.yaml
+kubectl apply -f tutorials/labs/examples/07-hami-isolation-k3s/share-two-pods.yaml
 kubectl wait --for=condition=Ready pod/hami-share-a pod/hami-share-b --timeout=300s
 kubectl get pods -o wide
 ```
@@ -303,7 +303,7 @@ cudaMalloc refused after 7424 MiB allocated: out of memory
 现在证明显卡的显存是一个共享的、有限的预算。`oversubscribe-pending.yaml` 请求一个 90000 MiB 的切片，空的 96 GB 卡放得下，但在已有两个 8000 MiB 切片的情况下放不下（97887 − 16000 ≈ 82000 MiB 空闲）：
 
 ```bash
-kubectl apply -f oversubscribe-pending.yaml
+kubectl apply -f tutorials/labs/examples/07-hami-isolation-k3s/oversubscribe-pending.yaml
 sleep 15
 kubectl get pod hami-oversubscribe
 kubectl describe pod hami-oversubscribe | grep -A5 Events:

--- a/tutorials/labs/gpu-partitioning.md
+++ b/tutorials/labs/gpu-partitioning.md
@@ -93,7 +93,7 @@ spec:
 `gpumem-pod-b.yaml` is identical except for the name. Apply both:
 
 ```bash
-kubectl apply -f gpumem-pod-a.yaml -f gpumem-pod-b.yaml
+kubectl apply -f tutorials/labs/examples/03-gpu-partitioning/gpumem-pod-a.yaml -f tutorials/labs/examples/03-gpu-partitioning/gpumem-pod-b.yaml
 kubectl get pods gpumem-pod-a gpumem-pod-b -o wide
 ```
 
@@ -174,7 +174,7 @@ spec:
 ```
 
 ```bash
-kubectl apply -f oom-test-pod.yaml
+kubectl apply -f tutorials/labs/examples/03-gpu-partitioning/oom-test-pod.yaml
 ```
 
 While the image pulls, watch the HAMi scheduler make its decision:
@@ -240,7 +240,7 @@ resources:
 ```
 
 ```bash
-kubectl apply -f gpucores-pod.yaml
+kubectl apply -f tutorials/labs/examples/03-gpu-partitioning/gpucores-pod.yaml
 ```
 
 Check the environment HAMi injected into the container:

--- a/tutorials/labs/hami-dra.md
+++ b/tutorials/labs/hami-dra.md
@@ -114,8 +114,8 @@ accept-nvidia-visible-devices-as-volume-mounts = true
 The driver runs as a kubelet plugin DaemonSet. Two manifests: RBAC, then the DaemonSet.
 
 ```bash
-kubectl apply -f rbac.yaml
-kubectl apply -f ds-gpu-operator.yaml
+kubectl apply -f tutorials/labs/examples/04-hami-dra/rbac.yaml
+kubectl apply -f tutorials/labs/examples/04-hami-dra/ds-gpu-operator.yaml
 
 kubectl get pods -n hami-dra-driver
 ```
@@ -192,8 +192,8 @@ spec:
 Apply and verify:
 
 ```bash
-kubectl apply -f setup.yaml
-kubectl create -f pod-0.yaml
+kubectl apply -f tutorials/labs/examples/04-hami-dra/setup.yaml
+kubectl create -f tutorials/labs/examples/04-hami-dra/pod-0.yaml
 kubectl get pod pod-0 -n test-dra
 kubectl get resourceclaim single-gpu-0 -n test-dra -o jsonpath='{.status.allocation.devices.results[0]}' | python3 -m json.tool
 ```
@@ -232,7 +232,7 @@ kubectl exec -n test-dra pod-0 -- nvidia-smi | head -11
 `pod-tpl-0.yaml` uses a `ResourceClaimTemplate`, so each Pod gets its own auto-generated claim:
 
 ```bash
-kubectl create -f pod-tpl-0.yaml
+kubectl create -f tutorials/labs/examples/04-hami-dra/pod-tpl-0.yaml
 kubectl get pods -n test-dra
 kubectl get resourceclaims -n test-dra
 ```

--- a/tutorials/labs/hami-isolation-k3s.md
+++ b/tutorials/labs/hami-isolation-k3s.md
@@ -217,7 +217,7 @@ spec:
 > `hami-share-b` is identical except for the name. The `devel` image is used because Step 6 compiles a small CUDA allocator with `nvcc` inside the Pod; it is large to pull, which is expected. On a 24 GB card use ~4000 MiB slices instead.
 
 ```bash
-kubectl apply -f share-two-pods.yaml
+kubectl apply -f tutorials/labs/examples/07-hami-isolation-k3s/share-two-pods.yaml
 kubectl wait --for=condition=Ready pod/hami-share-a pod/hami-share-b --timeout=300s
 kubectl get pods -o wide
 ```
@@ -303,7 +303,7 @@ cudaMalloc refused after 7424 MiB allocated: out of memory
 Now prove the card's memory is one shared, finite budget. `oversubscribe-pending.yaml` requests a 90000 MiB slice - it would fit an empty 96 GB card, but not beside the two 8000 MiB slices already held (97887 − 16000 ≈ 82000 MiB free):
 
 ```bash
-kubectl apply -f oversubscribe-pending.yaml
+kubectl apply -f tutorials/labs/examples/07-hami-isolation-k3s/oversubscribe-pending.yaml
 sleep 15
 kubectl get pod hami-oversubscribe
 kubectl describe pod hami-oversubscribe | grep -A5 Events:


### PR DESCRIPTION
gpu-partitioning.md, hami-dra.md, and hami-isolation-k3s.md apply manifests by bare filename, which only works if the reader happens to be in the examples subdirectory. Every other lab uses the full path from repo root. Changed these to match, in English and zh.