### PR TITLE
Add Events page from Google Calendar

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -253,6 +253,18 @@ module.exports = {
         onInlineAuthors: "warn",
       },
     ],
+    [
+      "./src/plugins/events/index.js",
+      {
+        sources: [
+          {
+            name: "Community Call",
+            icsUrl:
+              "https://calendar.google.com/calendar/ical/4eef0c8621ddcb873a7e4be9cf487db9d2278de173451abc78dfbc988c7cad45%40group.calendar.google.com/public/basic.ics",
+          },
+        ],
+      },
+    ],
   ],
   themes: [
     "@docusaurus/theme-mermaid",
@@ -317,6 +329,12 @@ module.exports = {
           to: "/community",
           activeBasePath: "community",
           label: "Community",
+          position: "left",
+        },
+        {
+          to: "/events",
+          activeBasePath: "events",
+          label: "Events",
           position: "left",
         },
         {

--- a/i18n/zh/docusaurus-theme-classic/navbar.json
+++ b/i18n/zh/docusaurus-theme-classic/navbar.json
@@ -50,5 +50,9 @@
   "item.label.Tutorials": {
     "message": "教程",
     "description": "Navbar item with label Tutorials"
+  },
+  "item.label.Events": {
+    "message": "活动",
+    "description": "Navbar item with label Events"
   }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -7,6 +7,7 @@
     "": {
       "name": "@project-hami/website",
       "version": "0.0.1",
+      "license": "CC-BY-4.0",
       "dependencies": {
         "@docusaurus/core": "^3.10.1",
         "@docusaurus/plugin-content-blog": "^3.10.1",
@@ -21,6 +22,7 @@
         "@fortawesome/react-fontawesome": "^3.2.0",
         "asciinema-player": "^3.0.1",
         "clsx": "^1.2.1",
+        "node-ical": "^0.27.1",
         "prism-react-renderer": "^2.4.0",
         "react": "^18.2.0",
         "react-dom": "^18.2.0",
@@ -16253,6 +16255,19 @@
         "node": ">=18"
       }
     },
+    "node_modules/node-ical": {
+      "version": "0.27.1",
+      "resolved": "https://registry.npmjs.org/node-ical/-/node-ical-0.27.1.tgz",
+      "integrity": "sha512-5fiKuh/h2HrWKzFt20LtRQdjtjdGfijGfDnCfdAEc++SFX9gA6sa7xwj7/BJmRfWtW/NJWBenN4tOJhg0vM3pg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "rrule-temporal": "^2.0.0",
+        "temporal-polyfill": "^1.0.1"
+      },
+      "engines": {
+        "node": ">=22"
+      }
+    },
     "node_modules/node-releases": {
       "version": "2.0.50",
       "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.50.tgz",
@@ -19388,6 +19403,15 @@
         "points-on-path": "^0.2.1"
       }
     },
+    "node_modules/rrule-temporal": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/rrule-temporal/-/rrule-temporal-2.0.1.tgz",
+      "integrity": "sha512-pUSHCgOho0yNYMQRu7P6TSqqaj1GjYdSXlzo4zRoO7dVvY3Is7a2QMKYzSLJrMU/OF0tRB/9NzK1YLjQ8dmkug==",
+      "license": "MIT",
+      "dependencies": {
+        "temporal-spec": "^1.0.0"
+      }
+    },
     "node_modules/rtlcss": {
       "version": "4.3.0",
       "resolved": "https://registry.npmjs.org/rtlcss/-/rtlcss-4.3.0.tgz",
@@ -20468,6 +20492,28 @@
       "engines": {
         "node": ">=6"
       }
+    },
+    "node_modules/temporal-polyfill": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/temporal-polyfill/-/temporal-polyfill-1.0.1.tgz",
+      "integrity": "sha512-N2SoI9olnW7BUsU8RosDphZQl9s+WJ8O7PoJMFCr/e5/1rFkVI4GNOWaSeySG+UoP04foPYsnLWbJmbXOiShZg==",
+      "license": "MIT",
+      "dependencies": {
+        "temporal-spec": "1.0.0",
+        "temporal-utils": "1.0.1"
+      }
+    },
+    "node_modules/temporal-spec": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/temporal-spec/-/temporal-spec-1.0.0.tgz",
+      "integrity": "sha512-00Ahj1e1ifaERTMOIIGpOCdOo9IEk2m6GGSMedsn9a2SIsGLdOTbmME1Htv6IM82b6VHrzSUTIVc7YHy6hdhFQ==",
+      "license": "Apache-2.0"
+    },
+    "node_modules/temporal-utils": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/temporal-utils/-/temporal-utils-1.0.1.tgz",
+      "integrity": "sha512-HAixuesxFQIUaQk3ptX2jhfO/FsOkgVkDDMawvp6n/fkB1q6BKfs3lURw9I+pK/2e2e/q/vrLrxmeqauBoyGMQ==",
+      "license": "MIT"
     },
     "node_modules/terser": {
       "version": "5.42.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -22,7 +22,7 @@
         "@fortawesome/react-fontawesome": "^3.2.0",
         "asciinema-player": "^3.0.1",
         "clsx": "^1.2.1",
-        "node-ical": "^0.27.1",
+        "node-ical": "^0.26.1",
         "prism-react-renderer": "^2.4.0",
         "react": "^18.2.0",
         "react-dom": "^18.2.0",
@@ -4549,6 +4549,18 @@
       "dependencies": {
         "@jridgewell/resolve-uri": "^3.1.0",
         "@jridgewell/sourcemap-codec": "^1.4.14"
+      }
+    },
+    "node_modules/@js-temporal/polyfill": {
+      "version": "0.5.1",
+      "resolved": "https://registry.npmjs.org/@js-temporal/polyfill/-/polyfill-0.5.1.tgz",
+      "integrity": "sha512-hloP58zRVCRSpgDxmqCWJNlizAlUgJFqG2ypq79DCvyv9tHjRYMDOcPFjzfl/A1/YxDvRCZz8wvZvmapQnKwFQ==",
+      "license": "ISC",
+      "dependencies": {
+        "jsbi": "^4.3.0"
+      },
+      "engines": {
+        "node": ">=12"
       }
     },
     "node_modules/@jsonjoy.com/base64": {
@@ -12739,6 +12751,12 @@
         "js-yaml": "bin/js-yaml.js"
       }
     },
+    "node_modules/jsbi": {
+      "version": "4.3.2",
+      "resolved": "https://registry.npmjs.org/jsbi/-/jsbi-4.3.2.tgz",
+      "integrity": "sha512-9fqMSQbhJykSeii05nxKl4m6Eqn2P6rOlYiS+C5Dr/HPIU/7yZxu5qzbs40tgaFORiw2Amd0mirjxatXYMkIew==",
+      "license": "Apache-2.0"
+    },
     "node_modules/jsesc": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-3.1.0.tgz",
@@ -16256,16 +16274,16 @@
       }
     },
     "node_modules/node-ical": {
-      "version": "0.27.1",
-      "resolved": "https://registry.npmjs.org/node-ical/-/node-ical-0.27.1.tgz",
-      "integrity": "sha512-5fiKuh/h2HrWKzFt20LtRQdjtjdGfijGfDnCfdAEc++SFX9gA6sa7xwj7/BJmRfWtW/NJWBenN4tOJhg0vM3pg==",
+      "version": "0.26.1",
+      "resolved": "https://registry.npmjs.org/node-ical/-/node-ical-0.26.1.tgz",
+      "integrity": "sha512-KoYLpsz7Ga9lPDpt9vy0iKcgcb/9Ix7ICRZd0csLXMl2lZOSONGj7HrcktJFR7Jid1l44Zu1H4k/1nB04rWPgQ==",
       "license": "Apache-2.0",
       "dependencies": {
-        "rrule-temporal": "^2.0.0",
-        "temporal-polyfill": "^1.0.1"
+        "rrule-temporal": "^1.5.3",
+        "temporal-polyfill": "^0.3.2"
       },
       "engines": {
-        "node": ">=22"
+        "node": ">=20"
       }
     },
     "node_modules/node-releases": {
@@ -19404,11 +19422,12 @@
       }
     },
     "node_modules/rrule-temporal": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/rrule-temporal/-/rrule-temporal-2.0.1.tgz",
-      "integrity": "sha512-pUSHCgOho0yNYMQRu7P6TSqqaj1GjYdSXlzo4zRoO7dVvY3Is7a2QMKYzSLJrMU/OF0tRB/9NzK1YLjQ8dmkug==",
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/rrule-temporal/-/rrule-temporal-1.6.0.tgz",
+      "integrity": "sha512-tlhiNroletItRVdVP3knk92MCPNdFmPpehQMxf+jSo0CHZpmp1WUsvdVpg2iS++J9+O7/89J64BldN21kbcBqA==",
       "license": "MIT",
       "dependencies": {
+        "@js-temporal/polyfill": "^0.5.1",
         "temporal-spec": "^1.0.0"
       }
     },
@@ -20494,26 +20513,25 @@
       }
     },
     "node_modules/temporal-polyfill": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/temporal-polyfill/-/temporal-polyfill-1.0.1.tgz",
-      "integrity": "sha512-N2SoI9olnW7BUsU8RosDphZQl9s+WJ8O7PoJMFCr/e5/1rFkVI4GNOWaSeySG+UoP04foPYsnLWbJmbXOiShZg==",
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/temporal-polyfill/-/temporal-polyfill-0.3.2.tgz",
+      "integrity": "sha512-TzHthD/heRK947GNiSu3Y5gSPpeUDH34+LESnfsq8bqpFhsB79HFBX8+Z834IVX68P3EUyRPZK5bL/1fh437Eg==",
       "license": "MIT",
       "dependencies": {
-        "temporal-spec": "1.0.0",
-        "temporal-utils": "1.0.1"
+        "temporal-spec": "0.3.1"
       }
