### PR TITLE
Add announcement for KubeCon + CloudNativeCon Japan 2026 and update metrics

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -281,6 +281,13 @@ module.exports = {
       defaultMode: "dark",
       respectPrefersColorScheme: false,
     },
+    announcementBar: {
+      id: "kubecon_japan_2026",
+      content: "kubecon_japan_2026",
+      backgroundColor: "#20232a",
+      textColor: "#ffffff",
+      isCloseable: true,
+    },
     navbar: {
       title: "HAMi",
       logo: {

--- a/i18n/en/docusaurus-theme-classic/announcementBar.json
+++ b/i18n/en/docusaurus-theme-classic/announcementBar.json
@@ -1,4 +1,5 @@
 {
   "kubecon_india_2026": "🇮🇳 Meet the HAMi team at <strong>KubeCon + CloudNativeCon India 2026</strong>! Visit us at <strong>Booth T-10</strong> in the Project Pavilion (Jasmine Hall 1, Level 3) on <strong>June 18, 3:30–7:30 PM IST</strong>. <a href=\"https://events.linuxfoundation.org/kubecon-cloudnativecon-india/\" style=\"text-decoration:underline;color:#66b2ff\">Learn more →</a>",
+  "kubecon_japan_2026": "🇯🇵 Meet HAMi at <strong>KubeCon + CloudNativeCon Japan 2026</strong> in Yokohama, Jul 28–30. Find us at <strong>Booth T-6</strong>, Project Pavilion (Pacifico Yokohama 3F). <a href=\"https://events.linuxfoundation.org/kubecon-cloudnativecon-japan/program/schedule/\" style=\"text-decoration:underline;color:#66b2ff\">View schedule →</a>",
   "theme.announcementBar.message": ""
 }

--- a/i18n/zh/docusaurus-theme-classic/announcementBar.json
+++ b/i18n/zh/docusaurus-theme-classic/announcementBar.json
@@ -1,4 +1,5 @@
 {
   "kubecon_india_2026": "🇮🇳 来 <strong>KubeCon + CloudNativeCon India 2026</strong> 与 HAMi 团队见面！6 月 18 日 <strong>下午 3:30–7:30 IST</strong>，Project Pavilion（Jasmine Hall 1 三层）<strong>T-10 展台</strong>。 <a href=\"https://events.linuxfoundation.org/kubecon-cloudnativecon-india/\" style=\"text-decoration:underline;color:#66b2ff\">了解更多 →</a>",
+  "kubecon_japan_2026": "🇯🇵 7 月 28–30 日，来横滨 <strong>KubeCon + CloudNativeCon Japan 2026</strong> 与 HAMi 团队见面！Project Pavilion（Pacifico Yokohama 3F）<strong>T-6 展台</strong>。<a href=\"https://events.linuxfoundation.org/kubecon-cloudnativecon-japan/program/schedule/\" style=\"text-decoration:underline;color:#66b2ff\">查看日程 →</a>",
   "theme.announcementBar.message": ""
 }

--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -375,13 +375,13 @@ export default function Home() {
   const { i18n } = useDocusaurusContext();
   const isZh = i18n.currentLocale === "zh";
   const [starsCount, setStarsCount] = useState(3100);
-  const [dockerPulls, setDockerPulls] = useState(162000);
+  const [dockerPulls, setDockerPulls] = useState(325000);
   const kubernetesLogo = useBaseUrl("img/kubernetes-logo.svg");
   const hamiLogo = useBaseUrl("img/hami-graph-color.svg");
   const hamiHorizontalLogoLight = useBaseUrl("img/hami-horizontal-color-black.svg");
   const hamiHorizontalLogoDark = useBaseUrl("img/hami-horizontal-color-white.svg");
   const contributorsCount = useCountUp(500);
-  const contributorCountries = useCountUp(17);
+  const contributorCountries = useCountUp(27);
   const starsCountDisplay = useCountUp(starsCount);
   const dockerPullsDisplay = useCountUp(dockerPulls);
 


### PR DESCRIPTION
Introduce an announcement for KubeCon + CloudNativeCon Japan 2026 and update the counts for Docker pulls and contributor countries. This enhances visibility for the upcoming event and reflects the current metrics accurately.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a dismissible announcement bar highlighting KubeCon Japan 2026.
  - Added English and Chinese event details, including dates, venue, booth information, and schedule links.

- **Bug Fixes**
  - Updated fallback community metrics displayed when live data cannot be retrieved, including Docker image pulls and contributor country counts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->