### PR TITLE
chore: use https for adopter and contributor links

### DIFF
--- a/src/data/adopters.json
+++ b/src/data/adopters.json
@@ -337,7 +337,7 @@
     "name": "RageHealth",
     "nameZh": "深圳伯德睿捷健康科技有限公司",
     "logo": "/img/adopters/ragehealth.png",
-    "website": "http://ragehealth.cn/"
+    "website": "https://ragehealth.cn/"
   },
   {
     "name": "Shanghai Ashermed Medical Technology Co., Ltd.",

--- a/src/data/contributors.js
+++ b/src/data/contributors.js
@@ -77,7 +77,7 @@ const contributorsData = [
   {
     logo: "/img/contributors/tenxcloud.svg",
     alt: "TenxCloud",
-    href: "http://www.tenxcloud.com",
+    href: "https://www.tenxcloud.com",
   },
   {
     logo: "/img/contributors/caih.png",


### PR DESCRIPTION
## What

Switches two external links from `http://` to `https://`:

- `src/data/adopters.json`: `ragehealth.cn`
- `src/data/contributors.js`: `www.tenxcloud.com`

Both sites were verified to serve HTTP 200 over https. The remaining `http://www.arkunion.com` link is left unchanged because that host does not answer on https.

## Why

LFX Insights control OSPS-BR-03.01 checks that all links in the project use encrypted channels. Plain http links from the site expose visitors to trivial downgrade and injection on the hop.