+    },
+    "node_modules/temporal-polyfill/node_modules/temporal-spec": {
+      "version": "0.3.1",
+      "resolved": "https://registry.npmjs.org/temporal-spec/-/temporal-spec-0.3.1.tgz",
+      "integrity": "sha512-B4TUhezh9knfSIMwt7RVggApDRJZo73uZdj8AacL2mZ8RP5KtLianh2MXxL06GN9ESYiIsiuoLQhgVfwe55Yhw==",
+      "license": "ISC"
     },
     "node_modules/temporal-spec": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/temporal-spec/-/temporal-spec-1.0.0.tgz",
       "integrity": "sha512-00Ahj1e1ifaERTMOIIGpOCdOo9IEk2m6GGSMedsn9a2SIsGLdOTbmME1Htv6IM82b6VHrzSUTIVc7YHy6hdhFQ==",
       "license": "Apache-2.0"
-    },
-    "node_modules/temporal-utils": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/temporal-utils/-/temporal-utils-1.0.1.tgz",
-      "integrity": "sha512-HAixuesxFQIUaQk3ptX2jhfO/FsOkgVkDDMawvp6n/fkB1q6BKfs3lURw9I+pK/2e2e/q/vrLrxmeqauBoyGMQ==",
-      "license": "MIT"
     },
     "node_modules/terser": {
       "version": "5.42.0",

--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
     "@fortawesome/react-fontawesome": "^3.2.0",
     "asciinema-player": "^3.0.1",
     "clsx": "^1.2.1",
-    "node-ical": "^0.27.1",
+    "node-ical": "^0.26.1",
     "prism-react-renderer": "^2.4.0",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",

--- a/package.json
+++ b/package.json
@@ -42,6 +42,7 @@
     "@fortawesome/react-fontawesome": "^3.2.0",
     "asciinema-player": "^3.0.1",
     "clsx": "^1.2.1",
+    "node-ical": "^0.27.1",
     "prism-react-renderer": "^2.4.0",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",

--- a/src/pages/events.js
+++ b/src/pages/events.js
@@ -1,0 +1,296 @@
+import {useState, useMemo} from "react";
+import Layout from "@theme/Layout";
+import useDocusaurusContext from "@docusaurus/useDocusaurusContext";
+import {usePluginData} from "@docusaurus/useGlobalData";
+import styles from "./events.module.css";
+
+const DAYS = 14;
+const DAY_MS = 86400000;
+
+const dateKey = (d) => d.toISOString().slice(0, 10);
+
+function startOfDay(d) {
+  const c = new Date(d);
+  c.setHours(0, 0, 0, 0);
+  return c;
+}
+
+function sameDay(a, b) {
+  return (
+    a.getFullYear() === b.getFullYear() &&
+    a.getMonth() === b.getMonth() &&
+    a.getDate() === b.getDate()
+  );
+}
+
+export default function EventsPage() {
+  const {i18n} = useDocusaurusContext();
+  const {events} = usePluginData("plugin-events");
+  const isZh = i18n.currentLocale === "zh";
+  const localeStr = isZh ? "zh-CN" : "en-US";
+
+  const [activeCategory, setActiveCategory] = useState(null);
+  const [weekOffset, setWeekOffset] = useState(0);
+
+  const today = startOfDay(new Date());
+  const baseSunday = new Date(today);
+  baseSunday.setDate(today.getDate() - today.getDay());
+  const sunday = new Date(baseSunday.getTime() + weekOffset * DAYS * DAY_MS);
+  const days = Array.from({length: DAYS}, (_, i) => {
+    const d = new Date(sunday.getTime() + i * DAY_MS);
+    return d;
+  });
+  const rangeEnd = new Date(sunday.getTime() + DAYS * DAY_MS);
+
+  const categories = useMemo(() => {
+    const set = new Set();
+    if (events) events.forEach((e) => e.categories.forEach((c) => set.add(c)));
+    return [...set].sort();
+  }, [events]);
+
+  const filtered = useMemo(() => {
+    if (!events) return [];
+    if (!activeCategory) return events;
+    return events.filter((e) => e.categories.includes(activeCategory));
+  }, [events, activeCategory]);
+
+  const eventsByDay = useMemo(() => {
+    const map = {};
+    days.forEach((d) => {
+      map[dateKey(d)] = [];
+    });
+    filtered.forEach((e) => {
+      const start = new Date(e.start);
+      if (start >= rangeEnd) return;
+      for (let i = 0; i < DAYS; i++) {
+        if (sameDay(start, days[i])) {
+          map[dateKey(days[i])].push(e);
+          break;
+        }
+      }
+    });
+    return map;
+  }, [filtered, days, rangeEnd]);
+
+  const daysWithEvents = useMemo(
+    () => days.filter((d) => (eventsByDay[dateKey(d)] || []).length > 0),
+    [days, eventsByDay],
+  );
+
+  const formatDay = (d) =>
+    d.toLocaleDateString(localeStr, {day: "numeric"});
+  const formatWeekday = (d) =>
+    d.toLocaleDateString(localeStr, {weekday: "short"});
+  const formatFull = (d) =>
+    d.toLocaleDateString(localeStr, {weekday: "long", month: "long", day: "numeric"});
+  const formatTime = (iso) =>
+    new Date(iso).toLocaleTimeString(localeStr, {
+      hour: "2-digit",
+      minute: "2-digit",
+      timeZoneName: "short",
+    });
+
+  return (
+    <Layout
+      title={isZh ? "活动" : "Events"}
+      description={
+        isZh
+          ? "HAMi 社区活动、会议和发布日程。"
+          : "HAMi community events, meetings, and release schedule."
+      }
+    >
+      <main className={styles.page}>
+        <section className={styles.hero}>
+          <div className="container">
+            <h1 className={styles.title}>
+              {isZh ? "活动" : "Events"}
+            </h1>
+            <p className={styles.subtitle}>
+              {isZh
+                ? "未来两周概览"
+                : "View the next two weeks at a glance"}
+            </p>
+          </div>
+        </section>
+
+        <section className={styles.section}>
+          <div className="container">
+            <div className={styles.toolbar}>
+              {categories.length > 0 && (
+                <div className={styles.filters}>
+                  <button
+                    className={`${styles.filterPill} ${activeCategory === null ? styles.filterPillActive : ""}`}
+                    onClick={() => setActiveCategory(null)}
+                  >
+                    {isZh ? "全部" : "All"}
+                  </button>
+                  {categories.map((cat) => (
+                    <button
+                      key={cat}
+                      className={`${styles.filterPill} ${activeCategory === cat ? styles.filterPillActive : ""}`}
+                      onClick={() =>
+                        setActiveCategory(activeCategory === cat ? null : cat)
+                      }
+                    >
+                      {cat}
+                    </button>
+                  ))}
+                </div>
+              )}
+              <div className={styles.nav}>
+                <button
+                  className={styles.navButton}
+                  onClick={() => setWeekOffset((o) => o - 1)}
+                  disabled={weekOffset <= 0}
+                  title={isZh ? "前两周" : "Previous two weeks"}
+                >
+                  ←
+                </button>
+                <button
+                  className={styles.navButton}
+                  onClick={() => setWeekOffset(0)}
+                  disabled={weekOffset === 0}
+                  title={isZh ? "今天" : "Today"}
+                >
+                  {isZh ? "今天" : "Today"}
+                </button>
+                <button
+                  className={styles.navButton}
+                  onClick={() => setWeekOffset((o) => o + 1)}
+                  title={isZh ? "后两周" : "Next two weeks"}
+                >
+                  →
+                </button>
+              </div>
+            </div>
+
+            <div className={styles.cardGrid}>
+              {days.map((d) => {
+                const key = dateKey(d);
+                const dayEvents = eventsByDay[key] || [];
+                const isToday = sameDay(d, today);
+                const hasEvents = dayEvents.length > 0;
+
+                return (
+                  <div
+                    key={key}
+                    className={`${styles.dayCard} ${!hasEvents ? styles.dayCardEmpty : ""} ${isToday ? styles.dayCardToday : ""}`}
+                  >
+                    <span className={styles.dayWeekday}>
+                      {formatWeekday(d)}
+                    </span>
+                    <span className={styles.dayDate}>
+                      {formatDay(d)}
+                    </span>
+                    {hasEvents && (
+                      <span className={styles.dayDot} />
+                    )}
+                  </div>
+                );
+              })}
+            </div>
+
+            {daysWithEvents.length > 0 && (
+              <div className={styles.agenda}>
+                <h2 className={styles.agendaTitle}>
+                  {isZh ? "日程" : "Agenda"}
+                </h2>
+                {daysWithEvents.map((d) => {
+                  const key = dateKey(d);
+                  const dayEvents = eventsByDay[key] || [];
+
+                  return (
+                    <div key={key} className={styles.agendaDay}>
+                      <div className={styles.agendaDayLabel}>
+                        <strong>{formatFull(d)}</strong>
+                      </div>
+                      <div className={styles.agendaEvents}>
+                        {dayEvents.map((ev, i) => (
+                          <div key={i} className={styles.agendaEvent}>
+                            <span className={styles.agendaTime}>
+                              {formatTime(ev.start)}
+                              {ev.end ? ` - ${formatTime(ev.end)}` : ""}
+                            </span>
+                            <div>
+                              <span className={styles.agendaSummary}>
+                                {ev.summary}
+                              </span>
+                              {ev.location && (
+                                <span className={styles.agendaLocation}>
+                                  {" "}—{" "}
+                                  {/^https?:\/\//.test(ev.location) ? (
+                                    <a href={ev.location} target="_blank" rel="noreferrer">
+                                      {ev.location}
+                                    </a>
+                                  ) : (
+                                    ev.location
+                                  )}
+                                </span>
+                              )}
+                              {ev.categories.length > 0 && (
+                                <span className={styles.agendaTags}>
+                                  {ev.categories.map((cat) => (
+                                    <span key={cat} className={styles.agendaTag}>
+                                      {cat}
+                                    </span>
+                                  ))}
+                                </span>
+                              )}
+                            </div>
+                          </div>
+                        ))}
+                      </div>
+                    </div>
+                  );
+                })}
+              </div>
+            )}
+
+            {(!events || events.length === 0) && (
+              <p className={styles.emptyNote}>
+                {isZh
+                  ? "暂无活动安排，敬请期待。"
+                  : "No upcoming events. Check back soon."}
+              </p>
+            )}
+          </div>
+        </section>
+
+        <section className={styles.cta}>
+          <div className="container">
+            <h2 className={styles.ctaTitle}>
+              {isZh
+                ? "想要主办或参与 HAMi 活动？"
+                : "Want to host or speak at a HAMi event?"}
+            </h2>
+            <ul className={styles.ctaList}>
+              <li>
+                {isZh
+                  ? "在社区会议上分享你的用例或功能"
+                  : "Share your use case or feature at a community meeting"}
+              </li>
+              <li>
+                {isZh
+                  ? "在你所在城市主办线下聚会"
+                  : "Host a meetup in your city"}
+              </li>
+              <li>
+                {isZh
+                  ? "为 HAMi 活动提供赞助或场地支持"
+                  : "Sponsor or provide venue support for a HAMi event"}
+              </li>
+            </ul>
+            <a
+              href="https://discord.gg/Nwt3jVVpnT"
+              className={styles.ctaEmail}
+              target="_blank"
+              rel="noreferrer"
+            >
+              {isZh ? "加入 Discord 活动频道" : "Join the events channel on Discord"}
+            </a>
+          </div>
+        </section>
+      </main>
+    </Layout>
+  );
+}

