### PR TITLE
chore: add issue and pull request templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,5 @@
+blank_issues_enabled: false
+contact_links:
+  - name: HAMi software bug
+    url: https://github.com/Project-HAMi/HAMi/issues/new/choose
+    about: For bugs in the HAMi scheduler or device plugins, file an issue in the main HAMi repo instead.

--- a/.github/ISSUE_TEMPLATE/doc-improvement.md
+++ b/.github/ISSUE_TEMPLATE/doc-improvement.md
@@ -1,0 +1,11 @@
+---
+name: Documentation improvement
+about: Request missing content, a new guide, or a clearer explanation.
+labels: kind/documentation
+---
+
+**What is missing or unclear**:
+
+**Where it should go** (existing page, or a new page):
+
+**Why this would help**:

--- a/.github/ISSUE_TEMPLATE/doc-issue.md
+++ b/.github/ISSUE_TEMPLATE/doc-issue.md
@@ -1,0 +1,11 @@
+---
+name: Documentation issue
+about: Report a typo, broken link, or wrong information on the docs site.
+labels: kind/documentation
+---
+
+**Page URL**:
+
+**What is wrong**:
+
+**What it should say instead**:

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,22 @@
+**What type of PR is this?**
+
+<!--
+Add one of the following kinds:
+/kind bug
+/kind cleanup
+/kind documentation
+/kind feature
+-->
+
+**What this PR does / why we need it**:
+
+**Which issue(s) this PR fixes**:
+
+Fixes #
+
+**Checklist**:
+
+- [ ] `npm run lint` and `npm run format:check` pass
+- [ ] `npm run build` succeeds for both `en` and `zh`
+- [ ] Chinese translation updated if English docs changed (or noted why not)
+- [ ] Commits are signed off (`git commit -s`)


### PR DESCRIPTION
This repo had no issue or PR templates. Added two doc-focused issue templates (typo/broken link, missing content), a config.yml pointing HAMi software bugs to the main repo, and a PR template with a checklist matching the actual CI checks (lint, format, build, DCO).