### PR TITLE
chore: fill package metadata and add readme badges

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # HAMi Documentation Website
 
-[![FOSSA Status](https://app.fossa.com/api/projects/git%2Bgithub.com%2FProject-HAMi%2Fwebsite.svg?type=shield)](https://app.fossa.com/projects/git%2Bgithub.com%2FProject-HAMi%2Fwebsite?ref=badge_shield)
+[![Docs Health Check](https://github.com/Project-HAMi/website/actions/workflows/docs-health.yml/badge.svg)](https://github.com/Project-HAMi/website/actions/workflows/docs-health.yml) [![FOSSA Status](https://app.fossa.com/api/projects/git%2Bgithub.com%2FProject-HAMi%2Fwebsite.svg?type=shield)](https://app.fossa.com/projects/git%2Bgithub.com%2FProject-HAMi%2Fwebsite?ref=badge_shield) [![License: CC BY 4.0](https://img.shields.io/badge/License-CC%20BY%204.0-lightgrey.svg)](./LICENSE)
 
 Official documentation and website for [HAMi (Heterogeneous AI Computing Virtualization Middleware)](https://project-hami.io/) - an open-source GPU virtualization solution for heterogeneous AI computing.
 

--- a/package.json
+++ b/package.json
@@ -1,5 +1,7 @@
 {
   "name": "@project-hami/website",
+  "description": "HAMi documentation and website",
+  "license": "CC-BY-4.0",
   "repository": {
     "type": "git",
     "url": "https://github.com/Project-HAMi/website.git"


### PR DESCRIPTION
package.json had no description or license field. README only had a FOSSA badge. Added description, license (CC-BY-4.0, matches LICENSE), a CI status badge for the docs-health workflow, and a license badge. Checked the CI badge URL resolves.