### PR TITLE
ci: pin GitHub Actions to commit SHAs

### DIFF
--- a/.github/workflows/docs-health.yml
+++ b/.github/workflows/docs-health.yml
@@ -15,10 +15,10 @@ jobs:
     name: Lint, Format, Build & Links
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
 
       - name: Setup Node.js
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@249970729cb0ef3589644e2896645e5dc5ba9c38 # v6
         with:
           node-version: 20
           cache: npm


### PR DESCRIPTION
## What

Pins `actions/checkout` and `actions/setup-node` in `docs-health.yml` to full commit SHAs with the tag kept as a comment.

## Why

Tag references like `@v7` are mutable. If an action repository is compromised, the tag can be repointed to a malicious commit and every workflow using it runs that code with repo access. Pinning to the commit SHA removes that attack path. This is the OSSF Scorecard `Pinned-Dependencies` check, which also feeds the LFX Insights security score.

SHAs resolved from the official tags:
- `actions/checkout@v7` -> `3d3c42e5aac5ba805825da76410c181273ba90b1`
- `actions/setup-node@v6` -> `249970729cb0ef3589644e2896645e5dc5ba9c38`