### PR TITLE
Add event landing page component, and Kubecon Japan event

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7,6 +7,7 @@
     "": {
       "name": "@project-hami/website",
       "version": "0.0.1",
+      "license": "CC-BY-4.0",
       "dependencies": {
         "@docusaurus/core": "^3.10.1",
         "@docusaurus/plugin-content-blog": "^3.10.1",

--- a/src/components/EventLanding.js
+++ b/src/components/EventLanding.js
@@ -47,14 +47,15 @@ export default function EventLanding({ event }) {
   const { i18n } = useDocusaurusContext();
   const isZh = i18n.currentLocale === "zh";
   const locale = i18n.currentLocale;
+  const bannerUrl = event.banner && useBaseUrl(event.banner);
 
   return (
     <main className={styles.page}>
       <section className={styles.hero}>
         <div className="container">
-          {event.banner && (
+          {bannerUrl && (
             <img
-              src={useBaseUrl(event.banner)}
+              src={bannerUrl}
               alt={pick(locale, event.title)}
               className={styles.banner}
             />

--- a/src/components/EventLanding.js
+++ b/src/components/EventLanding.js
@@ -47,13 +47,13 @@ export default function EventLanding({ event }) {
   const { i18n } = useDocusaurusContext();
   const isZh = i18n.currentLocale === "zh";
   const locale = i18n.currentLocale;
-  const bannerUrl = event.banner && useBaseUrl(event.banner);
+  const bannerUrl = useBaseUrl(event.banner || "");
 
   return (
     <main className={styles.page}>
       <section className={styles.hero}>
         <div className="container">
-          {bannerUrl && (
+          {event.banner && (
             <img src={bannerUrl} alt={pick(locale, event.title)} className={styles.banner} />
           )}
           <h1 className={styles.title}>{pick(locale, event.title)}</h1>

--- a/src/components/EventLanding.js
+++ b/src/components/EventLanding.js
@@ -1,0 +1,173 @@
+import useDocusaurusContext from "@docusaurus/useDocusaurusContext";
+import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
+import { faDiscord, faGithub } from "@fortawesome/free-brands-svg-icons";
+import {
+  faCalendarDays,
+  faLocationDot,
+  faFilePdf,
+  faVideo,
+} from "@fortawesome/free-solid-svg-icons";
+import useBaseUrl from "@docusaurus/useBaseUrl";
+import styles from "./EventLanding.module.css";
+
+function pick(locale, obj) {
+  return locale === "zh" && obj.zh ? obj.zh : obj.en;
+}
+
+function localeStr(locale) {
+  return locale === "zh" ? "zh-CN" : "en-US";
+}
+
+function formatDate(dateStr, locale) {
+  return new Date(dateStr).toLocaleDateString(localeStr(locale), {
+    year: "numeric",
+    month: "long",
+    day: "numeric",
+  });
+}
+
+function formatDateRange(startStr, endStr, locale) {
+  const lang = localeStr(locale);
+  const opts = { month: "long", day: "numeric" };
+  const start = new Date(startStr);
+  const end = new Date(endStr);
+  if (start.getFullYear() === end.getFullYear()) {
+    const startShort = start.toLocaleDateString(lang, opts);
+    const endShort = end.toLocaleDateString(lang, opts);
+    if (start.getMonth() === end.getMonth()) {
+      return `${startShort} – ${end.getDate()}, ${end.getFullYear()}`;
+    }
+    return `${startShort} – ${endShort}, ${end.getFullYear()}`;
+  }
+  return `${formatDate(startStr, locale)} – ${formatDate(endStr, locale)}`;
+}
+
+export default function EventLanding({ event }) {
+  const { i18n } = useDocusaurusContext();
+  const isZh = i18n.currentLocale === "zh";
+  const locale = i18n.currentLocale;
+
+  return (
+    <main className={styles.page}>
+      <section className={styles.hero}>
+        <div className="container">
+          {event.banner && (
+            <img
+              src={useBaseUrl(event.banner)}
+              alt={pick(locale, event.title)}
+              className={styles.banner}
+            />
+          )}
+          <h1 className={styles.title}>{pick(locale, event.title)}</h1>
+          <div className={styles.meta}>
+            <span className={styles.metaItem}>
+              <FontAwesomeIcon icon={faCalendarDays} className={styles.metaIcon} />
+              {event.endDate
+                ? formatDateRange(event.date, event.endDate, locale)
+                : formatDate(event.date, locale)}
+            </span>
+            <span className={styles.metaItem}>
+              <FontAwesomeIcon icon={faLocationDot} className={styles.metaIcon} />
+              {pick(locale, event.location)}
+            </span>
+          </div>
+          <p className={styles.description}>{pick(locale, event.description)}</p>
+        </div>
+      </section>
+
+      {event.caseStudy && (
+        <section className={styles.caseStudySection}>
+          <div className="container">
+            <div className={`hami-section-card ${styles.caseStudyCard}`}>
+              <h2 className={styles.sectionTitle}>{isZh ? "相关案例" : "Related Case Study"}</h2>
+              <div className={styles.caseStudyBody}>
+                <div className={styles.caseStudyCompany}>
+                  {pick(locale, {
+                    en: event.caseStudy.company,
+                    zh: event.caseStudy.companyZh || event.caseStudy.company,
+                  })}
+                </div>
+                <ul className={styles.highlights}>
+                  {event.caseStudy.highlights.map((h, i) => (
+                    <li key={i}>{pick(locale, h)}</li>
+                  ))}
+                </ul>
+                <a
+                  href={event.caseStudy.url}
+                  className={styles.caseStudyLink}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                >
+                  {isZh ? "查看 CNCF 原文" : "Read on CNCF"} →
+                </a>
+              </div>
+            </div>
+          </div>
+        </section>
+      )}
+
+      {event.resources && (
+        <section className={styles.resources}>
+          <div className="container">
+            <div className={`hami-section-card ${styles.resourcesCard}`}>
+              <h2 className={styles.sectionTitle}>{isZh ? "会议资料" : "Event Resources"}</h2>
+              <div className={styles.resourceList}>
+                {[
+                  { key: "communityFlyer", icon: faFilePdf },
+                  { key: "talkSlides", icon: faFilePdf },
+                  { key: "speakerReel", icon: faVideo },
+                ]
+                  .filter((r) => event.resources[r.key]?.url)
+                  .map((r) => (
+                    <a
+                      key={r.key}
+                      href={event.resources[r.key].url}
+                      className={styles.resourceLink}
+                      target="_blank"
+                      rel="noopener noreferrer"
+                    >
+                      <FontAwesomeIcon icon={r.icon} className={styles.resourceIcon} />
+                      <span>{pick(locale, event.resources[r.key])}</span>
+                    </a>
+                  ))}
+              </div>
+            </div>
+          </div>
+        </section>
+      )}
+
+      <section className={styles.cta}>
+        <div className="container">
+          <div className={`hami-section-card ${styles.ctaCard}`}>
+            <h2 className={styles.ctaTitle}>{isZh ? "加入社区" : "Join the Community"}</h2>
+            <p className={styles.ctaText}>
+              {isZh
+                ? "参与 HAMi 开源项目，与维护者和社区成员交流。"
+                : "Get involved with the HAMi open-source project. Connect with maintainers and the community."}
+            </p>
+            <div className={styles.ctaButtons}>
+              <a
+                href={event.cta.discordUrl}
+                className="button button--primary button--lg"
+                target="_blank"
+                rel="noopener noreferrer"
+              >
+                <FontAwesomeIcon icon={faDiscord} className={styles.btnIcon} />
+                Discord
+              </a>
+              <a
+                href={event.cta.githubUrl}
+                className="button button--outline button--lg"
+                target="_blank"
+                rel="noopener noreferrer"
+              >
+                <FontAwesomeIcon icon={faGithub} className={styles.btnIcon} />
+                GitHub
+              </a>
+            </div>
+          </div>
+        </div>
+      </section>
+    </main>
+  );
+}

--- a/src/components/EventLanding.js
+++ b/src/components/EventLanding.js
@@ -103,7 +103,7 @@ export default function EventLanding({ event }) {
         </section>
       )}
 
-      {event.resources && (
+      {event.resources && Object.values(event.resources).some((r) => r?.url) && (
         <section className={styles.resources}>
           <div className="container">
             <div className={`hami-section-card ${styles.resourcesCard}`}>

--- a/src/components/EventLanding.js
+++ b/src/components/EventLanding.js
@@ -10,8 +10,12 @@ import {
 import useBaseUrl from "@docusaurus/useBaseUrl";
 import styles from "./EventLanding.module.css";
 
+function isChinese(locale) {
+  return locale.startsWith("zh");
+}
+
 function pick(locale, obj) {
-  return locale === "zh" && obj.zh ? obj.zh : obj.en;
+  return isChinese(locale) && obj.zh ? obj.zh : obj.en;
 }
 
 function utm(url, slug) {
@@ -33,10 +37,11 @@ const DEFAULTS = {
 };
 
 function dateFmt(locale) {
-  return new Intl.DateTimeFormat(locale === "zh" ? "zh-CN" : "en-US", {
+  return new Intl.DateTimeFormat(isChinese(locale) ? "zh-CN" : "en-US", {
     year: "numeric",
     month: "long",
     day: "numeric",
+    timeZone: "UTC",
   });
 }
 
@@ -54,7 +59,7 @@ function formatDateRange(startStr, endStr, locale) {
 
 export default function EventLanding({ event }) {
   const { i18n } = useDocusaurusContext();
-  const isZh = i18n.currentLocale === "zh";
+  const isZh = isChinese(i18n.currentLocale);
   const locale = i18n.currentLocale;
   const bannerUrl = useBaseUrl(event.banner || "");
 
@@ -95,8 +100,8 @@ export default function EventLanding({ event }) {
                   })}
                 </div>
                 <ul className={styles.highlights}>
-                  {event.caseStudy.highlights.map((h, i) => (
-                    <li key={i}>{pick(locale, h)}</li>
+                  {event.caseStudy.highlights.map((h) => (
+                    <li key={h.en}>{pick(locale, h)}</li>
                   ))}
                 </ul>
                 <a

--- a/src/components/EventLanding.js
+++ b/src/components/EventLanding.js
@@ -54,11 +54,7 @@ export default function EventLanding({ event }) {
       <section className={styles.hero}>
         <div className="container">
           {bannerUrl && (
-            <img
-              src={bannerUrl}
-              alt={pick(locale, event.title)}
-              className={styles.banner}
-            />
+            <img src={bannerUrl} alt={pick(locale, event.title)} className={styles.banner} />
           )}
           <h1 className={styles.title}>{pick(locale, event.title)}</h1>
           <div className={styles.meta}>
@@ -82,7 +78,7 @@ export default function EventLanding({ event }) {
           <div className="container">
             <div className={`hami-section-card ${styles.caseStudyCard}`}>
               <h2 className={styles.sectionTitle}>{isZh ? "相关案例" : "Related Case Study"}</h2>
-              <div className={styles.caseStudyBody}>
+              <div>
                 <div className={styles.caseStudyCompany}>
                   {pick(locale, {
                     en: event.caseStudy.company,

--- a/src/components/EventLanding.js
+++ b/src/components/EventLanding.js
@@ -1,3 +1,4 @@
+import dayjs from "dayjs";
 import useDocusaurusContext from "@docusaurus/useDocusaurusContext";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import { faDiscord, faGithub } from "@fortawesome/free-brands-svg-icons";
@@ -14,32 +15,28 @@ function pick(locale, obj) {
   return locale === "zh" && obj.zh ? obj.zh : obj.en;
 }
 
-function localeStr(locale) {
-  return locale === "zh" ? "zh-CN" : "en-US";
+function fmt(dateStr, locale) {
+  return locale === "zh"
+    ? dayjs(dateStr).format("YYYY[年]M[月]D[日]")
+    : dayjs(dateStr).format("MMMM D, YYYY");
 }
 
-function formatDate(dateStr, locale) {
-  return new Date(dateStr).toLocaleDateString(localeStr(locale), {
-    year: "numeric",
-    month: "long",
-    day: "numeric",
-  });
+function fmtShort(dateStr, locale) {
+  return locale === "zh"
+    ? dayjs(dateStr).format("M[月]D[日]")
+    : dayjs(dateStr).format("MMMM D");
 }
 
 function formatDateRange(startStr, endStr, locale) {
-  const lang = localeStr(locale);
-  const opts = { month: "long", day: "numeric" };
-  const start = new Date(startStr);
-  const end = new Date(endStr);
-  if (start.getFullYear() === end.getFullYear()) {
-    const startShort = start.toLocaleDateString(lang, opts);
-    const endShort = end.toLocaleDateString(lang, opts);
-    if (start.getMonth() === end.getMonth()) {
-      return `${startShort} – ${end.getDate()}, ${end.getFullYear()}`;
+  const s = dayjs(startStr);
+  const e = dayjs(endStr);
+  if (s.year() === e.year()) {
+    if (s.month() === e.month()) {
+      return `${fmtShort(startStr, locale)} – ${e.date()}, ${e.year()}`;
     }
-    return `${startShort} – ${endShort}, ${end.getFullYear()}`;
+    return `${fmtShort(startStr, locale)} – ${fmtShort(endStr, locale)}, ${e.year()}`;
   }
-  return `${formatDate(startStr, locale)} – ${formatDate(endStr, locale)}`;
+  return `${fmt(startStr, locale)} – ${fmt(endStr, locale)}`;
 }
 
 export default function EventLanding({ event }) {
@@ -64,7 +61,7 @@ export default function EventLanding({ event }) {
               <FontAwesomeIcon icon={faCalendarDays} className={styles.metaIcon} />
               {event.endDate
                 ? formatDateRange(event.date, event.endDate, locale)
-                : formatDate(event.date, locale)}
+                : fmt(event.date, locale)}
             </span>
             <span className={styles.metaItem}>
               <FontAwesomeIcon icon={faLocationDot} className={styles.metaIcon} />

--- a/src/components/EventLanding.js
+++ b/src/components/EventLanding.js
@@ -1,4 +1,3 @@
-import dayjs from "dayjs";
 import useDocusaurusContext from "@docusaurus/useDocusaurusContext";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import { faDiscord, faGithub } from "@fortawesome/free-brands-svg-icons";
@@ -15,28 +14,20 @@ function pick(locale, obj) {
   return locale === "zh" && obj.zh ? obj.zh : obj.en;
 }
 
-function fmt(dateStr, locale) {
-  return locale === "zh"
-    ? dayjs(dateStr).format("YYYY[年]M[月]D[日]")
-    : dayjs(dateStr).format("MMMM D, YYYY");
+function dateFmt(locale) {
+  return new Intl.DateTimeFormat(locale === "zh" ? "zh-CN" : "en-US", {
+    year: "numeric",
+    month: "long",
+    day: "numeric",
+  });
 }
 
-function fmtShort(dateStr, locale) {
-  return locale === "zh"
-    ? dayjs(dateStr).format("M[月]D[日]")
-    : dayjs(dateStr).format("MMMM D");
+function formatDate(dateStr, locale) {
+  return dateFmt(locale).format(new Date(dateStr));
 }
 
 function formatDateRange(startStr, endStr, locale) {
-  const s = dayjs(startStr);
-  const e = dayjs(endStr);
-  if (s.year() === e.year()) {
-    if (s.month() === e.month()) {
-      return `${fmtShort(startStr, locale)} – ${e.date()}, ${e.year()}`;
-    }
-    return `${fmtShort(startStr, locale)} – ${fmtShort(endStr, locale)}, ${e.year()}`;
-  }
-  return `${fmt(startStr, locale)} – ${fmt(endStr, locale)}`;
+  return dateFmt(locale).formatRange(new Date(startStr), new Date(endStr));
 }
 
 export default function EventLanding({ event }) {
@@ -61,7 +52,7 @@ export default function EventLanding({ event }) {
               <FontAwesomeIcon icon={faCalendarDays} className={styles.metaIcon} />
               {event.endDate
                 ? formatDateRange(event.date, event.endDate, locale)
-                : fmt(event.date, locale)}
+                : formatDate(event.date, locale)}
             </span>
             <span className={styles.metaItem}>
               <FontAwesomeIcon icon={faLocationDot} className={styles.metaIcon} />

--- a/src/components/EventLanding.js
+++ b/src/components/EventLanding.js
@@ -14,6 +14,16 @@ function pick(locale, obj) {
   return locale === "zh" && obj.zh ? obj.zh : obj.en;
 }
 
+function utm(url, slug) {
+  const prefix = url.includes("?") ? "&" : "?";
+  return `${url}${prefix}utm_source=${slug}&utm_medium=event-landing&utm_campaign=${slug}`;
+}
+
+const DEFAULTS = {
+  discordUrl: "https://discord.gg/Nwt3jVVpnT",
+  githubUrl: "https://github.com/Project-HAMi/HAMi",
+};
+
 function dateFmt(locale) {
   return new Intl.DateTimeFormat(locale === "zh" ? "zh-CN" : "en-US", {
     year: "numeric",
@@ -81,10 +91,10 @@ export default function EventLanding({ event }) {
                   ))}
                 </ul>
                 <a
-                  href={event.caseStudy.url}
+                  href={utm(event.caseStudy.url, event.slug)}
                   className={styles.caseStudyLink}
                   target="_blank"
-                  rel="noopener noreferrer"
+                  rel="noopener"
                 >
                   {isZh ? "查看 CNCF 原文" : "Read on CNCF"} →
                 </a>
@@ -109,7 +119,7 @@ export default function EventLanding({ event }) {
                   .map((r) => (
                     <a
                       key={r.key}
-                      href={event.resources[r.key].url}
+                      href={utm(event.resources[r.key].url, event.slug)}
                       className={styles.resourceLink}
                       target="_blank"
                       rel="noopener noreferrer"
@@ -135,7 +145,11 @@ export default function EventLanding({ event }) {
             </p>
             <div className={styles.ctaButtons}>
               <a
-                href={event.cta.discordUrl}
+                href={
+                  event.cta?.discordUrl
+                    ? event.cta.discordUrl
+                    : utm(DEFAULTS.discordUrl, event.slug)
+                }
                 className="button button--primary button--lg"
                 target="_blank"
                 rel="noopener noreferrer"
@@ -144,7 +158,9 @@ export default function EventLanding({ event }) {
                 Discord
               </a>
               <a
-                href={event.cta.githubUrl}
+                href={
+                  event.cta?.githubUrl ? event.cta.githubUrl : utm(DEFAULTS.githubUrl, event.slug)
+                }
                 className="button button--outline button--lg"
                 target="_blank"
                 rel="noopener noreferrer"

--- a/src/components/EventLanding.js
+++ b/src/components/EventLanding.js
@@ -15,8 +15,11 @@ function pick(locale, obj) {
 }
 
 function utm(url, slug) {
-  const prefix = url.includes("?") ? "&" : "?";
-  return `${url}${prefix}utm_source=${slug}&utm_medium=event-landing&utm_campaign=${slug}`;
+  const u = new URL(url);
+  u.searchParams.set("utm_source", slug);
+  u.searchParams.set("utm_medium", "event-landing");
+  u.searchParams.set("utm_campaign", slug);
+  return u.toString();
 }
 
 const DEFAULTS = {

--- a/src/components/EventLanding.js
+++ b/src/components/EventLanding.js
@@ -15,7 +15,12 @@ function pick(locale, obj) {
 }
 
 function utm(url, slug) {
-  const u = new URL(url);
+  let u;
+  try {
+    u = new URL(url);
+  } catch {
+    return url;
+  }
   u.searchParams.set("utm_source", slug);
   u.searchParams.set("utm_medium", "event-landing");
   u.searchParams.set("utm_campaign", slug);
@@ -40,7 +45,11 @@ function formatDate(dateStr, locale) {
 }
 
 function formatDateRange(startStr, endStr, locale) {
-  return dateFmt(locale).formatRange(new Date(startStr), new Date(endStr));
+  const fmt = dateFmt(locale);
+  if (typeof fmt.formatRange !== "function") {
+    return `${fmt.format(new Date(startStr))} - ${fmt.format(new Date(endStr))}`;
+  }
+  return fmt.formatRange(new Date(startStr), new Date(endStr));
 }
 
 export default function EventLanding({ event }) {
@@ -94,7 +103,7 @@ export default function EventLanding({ event }) {
                   href={utm(event.caseStudy.url, event.slug)}
                   className={styles.caseStudyLink}
                   target="_blank"
-                  rel="noopener"
+                  rel="noopener noreferrer"
                 >
                   {isZh ? "查看 CNCF 原文" : "Read on CNCF"} →
                 </a>
@@ -145,11 +154,7 @@ export default function EventLanding({ event }) {
             </p>
             <div className={styles.ctaButtons}>
               <a
-                href={
-                  event.cta?.discordUrl
-                    ? event.cta.discordUrl
-                    : utm(DEFAULTS.discordUrl, event.slug)
-                }
+                href={utm(event.cta?.discordUrl || DEFAULTS.discordUrl, event.slug)}
                 className="button button--primary button--lg"
                 target="_blank"
                 rel="noopener noreferrer"
@@ -158,9 +163,7 @@ export default function EventLanding({ event }) {
                 Discord
               </a>
               <a
-                href={
-                  event.cta?.githubUrl ? event.cta.githubUrl : utm(DEFAULTS.githubUrl, event.slug)
-                }
+                href={utm(event.cta?.githubUrl || DEFAULTS.githubUrl, event.slug)}
                 className="button button--outline button--lg"
                 target="_blank"
                 rel="noopener noreferrer"

--- a/src/components/EventLanding.module.css
+++ b/src/components/EventLanding.module.css
@@ -1,0 +1,196 @@
+.page {
+  padding: var(--hami-space-48) 0 var(--hami-space-64);
+}
+
+/* Hero */
+.hero {
+  padding: var(--hami-space-32) 0 var(--hami-space-48);
+}
+
+.banner {
+  width: 100%;
+  max-height: 480px;
+  object-fit: cover;
+  border-radius: var(--hami-radius-md);
+  border: 1px solid var(--hami-color-border);
+  margin-bottom: var(--hami-space-32);
+}
+
+.title {
+  font-family: var(--hami-font-display);
+  font-size: var(--hami-text-h1);
+  margin-bottom: var(--hami-space-16);
+  color: var(--hami-color-text);
+}
+
+.meta {
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--hami-space-24);
+  margin-bottom: var(--hami-space-24);
+}
+
+.metaItem {
+  display: inline-flex;
+  align-items: center;
+  gap: var(--hami-space-8);
+  font-size: 1.05rem;
+  color: var(--hami-color-muted);
+}
+
+.metaIcon {
+  color: var(--hami-color-primary);
+  font-size: 0.95rem;
+}
+
+.description {
+  max-width: 720px;
+  font-size: 1.1rem;
+  line-height: 1.7;
+  color: var(--hami-color-muted);
+}
+
+/* Case study */
+.caseStudySection {
+  padding: var(--hami-space-32) 0;
+}
+
+.caseStudyCard {
+  padding: var(--hami-space-32);
+}
+
+.sectionTitle {
+  font-family: var(--hami-font-display);
+  font-size: var(--hami-text-h3);
+  margin-bottom: var(--hami-space-24);
+  color: var(--hami-color-muted-2);
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  font-size: 0.85rem;
+}
+
+.caseStudyCompany {
+  font-family: var(--hami-font-display);
+  font-size: 1.3rem;
+  font-weight: 700;
+  color: var(--hami-color-text);
+  margin-bottom: var(--hami-space-16);
+}
+
+.highlights {
+  list-style: none;
+  padding: 0;
+  margin: 0 0 var(--hami-space-24);
+  display: flex;
+  flex-direction: column;
+  gap: var(--hami-space-8);
+}
+
+.highlights li {
+  color: var(--hami-color-muted);
+  padding-left: 1.2em;
+  position: relative;
+}
+
+.highlights li::before {
+  content: "";
+  position: absolute;
+  left: 0;
+  top: 0.55em;
+  width: 6px;
+  height: 6px;
+  border-radius: 50%;
+  background: var(--hami-color-primary);
+}
+
+.caseStudyLink {
+  display: inline-flex;
+  align-items: center;
+  color: var(--hami-color-primary);
+  font-weight: 600;
+  text-decoration: none;
+}
+
+.caseStudyLink:hover {
+  color: var(--hami-color-primary-hover);
+  text-decoration: none;
+}
+
+/* Resources */
+.resources {
+  padding: var(--hami-space-32) 0;
+}
+
+.resourcesCard {
+  padding: var(--hami-space-32);
+}
+
+.resourceList {
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--hami-space-16);
+}
+
+.resourceLink {
+  display: inline-flex;
+  align-items: center;
+  gap: var(--hami-space-8);
+  padding: var(--hami-space-12) var(--hami-space-24);
+  border: 1px solid var(--hami-color-border);
+  border-radius: var(--hami-radius-sm);
+  color: var(--hami-color-text);
+  font-weight: 600;
+  text-decoration: none;
+  background: var(--hami-color-surface);
+  transition:
+    border-color var(--hami-motion-fast),
+    background var(--hami-motion-fast);
+}
+
+.resourceLink:hover {
+  border-color: var(--hami-color-primary);
+  color: var(--hami-color-primary-hover);
+  background: var(--hami-color-surface-2);
+  text-decoration: none;
+}
+
+.resourceIcon {
+  color: var(--hami-color-primary);
+  font-size: 1.2rem;
+}
+
+/* CTA */
+.cta {
+  padding: var(--hami-space-32) 0;
+}
+
+.ctaCard {
+  padding: var(--hami-space-48) var(--hami-space-32);
+  text-align: center;
+}
+
+.ctaTitle {
+  font-family: var(--hami-font-display);
+  font-size: var(--hami-text-h2);
+  margin-bottom: var(--hami-space-12);
+  color: var(--hami-color-text);
+}
+
+.ctaText {
+  color: var(--hami-color-muted);
+  margin-bottom: var(--hami-space-32);
+  max-width: 520px;
+  margin-left: auto;
+  margin-right: auto;
+}
+
+.ctaButtons {
+  display: flex;
+  justify-content: center;
+  gap: var(--hami-space-16);
+  flex-wrap: wrap;
+}
+
+.btnIcon {
+  margin-right: var(--hami-space-8);
+}

--- a/src/components/EventLanding.module.css
+++ b/src/components/EventLanding.module.css
@@ -61,7 +61,6 @@
 
 .sectionTitle {
   font-family: var(--hami-font-display);
-  font-size: var(--hami-text-h3);
   margin-bottom: var(--hami-space-24);
   color: var(--hami-color-muted-2);
   text-transform: uppercase;

--- a/src/data/events.js
+++ b/src/data/events.js
@@ -36,8 +36,8 @@ const events = [
       url: "https://www.cncf.io/case-studies/snow-corp/",
     },
     cta: {
-      discordUrl: "https://discord.gg/Nwt3jVVpnT",
-      githubUrl: "https://github.com/Project-HAMi/HAMi",
+      discordUrl: "https://go.dynamia.ai/hami-chat",
+      githubUrl: "https://go.dynamia.ai/proj-hami-jpvn",
     },
   },
 ];

--- a/src/data/events.js
+++ b/src/data/events.js
@@ -1,0 +1,62 @@
+const events = [
+  {
+    slug: "kubecon-japan",
+    title: {
+      en: "HAMi at KubeCon Japan 2026",
+      zh: "HAMi 亮相 KubeCon 日本 2026",
+    },
+    date: "2026-07-28",
+    endDate: "2026-07-30",
+    location: {
+      en: "Yokohama, Japan",
+      zh: "日本 横滨",
+    },
+    banner: "/img/landing/kubecon-japan-banner.jpeg",
+    description: {
+      en: 'Join the HAMi team at KubeCon + CloudNativeCon Japan 2026, the CNCF\'s flagship conference. Visit our booth in the Solutions Showcase and catch our talk "Shared GPU Scheduling + Proactive Autoscaling" on orchestrating GPU workloads with HAMi on Kubernetes.',
+      zh: "欢迎参加 KubeCon + CloudNativeCon 日本 2026，CNCF 旗舰大会。欢迎莅临 Solutions Showcase 展区 HAMi 展位，并聆听我们的演讲「共享 GPU 调度与主动自动伸缩」——基于 Kubernetes 与 HAMi 编排 GPU 工作负载。",
+    },
+    resources: {
+      communityFlyer: {
+        en: "Community Status Flyer",
+        zh: "社区状态宣传册",
+        url: "/pdf/landing/kubecon-japan-community-flyer.pdf",
+      },
+      talkSlides: {
+        en: "Talk Slides",
+        zh: "演讲幻灯片",
+        url: "/pdf/landing/kubecon-japan-slides.pdf",
+      },
+      speakerReel: {
+        en: "Speaker Reel",
+        zh: "演讲视频",
+        url: null,
+      },
+    },
+    caseStudy: {
+      company: "SNOW Corp.",
+      companyZh: "SNOW",
+      highlights: [
+        {
+          en: "2x fewer GPUs with HAMi GPU sharing, handling 700% traffic spikes",
+          zh: "借助 HAMi GPU 共享减少 50% GPU 需求，从容应对 700% 流量洪峰",
+        },
+        {
+          en: "USD 17.4M in estimated cost savings vs on-demand cloud GPU",
+          zh: "相比等量按需云 GPU，预估节省 1740 万美元",
+        },
+        {
+          en: "MTTR reduced by 91%; GPU surge errors dropped by 85%",
+          zh: "MTTR 降低 91%；GPU 涌流错误减少 85%",
+        },
+      ],
+      url: "https://www.cncf.io/case-studies/snow-corp/",
+    },
+    cta: {
+      discordUrl: "https://discord.gg/Nwt3jVVpnT",
+      githubUrl: "https://github.com/Project-HAMi/HAMi",
+    },
+  },
+];
+
+export default events;

--- a/src/data/events.js
+++ b/src/data/events.js
@@ -15,8 +15,7 @@ const events = [
       en: 'Join the HAMi team at KubeCon + CloudNativeCon Japan 2026, the CNCF\'s flagship conference. Visit our booth in the Solutions Showcase and catch our talk "Shared GPU Scheduling + Proactive Autoscaling" on orchestrating GPU workloads with HAMi on Kubernetes.',
       zh: "欢迎参加 KubeCon + CloudNativeCon 日本 2026，CNCF 旗舰大会。欢迎莅临 Solutions Showcase 展区 HAMi 展位，并聆听我们的演讲「共享 GPU 调度与主动自动伸缩」——基于 Kubernetes 与 HAMi 编排 GPU 工作负载。",
     },
-    resources: {
-    },
+    resources: {},
     caseStudy: {
       company: "SNOW Corp.",
       companyZh: "SNOW",

--- a/src/data/events.js
+++ b/src/data/events.js
@@ -11,27 +11,11 @@ const events = [
       en: "Yokohama, Japan",
       zh: "日本 横滨",
     },
-    banner: "/img/landing/kubecon-japan-banner.jpeg",
     description: {
       en: 'Join the HAMi team at KubeCon + CloudNativeCon Japan 2026, the CNCF\'s flagship conference. Visit our booth in the Solutions Showcase and catch our talk "Shared GPU Scheduling + Proactive Autoscaling" on orchestrating GPU workloads with HAMi on Kubernetes.',
       zh: "欢迎参加 KubeCon + CloudNativeCon 日本 2026，CNCF 旗舰大会。欢迎莅临 Solutions Showcase 展区 HAMi 展位，并聆听我们的演讲「共享 GPU 调度与主动自动伸缩」——基于 Kubernetes 与 HAMi 编排 GPU 工作负载。",
     },
     resources: {
-      communityFlyer: {
-        en: "Community Status Flyer",
-        zh: "社区状态宣传册",
-        url: "/pdf/landing/kubecon-japan-community-flyer.pdf",
-      },
-      talkSlides: {
-        en: "Talk Slides",
-        zh: "演讲幻灯片",
-        url: "/pdf/landing/kubecon-japan-slides.pdf",
-      },
-      speakerReel: {
-        en: "Speaker Reel",
-        zh: "演讲视频",
-        url: null,
-      },
     },
     caseStudy: {
       company: "SNOW Corp.",

--- a/src/pages/landing/kubecon-japan.js
+++ b/src/pages/landing/kubecon-japan.js
@@ -7,7 +7,7 @@ const event = events.find((e) => e.slug === "kubecon-japan");
 
 export default function KubeConJapan() {
   const { i18n } = useDocusaurusContext();
-  const isZh = i18n.currentLocale === "zh";
+  const isZh = i18n.currentLocale.startsWith("zh");
 
   if (!event) {
     return (

--- a/src/pages/landing/kubecon-japan.js
+++ b/src/pages/landing/kubecon-japan.js
@@ -1,0 +1,20 @@
+import Layout from "@theme/Layout";
+import useDocusaurusContext from "@docusaurus/useDocusaurusContext";
+import EventLanding from "@site/src/components/EventLanding";
+import events from "@site/src/data/events";
+
+const event = events.find((e) => e.slug === "kubecon-japan");
+
+export default function KubeConJapan() {
+  const { i18n } = useDocusaurusContext();
+  const isZh = i18n.currentLocale === "zh";
+
+  return (
+    <Layout
+      title={isZh ? event.title.zh : event.title.en}
+      description={isZh ? event.description.zh : event.description.en}
+    >
+      <EventLanding event={event} />
+    </Layout>
+  );
+}

--- a/src/pages/landing/kubecon-japan.js
+++ b/src/pages/landing/kubecon-japan.js
@@ -9,6 +9,16 @@ export default function KubeConJapan() {
   const { i18n } = useDocusaurusContext();
   const isZh = i18n.currentLocale === "zh";
 
+  if (!event) {
+    return (
+      <Layout title="Event not found">
+        <main className="container margin-vert--xl">
+          <h1>{isZh ? "未找到活动" : "Event not found"}</h1>
+        </main>
+      </Layout>
+    );
+  }
+
   return (
     <Layout
       title={isZh ? event.title.zh : event.title.en}

--- a/src/pages/landing/kubecon-japan.js
+++ b/src/pages/landing/kubecon-japan.js
@@ -11,7 +11,7 @@ export default function KubeConJapan() {
 
   if (!event) {
     return (
-      <Layout title="Event not found">
+      <Layout title={isZh ? "未找到活动" : "Event not found"}>
         <main className="container margin-vert--xl">
           <h1>{isZh ? "未找到活动" : "Event not found"}</h1>
         </main>


### PR DESCRIPTION
jpeg and pdfs are currently missing and will be added once git-lfs is merged

**What type of PR is this?**

/kind feature

**What this PR does / why we need it**:

I want a centralized place where we can track event conversions and a link that we can give out will data people going to the event may want.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added a localized “Event Landing” page for HAMi at KubeCon Japan 2026, including locale-aware dates, location, and description.
  - Introduced optional banner, “Related Case Study,” “Event Resources,” and a Discord/GitHub CTA section.
  - Added support for both single-date and date-range formatting, plus English/Chinese content.
  - Implemented UTM-tagged external links for case study, resources, and CTAs.
  - Added the underlying event content dataset and a new landing page route to render the event.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->