--- a/src/pages/events.js
+++ b/src/pages/events.js
@@ -8,8 +8,9 @@ import styles from "./events.module.css";
 
 const DAYS = 14;
 
-// en-CA uses YYYY-MM-DD format in local timezone (vs toISOString which is UTC)
-const dateKey = (d) => d.toLocaleDateString("en-CA");
+// local-timezone YYYY-MM-DD, built by hand so the key is deterministic across runtimes
+const dateKey = (d) =>
+  `${d.getFullYear()}-${String(d.getMonth() + 1).padStart(2, "0")}-${String(d.getDate()).padStart(2, "0")}`;
 
 function startOfDay(d) {
   const c = new Date(d);

--- a/src/pages/events.js
+++ b/src/pages/events.js
@@ -1,7 +1,8 @@
-import {useState, useMemo} from "react";
+import { useState, useMemo } from "react";
 import Layout from "@theme/Layout";
 import useDocusaurusContext from "@docusaurus/useDocusaurusContext";
-import {usePluginData} from "@docusaurus/useGlobalData";
+import { usePluginData } from "@docusaurus/useGlobalData";
+import { formatDay, formatWeekday, formatFullDate, formatTime } from "../utils/date";
 import styles from "./events.module.css";
 
 const DAYS = 14;
@@ -24,11 +25,11 @@ function sameDay(a, b) {
 }
 
 export default function EventsPage() {
-  const {i18n} = useDocusaurusContext();
+  const { i18n } = useDocusaurusContext();
   const pluginData = usePluginData("plugin-events");
   const events = pluginData?.events || [];
   const isZh = i18n.currentLocale === "zh";
-  const localeStr = isZh ? "zh-CN" : "en-US";
+  const locale = i18n.currentLocale;
 
   const [activeCategory, setActiveCategory] = useState(null);
   const [weekOffset, setWeekOffset] = useState(0);
@@ -37,7 +38,7 @@ export default function EventsPage() {
   const baseSunday = new Date(today);
   baseSunday.setDate(today.getDate() - today.getDay());
   const sunday = new Date(baseSunday.getTime() + weekOffset * DAYS * DAY_MS);
-  const days = Array.from({length: DAYS}, (_, i) => {
+  const days = Array.from({ length: DAYS }, (_, i) => {
     const d = new Date(sunday.getTime() + i * DAY_MS);
     return d;
   });
@@ -78,18 +79,7 @@ export default function EventsPage() {
     [days, eventsByDay],
   );
 
-  const formatDay = (d) =>
-    d.toLocaleDateString(localeStr, {day: "numeric"});
-  const formatWeekday = (d) =>
-    d.toLocaleDateString(localeStr, {weekday: "short"});
-  const formatFull = (d) =>
-    d.toLocaleDateString(localeStr, {weekday: "long", month: "long", day: "numeric"});
-  const formatTime = (iso) =>
-    new Date(iso).toLocaleTimeString(localeStr, {
-      hour: "2-digit",
-      minute: "2-digit",
-      timeZoneName: "short",
-    });
+  const formatDateFull = (d) => formatFullDate(d, locale);
 
   return (
     <Layout
@@ -103,13 +93,9 @@ export default function EventsPage() {
       <main className={styles.page}>
         <section className={styles.hero}>
           <div className="container">
-            <h1 className={styles.title}>
-              {isZh ? "活动" : "Events"}
-            </h1>
+            <h1 className={styles.title}>{isZh ? "活动" : "Events"}</h1>
             <p className={styles.subtitle}>
-              {isZh
-                ? "未来两周概览"
-                : "View the next two weeks at a glance"}
+              {isZh ? "未来两周概览" : "View the next two weeks at a glance"}
             </p>
           </div>
         </section>
@@ -129,9 +115,7 @@ export default function EventsPage() {
                     <button
                       key={cat}
                       className={`${styles.filterPill} ${activeCategory === cat ? styles.filterPillActive : ""}`}
-                      onClick={() =>
-                        setActiveCategory(activeCategory === cat ? null : cat)
-                      }
+                      onClick={() => setActiveCategory(activeCategory === cat ? null : cat)}
                     >
                       {cat}
                     </button>
@@ -176,15 +160,9 @@ export default function EventsPage() {
                     key={key}
                     className={`${styles.dayCard} ${!hasEvents ? styles.dayCardEmpty : ""} ${isToday ? styles.dayCardToday : ""}`}
                   >
-                    <span className={styles.dayWeekday}>
-                      {formatWeekday(d)}
-                    </span>
-                    <span className={styles.dayDate}>
-                      {formatDay(d)}
-                    </span>
-                    {hasEvents && (
-                      <span className={styles.dayDot} />
-                    )}
+                    <span className={styles.dayWeekday}>{formatWeekday(d, locale)}</span>
+                    <span className={styles.dayDate}>{formatDay(d, locale)}</span>
+                    {hasEvents && <span className={styles.dayDot} />}
                   </div>
                 );
               })}
@@ -192,9 +170,7 @@ export default function EventsPage() {
 
             {daysWithEvents.length > 0 && (
               <div className={styles.agenda}>
-                <h2 className={styles.agendaTitle}>
-                  {isZh ? "日程" : "Agenda"}
-                </h2>
+                <h2 className={styles.agendaTitle}>{isZh ? "日程" : "Agenda"}</h2>
                 {daysWithEvents.map((d) => {
                   const key = dateKey(d);
                   const dayEvents = eventsByDay[key] || [];
@@ -202,22 +178,21 @@ export default function EventsPage() {
                   return (
                     <div key={key} className={styles.agendaDay}>
                       <div className={styles.agendaDayLabel}>
-                        <strong>{formatFull(d)}</strong>
+                        <strong>{formatDateFull(d)}</strong>
                       </div>
                       <div className={styles.agendaEvents}>
                         {dayEvents.map((ev, i) => (
                           <div key={i} className={styles.agendaEvent}>
                             <span className={styles.agendaTime}>
-                              {formatTime(ev.start)}
-                              {ev.end ? ` - ${formatTime(ev.end)}` : ""}
+                              {formatTime(ev.start, locale)}
+                              {ev.end ? ` - ${formatTime(ev.end, locale)}` : ""}
                             </span>
                             <div>
-                              <span className={styles.agendaSummary}>
-                                {ev.summary}
-                              </span>
+                              <span className={styles.agendaSummary}>{ev.summary}</span>
                               {ev.location && (
                                 <span className={styles.agendaLocation}>
-                                  {" "}—{" "}
+                                  {" "}
+                                  —{" "}
                                   {/^https?:\/\//.test(ev.location) ? (
                                     <a href={ev.location} target="_blank" rel="noreferrer">
                                       {ev.location}
@@ -248,9 +223,7 @@ export default function EventsPage() {
 
             {(!events || events.length === 0) && (
               <p className={styles.emptyNote}>
-                {isZh
-                  ? "暂无活动安排，敬请期待。"
-                  : "No upcoming events. Check back soon."}
+                {isZh ? "暂无活动安排，敬请期待。" : "No upcoming events. Check back soon."}
               </p>
             )}
           </div>
@@ -259,9 +232,7 @@ export default function EventsPage() {
         <section className={styles.cta}>
           <div className={`container ${styles.ctaInner}`}>
             <h2 className={styles.ctaTitle}>
-              {isZh
-                ? "想要主办或参与 HAMi 活动？"
-                : "Want to host or speak at a HAMi event?"}
+              {isZh ? "想要主办或参与 HAMi 活动？" : "Want to host or speak at a HAMi event?"}
             </h2>
             <ul className={styles.ctaList}>
               <li>
@@ -269,11 +240,7 @@ export default function EventsPage() {
                   ? "在社区会议上分享你的用例或功能"
                   : "Share your use case or feature at a community meeting"}
               </li>
-              <li>
-                {isZh
-                  ? "在你所在城市主办线下聚会"
-                  : "Host a meetup in your city"}
-              </li>
+              <li>{isZh ? "在你所在城市主办线下聚会" : "Host a meetup in your city"}</li>
               <li>
                 {isZh
                   ? "为 HAMi 活动提供赞助或场地支持"

--- a/src/pages/events.js
+++ b/src/pages/events.js
@@ -37,18 +37,16 @@ export default function EventsPage() {
   const [activeCategory, setActiveCategory] = useState(null);
   const [weekOffset, setWeekOffset] = useState(0);
 
-  const today = startOfDay(new Date());
-  const baseSunday = new Date(today);
-  baseSunday.setDate(today.getDate() - today.getDay());
-  const sunday = new Date(baseSunday);
-  sunday.setDate(sunday.getDate() + weekOffset * DAYS);
-  const days = Array.from({ length: DAYS }, (_, i) => {
-    const d = new Date(sunday);
-    d.setDate(d.getDate() + i);
-    return d;
-  });
-  const rangeEnd = new Date(sunday);
-  rangeEnd.setDate(rangeEnd.getDate() + DAYS);
+  const today = useMemo(() => startOfDay(new Date()), [isBrowser]);
+  const days = useMemo(() => {
+    const sunday = new Date(today);
+    sunday.setDate(today.getDate() - today.getDay() + weekOffset * DAYS);
+    return Array.from({ length: DAYS }, (_, i) => {
+      const d = new Date(sunday);
+      d.setDate(d.getDate() + i);
+      return d;
+    });
+  }, [today, weekOffset]);
 
   const categories = useMemo(() => {
     const set = new Set();
@@ -68,17 +66,13 @@ export default function EventsPage() {
       map[dateKey(d)] = [];
     });
     filtered.forEach((e) => {
-      const start = new Date(e.start);
-      if (start >= rangeEnd) return;
-      for (let i = 0; i < DAYS; i++) {
-        if (sameDay(start, days[i])) {
-          map[dateKey(days[i])].push(e);
-          break;
-        }
+      const key = dateKey(new Date(e.start));
+      if (map[key]) {
+        map[key].push(e);
       }
     });
     return map;
-  }, [filtered, days, rangeEnd]);
+  }, [filtered, days]);
 
   const daysWithEvents = useMemo(
     () => days.filter((d) => (eventsByDay[dateKey(d)] || []).length > 0),

--- a/src/pages/events.js
+++ b/src/pages/events.js
@@ -1,6 +1,7 @@
 import { useState, useMemo } from "react";
 import Layout from "@theme/Layout";
 import useDocusaurusContext from "@docusaurus/useDocusaurusContext";
+import useIsBrowser from "@docusaurus/useIsBrowser";
 import { usePluginData } from "@docusaurus/useGlobalData";
 import { formatDay, formatWeekday, formatFullDate, formatTime } from "../utils/date";
 import styles from "./events.module.css";
@@ -25,6 +26,7 @@ function sameDay(a, b) {
 }
 
 export default function EventsPage() {
+  const isBrowser = useIsBrowser();
   const { i18n } = useDocusaurusContext();
   const pluginData = usePluginData("plugin-events");
   const events = pluginData?.events || [];
@@ -105,133 +107,141 @@ export default function EventsPage() {
 
         <section className={styles.section}>
           <div className="container">
-            <div className={styles.toolbar}>
-              {categories.length > 0 && (
-                <div className={styles.filters}>
-                  <button
-                    className={`${styles.filterPill} ${activeCategory === null ? styles.filterPillActive : ""}`}
-                    onClick={() => setActiveCategory(null)}
-                  >
-                    {isZh ? "全部" : "All"}
-                  </button>
-                  {categories.map((cat) => (
-                    <button
-                      key={cat}
-                      className={`${styles.filterPill} ${activeCategory === cat ? styles.filterPillActive : ""}`}
-                      onClick={() => setActiveCategory(activeCategory === cat ? null : cat)}
-                    >
-                      {cat}
-                    </button>
-                  ))}
-                </div>
-              )}
-              <div className={styles.nav}>
-                <button
-                  className={styles.navArrow}
-                  onClick={() => setWeekOffset((o) => o - 1)}
-                  disabled={weekOffset <= 0}
-                  title={isZh ? "前两周" : "Previous two weeks"}
-                  aria-label={isZh ? "前两周" : "Previous two weeks"}
-                >
-                  ←
-                </button>
-                <button
-                  className={styles.navToday}
-                  onClick={() => setWeekOffset(0)}
-                  disabled={weekOffset === 0}
-                  aria-label={isZh ? "回到今天" : "Back to today"}
-                >
-                  {isZh ? "今天" : "Today"}
-                </button>
-                <button
-                  className={styles.navArrow}
-                  onClick={() => setWeekOffset((o) => o + 1)}
-                  title={isZh ? "后两周" : "Next two weeks"}
-                  aria-label={isZh ? "后两周" : "Next two weeks"}
-                >
-                  →
-                </button>
-              </div>
-            </div>
-
-            <div className={styles.cardGrid}>
-              {days.map((d) => {
-                const key = dateKey(d);
-                const dayEvents = eventsByDay[key] || [];
-                const isToday = sameDay(d, today);
-                const hasEvents = dayEvents.length > 0;
-
-                return (
-                  <div
-                    key={key}
-                    className={`${styles.dayCard} ${!hasEvents ? styles.dayCardEmpty : ""} ${isToday ? styles.dayCardToday : ""}`}
-                  >
-                    <span className={styles.dayWeekday}>{formatWeekday(d, locale)}</span>
-                    <span className={styles.dayDate}>{formatDay(d, locale)}</span>
-                    {hasEvents && <span className={styles.dayDot} />}
-                  </div>
-                );
-              })}
-            </div>
-
-            {daysWithEvents.length > 0 && (
-              <div className={styles.agenda}>
-                <h2 className={styles.agendaTitle}>{isZh ? "日程" : "Agenda"}</h2>
-                {daysWithEvents.map((d) => {
-                  const key = dateKey(d);
-                  const dayEvents = eventsByDay[key] || [];
-
-                  return (
-                    <div key={key} className={styles.agendaDay}>
-                      <div className={styles.agendaDayLabel}>
-                        <strong>{formatDateFull(d)}</strong>
-                      </div>
-                      <div className={styles.agendaEvents}>
-                        {dayEvents.map((ev) => (
-                          <div key={`${ev.start}-${ev.summary}`} className={styles.agendaEvent}>
-                            <span className={styles.agendaTime}>
-                              {formatTime(ev.start, locale)}
-                              {ev.end ? ` - ${formatTime(ev.end, locale)}` : ""}
-                            </span>
-                            <div>
-                              <span className={styles.agendaSummary}>{ev.summary}</span>
-                              {ev.location && (
-                                <span className={styles.agendaLocation}>
-                                  {" - "}
-                                  {/^https?:\/\//.test(ev.location) ? (
-                                    <a href={ev.location} target="_blank" rel="noopener noreferrer">
-                                      {ev.location}
-                                    </a>
-                                  ) : (
-                                    ev.location
-                                  )}
-                                </span>
-                              )}
-                              {ev.categories.length > 0 && (
-                                <span className={styles.agendaTags}>
-                                  {ev.categories.map((cat) => (
-                                    <span key={cat} className={styles.agendaTag}>
-                                      {cat}
-                                    </span>
-                                  ))}
-                                </span>
-                              )}
-                            </div>
-                          </div>
-                        ))}
-                      </div>
+            {isBrowser && (
+              <>
+                <div className={styles.toolbar}>
+                  {categories.length > 0 && (
+                    <div className={styles.filters}>
+                      <button
+                        className={`${styles.filterPill} ${activeCategory === null ? styles.filterPillActive : ""}`}
+                        onClick={() => setActiveCategory(null)}
+                      >
+                        {isZh ? "全部" : "All"}
+                      </button>
+                      {categories.map((cat) => (
+                        <button
+                          key={cat}
+                          className={`${styles.filterPill} ${activeCategory === cat ? styles.filterPillActive : ""}`}
+                          onClick={() => setActiveCategory(activeCategory === cat ? null : cat)}
+                        >
+                          {cat}
+                        </button>
+                      ))}
                     </div>
-                  );
-                })}
-              </div>
-            )}
+                  )}
+                  <div className={styles.nav}>
+                    <button
+                      className={styles.navArrow}
+                      onClick={() => setWeekOffset((o) => o - 1)}
+                      disabled={weekOffset <= 0}
+                      title={isZh ? "前两周" : "Previous two weeks"}
+                      aria-label={isZh ? "前两周" : "Previous two weeks"}
+                    >
+                      ←
+                    </button>
+                    <button
+                      className={styles.navToday}
+                      onClick={() => setWeekOffset(0)}
+                      disabled={weekOffset === 0}
+                      aria-label={isZh ? "回到今天" : "Back to today"}
+                    >
+                      {isZh ? "今天" : "Today"}
+                    </button>
+                    <button
+                      className={styles.navArrow}
+                      onClick={() => setWeekOffset((o) => o + 1)}
+                      title={isZh ? "后两周" : "Next two weeks"}
+                      aria-label={isZh ? "后两周" : "Next two weeks"}
+                    >
+                      →
+                    </button>
+                  </div>
+                </div>
 
-            {daysWithEvents.length === 0 && (
-              <p className={styles.emptyNote}>
-                {isZh
-                  ? "该时间段暂无活动安排，敬请期待。"
-                  : "No events in this period. Check back soon."}
-              </p>
+                <div className={styles.cardGrid}>
+                  {days.map((d) => {
+                    const key = dateKey(d);
+                    const dayEvents = eventsByDay[key] || [];
+                    const isToday = sameDay(d, today);
+                    const hasEvents = dayEvents.length > 0;
+
+                    return (
+                      <div
+                        key={key}
+                        className={`${styles.dayCard} ${!hasEvents ? styles.dayCardEmpty : ""} ${isToday ? styles.dayCardToday : ""}`}
+                      >
+                        <span className={styles.dayWeekday}>{formatWeekday(d, locale)}</span>
+                        <span className={styles.dayDate}>{formatDay(d, locale)}</span>
+                        {hasEvents && <span className={styles.dayDot} />}
+                      </div>
+                    );
+                  })}
+                </div>
+
+                {daysWithEvents.length > 0 && (
+                  <div className={styles.agenda}>
+                    <h2 className={styles.agendaTitle}>{isZh ? "日程" : "Agenda"}</h2>
+                    {daysWithEvents.map((d) => {
+                      const key = dateKey(d);
+                      const dayEvents = eventsByDay[key] || [];
+
+                      return (
+                        <div key={key} className={styles.agendaDay}>
+                          <div className={styles.agendaDayLabel}>
+                            <strong>{formatDateFull(d)}</strong>
+                          </div>
+                          <div className={styles.agendaEvents}>
+                            {dayEvents.map((ev) => (
+                              <div key={`${ev.start}-${ev.summary}`} className={styles.agendaEvent}>
+                                <span className={styles.agendaTime}>
+                                  {formatTime(ev.start, locale)}
+                                  {ev.end ? ` - ${formatTime(ev.end, locale)}` : ""}
+                                </span>
+                                <div>
+                                  <span className={styles.agendaSummary}>{ev.summary}</span>
+                                  {ev.location && (
+                                    <span className={styles.agendaLocation}>
+                                      {" - "}
+                                      {/^https?:\/\//.test(ev.location) ? (
+                                        <a
+                                          href={ev.location}
+                                          target="_blank"
+                                          rel="noopener noreferrer"
+                                        >
+                                          {ev.location}
+                                        </a>
+                                      ) : (
+                                        ev.location
+                                      )}
+                                    </span>
+                                  )}
+                                  {ev.categories.length > 0 && (
+                                    <span className={styles.agendaTags}>
+                                      {ev.categories.map((cat) => (
+                                        <span key={cat} className={styles.agendaTag}>
+                                          {cat}
+                                        </span>
+                                      ))}
+                                    </span>
+                                  )}
+                                </div>
+                              </div>
+                            ))}
+                          </div>
+                        </div>
+                      );
+                    })}
+                  </div>
+                )}
+
+                {daysWithEvents.length === 0 && (
+                  <p className={styles.emptyNote}>
+                    {isZh
+                      ? "该时间段暂无活动安排，敬请期待。"
+                      : "No events in this period. Check back soon."}
+                  </p>
+                )}
+              </>
             )}
           </div>
         </section>

--- a/src/pages/events.js
+++ b/src/pages/events.js
@@ -102,12 +102,18 @@ export default function EventsPage() {
 
         <section className={styles.section}>
           <div className="container">
+            {!isBrowser && (
+              <p className={styles.emptyNote}>
+                {isZh ? "正在加载日历……" : "Loading the calendar..."}
+              </p>
+            )}
             {isBrowser && (
               <>
                 <div className={styles.toolbar}>
                   {categories.length > 0 && (
                     <div className={styles.filters}>
                       <button
+                        type="button"
                         className={`${styles.filterPill} ${activeCategory === null ? styles.filterPillActive : ""}`}
                         onClick={() => setActiveCategory(null)}
                       >
@@ -115,6 +121,7 @@ export default function EventsPage() {
                       </button>
                       {categories.map((cat) => (
                         <button
+                          type="button"
                           key={cat}
                           className={`${styles.filterPill} ${activeCategory === cat ? styles.filterPillActive : ""}`}
                           onClick={() => setActiveCategory(activeCategory === cat ? null : cat)}
@@ -126,6 +133,7 @@ export default function EventsPage() {
                   )}
                   <div className={styles.nav}>
                     <button
+                      type="button"
                       className={styles.navArrow}
                       onClick={() => setWeekOffset((o) => o - 1)}
                       disabled={weekOffset <= 0}
@@ -135,6 +143,7 @@ export default function EventsPage() {
                       ←
                     </button>
                     <button
+                      type="button"
                       className={styles.navToday}
                       onClick={() => setWeekOffset(0)}
                       disabled={weekOffset === 0}
@@ -143,6 +152,7 @@ export default function EventsPage() {
                       {isZh ? "今天" : "Today"}
                     </button>
                     <button
+                      type="button"
                       className={styles.navArrow}
                       onClick={() => setWeekOffset((o) => o + 1)}
                       title={isZh ? "后两周" : "Next two weeks"}

--- a/src/pages/events.js
+++ b/src/pages/events.js
@@ -25,7 +25,8 @@ function sameDay(a, b) {
 
 export default function EventsPage() {
   const {i18n} = useDocusaurusContext();
-  const {events} = usePluginData("plugin-events");
+  const pluginData = usePluginData("plugin-events");
+  const events = pluginData?.events || [];
   const isZh = i18n.currentLocale === "zh";
   const localeStr = isZh ? "zh-CN" : "en-US";
 
@@ -139,7 +140,7 @@ export default function EventsPage() {
               )}
               <div className={styles.nav}>
                 <button
-                  className={styles.navButton}
+                  className={styles.navArrow}
                   onClick={() => setWeekOffset((o) => o - 1)}
                   disabled={weekOffset <= 0}
                   title={isZh ? "前两周" : "Previous two weeks"}
@@ -147,15 +148,14 @@ export default function EventsPage() {
                   ←
                 </button>
                 <button
-                  className={styles.navButton}
+                  className={styles.navToday}
                   onClick={() => setWeekOffset(0)}
                   disabled={weekOffset === 0}
-                  title={isZh ? "今天" : "Today"}
                 >
                   {isZh ? "今天" : "Today"}
                 </button>
                 <button
-                  className={styles.navButton}
+                  className={styles.navArrow}
                   onClick={() => setWeekOffset((o) => o + 1)}
                   title={isZh ? "后两周" : "Next two weeks"}
                 >
@@ -257,7 +257,7 @@ export default function EventsPage() {
         </section>
 
         <section className={styles.cta}>
-          <div className="container">
+          <div className={`container ${styles.ctaInner}`}>
             <h2 className={styles.ctaTitle}>
               {isZh
                 ? "想要主办或参与 HAMi 活动？"
@@ -282,7 +282,7 @@ export default function EventsPage() {
             </ul>
             <a
               href="https://discord.gg/Nwt3jVVpnT"
-              className={styles.ctaEmail}
+              className="button button--primary"
               target="_blank"
               rel="noreferrer"
             >

--- a/src/pages/events.js
+++ b/src/pages/events.js
@@ -131,6 +131,7 @@ export default function EventsPage() {
                   onClick={() => setWeekOffset((o) => o - 1)}
                   disabled={weekOffset <= 0}
                   title={isZh ? "前两周" : "Previous two weeks"}
+                  aria-label={isZh ? "前两周" : "Previous two weeks"}
                 >
                   ←
                 </button>
@@ -138,6 +139,7 @@ export default function EventsPage() {
                   className={styles.navToday}
                   onClick={() => setWeekOffset(0)}
                   disabled={weekOffset === 0}
+                  aria-label={isZh ? "回到今天" : "Back to today"}
                 >
                   {isZh ? "今天" : "Today"}
                 </button>
@@ -145,6 +147,7 @@ export default function EventsPage() {
                   className={styles.navArrow}
                   onClick={() => setWeekOffset((o) => o + 1)}
                   title={isZh ? "后两周" : "Next two weeks"}
+                  aria-label={isZh ? "后两周" : "Next two weeks"}
                 >
                   →
                 </button>
@@ -184,8 +187,8 @@ export default function EventsPage() {
                         <strong>{formatDateFull(d)}</strong>
                       </div>
                       <div className={styles.agendaEvents}>
-                        {dayEvents.map((ev, i) => (
-                          <div key={i} className={styles.agendaEvent}>
+                        {dayEvents.map((ev) => (
+                          <div key={`${ev.start}-${ev.summary}`} className={styles.agendaEvent}>
                             <span className={styles.agendaTime}>
                               {formatTime(ev.start, locale)}
                               {ev.end ? ` - ${formatTime(ev.end, locale)}` : ""}
@@ -194,10 +197,9 @@ export default function EventsPage() {
                               <span className={styles.agendaSummary}>{ev.summary}</span>
                               {ev.location && (
                                 <span className={styles.agendaLocation}>
-                                  {" "}
-                                  —{" "}
+                                  {" - "}
                                   {/^https?:\/\//.test(ev.location) ? (
-                                    <a href={ev.location} target="_blank" rel="noreferrer">
+                                    <a href={ev.location} target="_blank" rel="noopener noreferrer">
                                       {ev.location}
                                     </a>
                                   ) : (
@@ -224,9 +226,11 @@ export default function EventsPage() {
               </div>
             )}
 
-            {(!events || events.length === 0) && (
+            {daysWithEvents.length === 0 && (
               <p className={styles.emptyNote}>
-                {isZh ? "暂无活动安排，敬请期待。" : "No upcoming events. Check back soon."}
+                {isZh
+                  ? "该时间段暂无活动安排，敬请期待。"
+                  : "No events in this period. Check back soon."}
               </p>
             )}
           </div>
@@ -254,7 +258,7 @@ export default function EventsPage() {
               href="https://discord.gg/Nwt3jVVpnT"
               className="button button--primary"
               target="_blank"
-              rel="noreferrer"
+              rel="noopener noreferrer"
             >
               {isZh ? "加入 Discord 活动频道" : "Join the events channel on Discord"}
             </a>

--- a/src/pages/events.js
+++ b/src/pages/events.js
@@ -6,9 +6,9 @@ import { formatDay, formatWeekday, formatFullDate, formatTime } from "../utils/d
 import styles from "./events.module.css";
 
 const DAYS = 14;
-const DAY_MS = 86400000;
 
-const dateKey = (d) => d.toISOString().slice(0, 10);
+// en-CA uses YYYY-MM-DD format in local timezone (vs toISOString which is UTC)
+const dateKey = (d) => d.toLocaleDateString("en-CA");
 
 function startOfDay(d) {
   const c = new Date(d);
@@ -37,12 +37,15 @@ export default function EventsPage() {
   const today = startOfDay(new Date());
   const baseSunday = new Date(today);
   baseSunday.setDate(today.getDate() - today.getDay());
-  const sunday = new Date(baseSunday.getTime() + weekOffset * DAYS * DAY_MS);
+  const sunday = new Date(baseSunday);
+  sunday.setDate(sunday.getDate() + weekOffset * DAYS);
   const days = Array.from({ length: DAYS }, (_, i) => {
-    const d = new Date(sunday.getTime() + i * DAY_MS);
+    const d = new Date(sunday);
+    d.setDate(d.getDate() + i);
     return d;
   });
-  const rangeEnd = new Date(sunday.getTime() + DAYS * DAY_MS);
+  const rangeEnd = new Date(sunday);
+  rangeEnd.setDate(rangeEnd.getDate() + DAYS);
 
   const categories = useMemo(() => {
     const set = new Set();

--- a/src/pages/events.module.css
+++ b/src/pages/events.module.css
@@ -341,7 +341,7 @@
 
 @media (max-width: 768px) {
   .cardGrid {
-    grid-template-columns: repeat(7, minmax(44px, 1fr));
+    grid-template-columns: repeat(7, minmax(0, 1fr));
     gap: 4px;
   }
 

--- a/src/pages/events.module.css
+++ b/src/pages/events.module.css
@@ -1,0 +1,345 @@
+.page {
+  padding-bottom: var(--hami-space-64);
+}
+
+/* ── hero ── */
+
+.hero {
+  padding: var(--hami-space-64) 0 var(--hami-space-32);
+  background:
+    radial-gradient(circle at 0% 0%, rgba(17, 208, 93, 0.18), transparent 34%),
+    linear-gradient(180deg, rgba(17, 208, 93, 0.08), transparent 70%);
+}
+
+.title {
+  margin: 0 0 var(--hami-space-16);
+  max-width: 880px;
+}
+
+.subtitle {
+  margin: 0;
+  max-width: 760px;
+  font-size: 1.08rem;
+}
+
+.section {
+  padding: var(--hami-space-24) 0;
+}
+
+/* ── toolbar ── */
+
+.toolbar {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: var(--hami-space-12);
+  margin-bottom: var(--hami-space-24);
+}
+
+/* ── filters ── */
+
+.filters {
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--hami-space-8);
+}
+
+/* ── nav arrows ── */
+
+.nav {
+  display: flex;
+  gap: 4px;
+  flex-shrink: 0;
+}
+
+.navButton {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 32px;
+  height: 32px;
+  border-radius: 8px;
+  border: 1px solid var(--hami-color-border);
+  background: var(--hami-color-surface);
+  color: var(--hami-color-text);
+  font-size: 0.9rem;
+  cursor: pointer;
+  transition:
+    border-color var(--hami-motion-fast),
+    background var(--hami-motion-fast);
+}
+
+.navButton:hover:not(:disabled) {
+  border-color: var(--hami-color-primary);
+  background: var(--hami-primary-muted);
+}
+
+.navButton:disabled {
+  opacity: 0.35;
+  cursor: default;
+}
+
+.filterPill {
+  display: inline-flex;
+  align-items: center;
+  padding: 4px 12px;
+  border-radius: 999px;
+  border: 1px solid var(--hami-color-border);
+  background: var(--hami-primary-muted);
+  font-size: 0.82rem;
+  font-weight: 600;
+  color: var(--ifm-color-emphasis-700);
+  cursor: pointer;
+  transition:
+    border-color var(--hami-motion-fast),
+    background var(--hami-motion-fast);
+}
+
+.filterPill:hover {
+  border-color: var(--hami-color-primary);
+}
+
+.filterPillActive {
+  border-color: var(--hami-color-primary);
+  background: rgba(17, 208, 93, 0.14);
+  color: var(--hami-color-text);
+}
+
+/* ── 2-week card grid ── */
+
+.cardGrid {
+  display: grid;
+  grid-template-columns: repeat(7, minmax(0, 1fr));
+  gap: 8px;
+}
+
+.dayCard {
+  position: relative;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 4px;
+  padding: 12px 8px 14px;
+  border-radius: var(--hami-radius-lg);
+  border: 1px solid var(--hami-color-border);
+  background: var(--hami-color-surface);
+  transition: opacity 0.2s;
+}
+
+.dayCardEmpty {
+  opacity: 0.45;
+}
+
+.dayCardToday {
+  border-color: var(--hami-color-primary);
+  box-shadow: 0 0 0 1px rgba(17, 208, 93, 0.18);
+}
+
+.dayWeekday {
+  font-size: 0.7rem;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  color: var(--hami-color-muted);
+}
+
+.dayCardToday .dayWeekday {
+  color: var(--hami-color-primary);
+}
+
+.dayDate {
+  font-size: 1.1rem;
+  font-weight: 700;
+  color: var(--hami-color-text);
+}
+
+.dayDot {
+  width: 6px;
+  height: 6px;
+  border-radius: 50%;
+  background: var(--hami-color-primary);
+  margin-top: 2px;
+}
+
+/* ── agenda ── */
+
+.agenda {
+  margin-top: var(--hami-space-48);
+}
+
+.agendaTitle {
+  margin: 0 0 var(--hami-space-20);
+  font-size: 1.2rem;
+}
+
+.agendaDay {
+  padding: var(--hami-space-16) 0;
+  border-top: 1px solid var(--hami-color-border);
+}
+
+.agendaDayLabel {
+  margin-bottom: var(--hami-space-12);
+  font-size: 0.88rem;
+  color: var(--hami-color-muted);
+}
+
+.agendaEvents {
+  display: flex;
+  flex-direction: column;
+  gap: var(--hami-space-12);
+}
+
+.agendaEvent {
+  display: flex;
+  gap: var(--hami-space-16);
+  align-items: baseline;
+}
+
+.agendaTime {
+  flex-shrink: 0;
+  min-width: 130px;
+  font-size: 0.85rem;
+  font-weight: 600;
+  color: var(--hami-color-muted);
+  font-variant-numeric: tabular-nums;
+}
+
+.agendaSummary {
+  font-size: 0.96rem;
+  font-weight: 600;
+  color: var(--hami-color-text);
+}
+
+.agendaLocation {
+  font-size: 0.85rem;
+  color: var(--hami-color-muted);
+}
+
+.agendaTags {
+  display: inline-flex;
+  flex-wrap: wrap;
+  gap: 4px;
+  margin-left: 8px;
+  vertical-align: middle;
+}
+
+.agendaTag {
+  display: inline-block;
+  padding: 1px 8px;
+  border-radius: 999px;
+  border: 1px solid var(--hami-color-border);
+  background: var(--hami-primary-muted);
+  font-size: 0.7rem;
+  font-weight: 600;
+  color: var(--ifm-color-emphasis-700);
+}
+
+/* ── empty ── */
+
+.emptyNote {
+  text-align: center;
+  padding: var(--hami-space-48) 0;
+  color: var(--hami-color-muted);
+  font-size: 1rem;
+}
+
+/* ── cta ── */
+
+.cta {
+  padding: var(--hami-space-64) 0;
+  border-top: 1px solid var(--hami-color-border);
+  background: linear-gradient(180deg, rgba(17, 208, 93, 0.04), transparent);
+  text-align: center;
+}
+
+.ctaTitle {
+  margin: 0 0 var(--hami-space-20);
+  font-size: 1.3rem;
+}
+
+.ctaList {
+  margin: 0 auto var(--hami-space-20);
+  padding: 0;
+  display: inline-flex;
+  flex-direction: column;
+  gap: var(--hami-space-8);
+  color: var(--hami-color-muted);
+  font-size: 0.96rem;
+  line-height: 1.6;
+  list-style: none;
+  text-align: center;
+}
+
+.ctaEmail {
+  display: block;
+  font-weight: 700;
+  font-size: 1rem;
+  color: var(--hami-color-primary);
+}
+
+.ctaEmail:hover {
+  color: var(--hami-color-primary-hover);
+  text-decoration: none;
+}
+
+/* ── dark mode ── */
+
+[data-theme="dark"] .dayCard {
+  border-color: rgba(74, 96, 120, 0.55);
+  background: rgba(22, 30, 42, 0.88);
+}
+
+[data-theme="dark"] .dayCardToday {
+  border-color: var(--hami-color-primary);
+}
+
+[data-theme="dark"] .filterPill {
+  border-color: rgba(74, 96, 120, 0.55);
+  background: rgba(20, 30, 44, 0.9);
+  color: rgba(220, 231, 245, 0.95);
+}
+
+[data-theme="dark"] .filterPill:hover {
+  border-color: var(--hami-color-primary-hover);
+}
+
+[data-theme="dark"] .filterPillActive {
+  border-color: var(--hami-color-primary);
+  background: rgba(17, 208, 93, 0.18);
+  color: #f4ffdf;
+}
+
+[data-theme="dark"] .agendaDay {
+  border-top-color: rgba(74, 96, 120, 0.4);
+}
+
+/* ── responsive ── */
+
+@media (max-width: 768px) {
+  .cardGrid {
+    grid-template-columns: repeat(7, minmax(44px, 1fr));
+    gap: 4px;
+  }
+
+  .dayCard {
+    padding: 8px 2px 10px;
+    gap: 2px;
+  }
+
+  .dayWeekday {
+    font-size: 0.6rem;
+  }
+
+  .dayDate {
+    font-size: 0.88rem;
+  }
+
+  .agendaEvent {
+    flex-direction: column;
+    gap: 2px;
+  }
+
+  .agendaTime {
+    min-width: auto;
+  }
+}

--- a/src/pages/events.module.css
+++ b/src/pages/events.module.css
@@ -48,11 +48,12 @@
 
 .nav {
   display: flex;
-  gap: 4px;
+  gap: 0;
   flex-shrink: 0;
+  margin-left: auto;
 }
 
-.navButton {
+.navArrow {
   display: inline-flex;
   align-items: center;
   justify-content: center;
@@ -67,14 +68,45 @@
   transition:
     border-color var(--hami-motion-fast),
     background var(--hami-motion-fast);
+  flex-shrink: 0;
 }
 
-.navButton:hover:not(:disabled) {
+.navArrow:hover:not(:disabled) {
   border-color: var(--hami-color-primary);
   background: var(--hami-primary-muted);
 }
 
-.navButton:disabled {
+.navArrow:disabled {
+  opacity: 0.35;
+  cursor: default;
+}
+
+.navToday {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  height: 32px;
+  padding: 0 16px;
+  margin: 0 4px;
+  border-radius: 8px;
+  border: 1px solid var(--hami-color-border);
+  background: var(--hami-color-surface);
+  color: var(--hami-color-text);
+  font-size: 0.82rem;
+  font-weight: 600;
+  cursor: pointer;
+  white-space: nowrap;
+  transition:
+    border-color var(--hami-motion-fast),
+    background var(--hami-motion-fast);
+}
+
+.navToday:hover:not(:disabled) {
+  border-color: var(--hami-color-primary);
+  background: var(--hami-primary-muted);
+}
+
+.navToday:disabled {
   opacity: 0.35;
   cursor: default;
 }
@@ -249,37 +281,29 @@
   padding: var(--hami-space-64) 0;
   border-top: 1px solid var(--hami-color-border);
   background: linear-gradient(180deg, rgba(17, 208, 93, 0.04), transparent);
+}
+
+.ctaInner {
+  max-width: 560px;
+  margin: 0 auto;
   text-align: center;
 }
 
 .ctaTitle {
-  margin: 0 0 var(--hami-space-20);
+  margin: 0 0 var(--hami-space-32);
   font-size: 1.3rem;
 }
 
 .ctaList {
-  margin: 0 auto var(--hami-space-20);
-  padding: 0;
+  margin: 0 0 var(--hami-space-32);
+  padding: 0 0 0 2rem;
   display: inline-flex;
   flex-direction: column;
   gap: var(--hami-space-8);
   color: var(--hami-color-muted);
   font-size: 0.96rem;
   line-height: 1.6;
-  list-style: none;
-  text-align: center;
-}
-
-.ctaEmail {
-  display: block;
-  font-weight: 700;
-  font-size: 1rem;
-  color: var(--hami-color-primary);
-}
-
-.ctaEmail:hover {
-  color: var(--hami-color-primary-hover);
-  text-decoration: none;
+  text-align: left;
 }
 
 /* ── dark mode ── */

--- a/src/plugins/events/index.js
+++ b/src/plugins/events/index.js
@@ -30,14 +30,15 @@ export default function pluginEvents(context, options) {
           for (const ev of vevents) {
             const expanded = ical.expandRecurringEvent(ev, { from: now, to: rangeEnd });
             for (const inst of expanded) {
+              if (!inst.start) {
+                continue;
+              }
               instances.push({
-                summary: inst.event.summary || ev.summary || "",
-                start: inst.start?.toISOString() || "",
+                summary: inst.summary || ev.summary || "",
+                start: inst.start.toISOString(),
                 end: inst.end?.toISOString() || "",
-                location: inst.event.location || ev.location || "",
-                description: sanitizeCalendarDescription(
-                  inst.event.description || ev.description || "",
-                ),
+                location: inst.location || ev.location || "",
+                description: sanitizeCalendarDescription(inst.description || ev.description || ""),
                 categories: [sourceTag],
               });
             }

--- a/src/plugins/events/index.js
+++ b/src/plugins/events/index.js
@@ -1,0 +1,72 @@
+import ical from 'node-ical';
+
+const STRIP_ATTRS = /\s(on\w+|style|class|id|data-\w+)\s*=\s*"[^"]*"/gi;
+const STRIP_TAGS = /<(?!\/?(a|b|i|em|strong|u|ul|ol|li|br|p)\b)[^>]*>/gi;
+const URL_RE = /(?<!href="|">)(https?:\/\/[^\s<>"')\]]+)/gi;
+
+function sanitizeHTML(text) {
+  if (!text) return '';
+  let out = text.replace(/\\n/g, '');
+  out = out.replace(/:\w+:/g, '');
+  out = out.replace(STRIP_TAGS, '');
+  out = out.replace(STRIP_ATTRS, '');
+  out = out.replace(URL_RE, '<a href="$1">$1</a>');
+  return out;
+}
+
+export default function pluginEvents(context, options) {
+  const {sources} = options;
+  if (!sources || !sources.length) {
+    throw new Error('plugin-events: must provide `sources` array with at least one {name, icsUrl} entry');
+  }
+
+  return {
+    name: 'plugin-events',
+
+    async loadContent() {
+      const now = new Date();
+      now.setHours(0, 0, 0, 0);
+      const rangeEnd = new Date(now);
+      rangeEnd.setMonth(rangeEnd.getMonth() + 6);
+      const all = [];
+
+      for (const src of sources) {
+        try {
+          const data = await ical.async.fromURL(src.icsUrl, {});
+          const sourceTag = src.name;
+
+          const vevents = Object.values(data).filter((e) => e.type === 'VEVENT');
+
+          const instances = [];
+          for (const ev of vevents) {
+            const expanded = ical.expandRecurringEvent(ev, {from: now, to: rangeEnd});
+            for (const inst of expanded) {
+              instances.push({
+                summary: inst.event.summary || ev.summary || '',
+                start: inst.start?.toISOString() || '',
+                end: inst.end?.toISOString() || '',
+                location: inst.event.location || ev.location || '',
+                description: sanitizeHTML(inst.event.description || ev.description || ''),
+                categories: [sourceTag],
+              });
+            }
+          }
+
+          console.log(`plugin-events: "${src.name}" — ${vevents.length} VEVENTs → ${instances.length} instances expanded`);
+          all.push(...instances);
+        } catch (err) {
+          console.warn(
+            `plugin-events: failed to parse "${src.name}" (${src.icsUrl}), skipping:`,
+            err.message,
+          );
+        }
+      }
+
+      return all.sort((a, b) => a.start.localeCompare(b.start));
+    },
+
+    async contentLoaded({content, actions}) {
+      actions.setGlobalData({events: content});
+    },
+  };
+};

--- a/src/plugins/events/index.js
+++ b/src/plugins/events/index.js
@@ -1,18 +1,5 @@
 import ical from 'node-ical';
-
-const STRIP_ATTRS = /\s(on\w+|style|class|id|data-\w+)\s*=\s*"[^"]*"/gi;
-const STRIP_TAGS = /<(?!\/?(a|b|i|em|strong|u|ul|ol|li|br|p)\b)[^>]*>/gi;
-const URL_RE = /(?<!href="|">)(https?:\/\/[^\s<>"')\]]+)/gi;
-
-function sanitizeHTML(text) {
-  if (!text) return '';
-  let out = text.replace(/\\n/g, '');
-  out = out.replace(/:\w+:/g, '');
-  out = out.replace(STRIP_TAGS, '');
-  out = out.replace(STRIP_ATTRS, '');
-  out = out.replace(URL_RE, '<a href="$1">$1</a>');
-  return out;
-}
+import { sanitizeCalendarDescription } from '../../utils/ical.js';
 
 export default function pluginEvents(context, options) {
   const {sources} = options;
@@ -46,7 +33,7 @@ export default function pluginEvents(context, options) {
                 start: inst.start?.toISOString() || '',
                 end: inst.end?.toISOString() || '',
                 location: inst.event.location || ev.location || '',
-                description: sanitizeHTML(inst.event.description || ev.description || ''),
+                description: sanitizeCalendarDescription(inst.event.description || ev.description || ''),
                 categories: [sourceTag],
               });
             }

--- a/src/plugins/events/index.js
+++ b/src/plugins/events/index.js
@@ -1,5 +1,4 @@
 import ical from "node-ical";
-import { sanitizeCalendarDescription } from "../../utils/ical.js";
 
 export default function pluginEvents(context, options) {
   const { sources } = options;
@@ -38,7 +37,6 @@ export default function pluginEvents(context, options) {
                 start: inst.start.toISOString(),
                 end: inst.end?.toISOString() || "",
                 location: inst.location || ev.location || "",
-                description: sanitizeCalendarDescription(inst.description || ev.description || ""),
                 categories: [sourceTag],
               });
             }

--- a/src/plugins/events/index.js
+++ b/src/plugins/events/index.js
@@ -21,7 +21,7 @@ export default function pluginEvents(context, options) {
 
       for (const src of sources) {
         try {
-          const data = await ical.async.fromURL(src.icsUrl, {});
+          const data = await ical.async.fromURL(src.icsUrl, { timeout: 10000 });
           const sourceTag = src.name;
 
           const vevents = Object.values(data).filter((e) => e.type === "VEVENT");
@@ -44,7 +44,7 @@ export default function pluginEvents(context, options) {
           }
 
           console.log(
-            `plugin-events: "${src.name}" — ${vevents.length} VEVENTs → ${instances.length} instances expanded`,
+            `plugin-events: "${src.name}": ${vevents.length} VEVENTs, ${instances.length} instances expanded`,
           );
           all.push(...instances);
         } catch (err) {

--- a/src/plugins/events/index.js
+++ b/src/plugins/events/index.js
@@ -1,14 +1,16 @@
-import ical from 'node-ical';
-import { sanitizeCalendarDescription } from '../../utils/ical.js';
+import ical from "node-ical";
+import { sanitizeCalendarDescription } from "../../utils/ical.js";
 
 export default function pluginEvents(context, options) {
-  const {sources} = options;
+  const { sources } = options;
   if (!sources || !sources.length) {
-    throw new Error('plugin-events: must provide `sources` array with at least one {name, icsUrl} entry');
+    throw new Error(
+      "plugin-events: must provide `sources` array with at least one {name, icsUrl} entry",
+    );
   }
 
   return {
-    name: 'plugin-events',
+    name: "plugin-events",
 
     async loadContent() {
       const now = new Date();
@@ -22,24 +24,28 @@ export default function pluginEvents(context, options) {
           const data = await ical.async.fromURL(src.icsUrl, {});
           const sourceTag = src.name;
 
-          const vevents = Object.values(data).filter((e) => e.type === 'VEVENT');
+          const vevents = Object.values(data).filter((e) => e.type === "VEVENT");
 
           const instances = [];
           for (const ev of vevents) {
-            const expanded = ical.expandRecurringEvent(ev, {from: now, to: rangeEnd});
+            const expanded = ical.expandRecurringEvent(ev, { from: now, to: rangeEnd });
             for (const inst of expanded) {
               instances.push({
-                summary: inst.event.summary || ev.summary || '',
-                start: inst.start?.toISOString() || '',
-                end: inst.end?.toISOString() || '',
-                location: inst.event.location || ev.location || '',
-                description: sanitizeCalendarDescription(inst.event.description || ev.description || ''),
+                summary: inst.event.summary || ev.summary || "",
+                start: inst.start?.toISOString() || "",
+                end: inst.end?.toISOString() || "",
+                location: inst.event.location || ev.location || "",
+                description: sanitizeCalendarDescription(
+                  inst.event.description || ev.description || "",
+                ),
                 categories: [sourceTag],
               });
             }
           }
 
-          console.log(`plugin-events: "${src.name}" — ${vevents.length} VEVENTs → ${instances.length} instances expanded`);
+          console.log(
+            `plugin-events: "${src.name}" — ${vevents.length} VEVENTs → ${instances.length} instances expanded`,
+          );
           all.push(...instances);
         } catch (err) {
           console.warn(
@@ -52,8 +58,8 @@ export default function pluginEvents(context, options) {
       return all.sort((a, b) => a.start.localeCompare(b.start));
     },
 
-    async contentLoaded({content, actions}) {
-      actions.setGlobalData({events: content});
+    async contentLoaded({ content, actions }) {
+      actions.setGlobalData({ events: content });
     },
   };
-};
+}

--- a/src/utils/date.js
+++ b/src/utils/date.js
@@ -1,9 +1,7 @@
-function lang(locale) {
-  return locale === "zh" ? "zh-CN" : "en-US";
-}
+const LOCALE_MAP = { zh: "zh-CN", en: "en-US" };
 
 export function formatDate(dateStr, locale) {
-  return new Intl.DateTimeFormat(lang(locale), {
+  return new Intl.DateTimeFormat(LOCALE_MAP[locale], {
     year: "numeric",
     month: "long",
     day: "numeric",
@@ -11,7 +9,7 @@ export function formatDate(dateStr, locale) {
 }
 
 export function formatDateRange(startStr, endStr, locale) {
-  return new Intl.DateTimeFormat(lang(locale), {
+  return new Intl.DateTimeFormat(LOCALE_MAP[locale], {
     year: "numeric",
     month: "long",
     day: "numeric",
@@ -19,15 +17,15 @@ export function formatDateRange(startStr, endStr, locale) {
 }
 
 export function formatDay(date, locale) {
-  return date.toLocaleDateString(lang(locale), { day: "numeric" });
+  return date.toLocaleDateString(LOCALE_MAP[locale], { day: "numeric" });
 }
 
 export function formatWeekday(date, locale) {
-  return date.toLocaleDateString(lang(locale), { weekday: "short" });
+  return date.toLocaleDateString(LOCALE_MAP[locale], { weekday: "short" });
 }
 
 export function formatFullDate(date, locale) {
-  return date.toLocaleDateString(lang(locale), {
+  return date.toLocaleDateString(LOCALE_MAP[locale], {
     weekday: "long",
     month: "long",
     day: "numeric",
@@ -35,7 +33,7 @@ export function formatFullDate(date, locale) {
 }
 
 export function formatTime(isoStr, locale) {
-  return new Date(isoStr).toLocaleTimeString(lang(locale), {
+  return new Date(isoStr).toLocaleTimeString(LOCALE_MAP[locale], {
     hour: "2-digit",
     minute: "2-digit",
     timeZoneName: "short",

--- a/src/utils/date.js
+++ b/src/utils/date.js
@@ -1,0 +1,43 @@
+function lang(locale) {
+  return locale === "zh" ? "zh-CN" : "en-US";
+}
+
+export function formatDate(dateStr, locale) {
+  return new Intl.DateTimeFormat(lang(locale), {
+    year: "numeric",
+    month: "long",
+    day: "numeric",
+  }).format(new Date(dateStr));
+}
+
+export function formatDateRange(startStr, endStr, locale) {
+  return new Intl.DateTimeFormat(lang(locale), {
+    year: "numeric",
+    month: "long",
+    day: "numeric",
+  }).formatRange(new Date(startStr), new Date(endStr));
+}
+
+export function formatDay(date, locale) {
+  return date.toLocaleDateString(lang(locale), { day: "numeric" });
+}
+
+export function formatWeekday(date, locale) {
+  return date.toLocaleDateString(lang(locale), { weekday: "short" });
+}
+
+export function formatFullDate(date, locale) {
+  return date.toLocaleDateString(lang(locale), {
+    weekday: "long",
+    month: "long",
+    day: "numeric",
+  });
+}
+
+export function formatTime(isoStr, locale) {
+  return new Date(isoStr).toLocaleTimeString(lang(locale), {
+    hour: "2-digit",
+    minute: "2-digit",
+    timeZoneName: "short",
+  });
+}

--- a/src/utils/ical.js
+++ b/src/utils/ical.js
@@ -1,0 +1,13 @@
+const STRIP_ATTRS = /\s(on\w+|style|class|id|data-\w+)\s*=\s*"[^"]*"/gi;
+const STRIP_TAGS = /<(?!\/?(a|b|i|em|strong|u|ul|ol|li|br|p)\b)[^>]*>/gi;
+const URL_RE = /(?<!href="|">)(https?:\/\/[^\s<>"')\]]+)/gi;
+
+export function sanitizeCalendarDescription(text) {
+  if (!text) return "";
+  let out = text.replace(/\\n/g, "");
+  out = out.replace(/:\w+:/g, "");
+  out = out.replace(STRIP_TAGS, "");
+  out = out.replace(STRIP_ATTRS, "");
+  out = out.replace(URL_RE, '<a href="$1">$1</a>');
+  return out;
+}

--- a/src/utils/ical.js
+++ b/src/utils/ical.js
@@ -1,7 +1,0 @@
-export function sanitizeCalendarDescription(text) {
-  if (!text) return "";
-  let out = text.replace(/\\n/g, " ");
-  out = out.replace(/:\w+:/g, "");
-  out = out.replace(/<[^>]*>/g, " ");
-  return out.replace(/\s+/g, " ").trim();
-}

--- a/src/utils/ical.js
+++ b/src/utils/ical.js
@@ -1,13 +1,7 @@
-const STRIP_ATTRS = /\s(on\w+|style|class|id|data-\w+)\s*=\s*"[^"]*"/gi;
-const STRIP_TAGS = /<(?!\/?(a|b|i|em|strong|u|ul|ol|li|br|p)\b)[^>]*>/gi;
-const URL_RE = /(?<!href="|">)(https?:\/\/[^\s<>"')\]]+)/gi;
-
 export function sanitizeCalendarDescription(text) {
   if (!text) return "";
-  let out = text.replace(/\\n/g, "");
+  let out = text.replace(/\\n/g, " ");
   out = out.replace(/:\w+:/g, "");
-  out = out.replace(STRIP_TAGS, "");
-  out = out.replace(STRIP_ATTRS, "");
-  out = out.replace(URL_RE, '<a href="$1">$1</a>');
-  return out;
+  out = out.replace(/<[^>]*>/g, " ");
+  return out.replace(/\s+/g, " ").trim();
 }


### PR DESCRIPTION
- Create new Events page with 2-week calendar grid, agenda view, and category filters

Co-authored-by: deepseek <deepseek@users.noreply.github.com>
Signed-off-by: Reza Jelveh <fishmangit@dynamia.ai>

**What type of PR is this?**

/kind documentation
/kind feature

**What this PR does / why we need it**:

This is based on the vLLM events page. https://vllm.ai/events


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an Events page accessible from the main navigation.
  * Displays upcoming community events in a two-week calendar and agenda view.
  * Added week navigation, “Today” shortcut, category filters, event details, locations, and tags.
  * Supports recurring events, localized Chinese and English date/time formatting, dark mode, and responsive layouts.
  * Added a community call calendar and a Discord invitation call to action.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->