### PR TITLE
docs(tutorials): add Lab 15: Run SGLang on HAMi GPU Shares

### DIFF
--- a/i18n/zh/docusaurus-plugin-content-docs-tutorials/current/labs/hami-sglang.md
+++ b/i18n/zh/docusaurus-plugin-content-docs-tutorials/current/labs/hami-sglang.md
@@ -138,10 +138,8 @@ kubectl delete daemonset "${VENDOR_PLUGIN_DAEMONSET}" \
 
 ```bash
 GPU_NODE=<gpu-node-name>
+GPU_LABEL_WAS_PRESENT="$(kubectl get node "${GPU_NODE}" -o go-template='{{if hasKey .metadata.labels "gpu"}}true{{else}}false{{end}}')"
 GPU_LABEL_BEFORE="$(kubectl get node "${GPU_NODE}" -o jsonpath='{.metadata.labels.gpu}')"
-if [ "${GPU_LABEL_BEFORE}" != "on" ]; then
-  export HAMI_LAB_ADDED_GPU_LABEL=true
-fi
 kubectl label node "${GPU_NODE}" gpu=on --overwrite
 ```
 
@@ -179,7 +177,15 @@ helm upgrade --install hami hami-charts/hami \
   -n kube-system \
   -f hami-values.yaml \
   --version 2.9.0
+```
 
+> 在部分 ACK Kubernetes 1.36 集群中，如果调度器日志显示 `resource.k8s.io` 权限错误，请应用实验 6 使用的 DRA RBAC 辅助清单：
+>
+> ```bash
+> kubectl apply -f https://raw.githubusercontent.com/Project-HAMi/website/master/tutorials/labs/hami-vllm/hami-scheduler-dra-rbac.yaml
+> ```
+
+```bash
 kubectl rollout status deployment/hami-scheduler -n kube-system
 kubectl rollout status daemonset/hami-device-plugin -n kube-system
 ```
@@ -364,14 +370,19 @@ memory.total [MiB], memory.used [MiB]
 
 容器内 `nvidia-smi` 应显示接近 25,000 MiB 的总显存，而主机仍显示物理卡完整容量。这证明 HAMi 的 NVML 拦截公开了所配置的配额，但还不能单独证明超额 CUDA 分配会失败。
 
-可以选择从单独进程请求一次 26 GiB 分配，以验证 CUDA 层的配额实施。该请求超过 Pod 的完整 25,000 MiB 配额，因此应失败，并且不会保留显存或改变服务进程：
+可以选择从单独进程验证 CUDA 层的配额实施。将 `GPU_QUOTA_MIB` 设置为清单中的 `nvidia.com/gpumem` 值。探针会请求比该配额多 1024 MiB，因此降低其他 GPU 的配额后仍然适用：
 
 ```bash
-kubectl exec -i -n sglang ${POD} -- python3 - <<'PY'
+GPU_QUOTA_MIB=25000
+OVER_QUOTA_MIB=$((GPU_QUOTA_MIB + 1024))
+kubectl exec -i -n sglang ${POD} -- \
+  env OVER_QUOTA_MIB="${OVER_QUOTA_MIB}" python3 - <<'PY'
+import os
 import torch
 
+allocation_mib = int(os.environ["OVER_QUOTA_MIB"])
 try:
-    torch.empty(26 * 1024**3 // 4, dtype=torch.float32, device="cuda")
+    torch.empty(allocation_mib * 1024**2 // 4, dtype=torch.float32, device="cuda")
 except RuntimeError as exc:
     if "out of memory" not in str(exc).lower():
         raise
@@ -381,7 +392,7 @@ else:
 PY
 ```
 
-预期输出包含 `PASS`。随后确认实时服务仍然健康：
+预期输出包含 `PASS`。失败的请求不应保留显存或改变服务进程。随后确认实时服务仍然健康：
 
 ```bash
 curl --fail --silent http://127.0.0.1:8001/health
@@ -422,23 +433,25 @@ kubectl apply -f <original-version-pinned-device-plugin-manifest>
 
 对于 Helm release、GPU Operator 或托管插件，请通过相同的管理机制恢复它，并确认只有一个设备插件 DaemonSet 管理 `nvidia.com/gpu`。
 
-仅当本实验添加了 `gpu=on` 时才移除该标签；请在设置变量的同一 shell 中执行：
+恢复原始 `gpu` 标签状态。请在记录 `GPU_LABEL_WAS_PRESENT` 和 `GPU_LABEL_BEFORE` 的同一 shell 中执行：
 
 ```bash
-if [ "${HAMI_LAB_ADDED_GPU_LABEL:-false}" = true ]; then
+if [ "${GPU_LABEL_WAS_PRESENT}" = true ]; then
+  kubectl label node "${GPU_NODE}" "gpu=${GPU_LABEL_BEFORE}" --overwrite
+else
   kubectl label node "${GPU_NODE}" gpu-
 fi
 ```
 
 ## 验证结果
 
-| 声明                      | 证据                                                   |
-| ------------------------- | ------------------------------------------------------ |
-| HAMi 接管 GPU 调度        | Pod 使用 `hami-scheduler` 并请求 HAMi GPU 资源。       |
-| SGLang 在 HAMi 资源上运行 | Pod Ready，HAMi 注入显存和 SM 限制变量。               |
-| 容器内可见显存配额        | Pod 内显示 25,000 MiB，而主机显示完整物理容量。        |
-| 超额分配被拒绝            | 26 GiB PyTorch CUDA 分配在 25,000 MiB 配额下返回 OOM。 |
-| 推理服务可访问            | 模型列表和聊天接口均正常返回。                         |
+| 声明                      | 证据                                                     |
+| ------------------------- | -------------------------------------------------------- |
+| HAMi 接管 GPU 调度        | Pod 使用 `hami-scheduler` 并请求 HAMi GPU 资源。         |
+| SGLang 在 HAMi 资源上运行 | Pod Ready，HAMi 注入显存和 SM 限制变量。                 |
+| 容器内可见显存配额        | Pod 内显示 25,000 MiB，而主机显示完整物理容量。          |
+| 超额分配被拒绝            | PyTorch CUDA 分配请求比配置配额高 1024 MiB，并返回 OOM。 |
+| 推理服务可访问            | 模型列表和聊天接口均正常返回。                           |
 
 ## 后续步骤
 

--- a/i18n/zh/docusaurus-plugin-content-docs-tutorials/current/labs/hami-sglang.md
+++ b/i18n/zh/docusaurus-plugin-content-docs-tutorials/current/labs/hami-sglang.md
@@ -140,8 +140,14 @@ kubectl delete daemonset "${VENDOR_PLUGIN_DAEMONSET}" \
 
 ```bash
 GPU_NODE=<gpu-node-name>
-GPU_LABEL_WAS_PRESENT="$(kubectl get node "${GPU_NODE}" -o go-template='{{if hasKey .metadata.labels "gpu"}}true{{else}}false{{end}}')"
-GPU_LABEL_BEFORE="$(kubectl get node "${GPU_NODE}" -o jsonpath='{.metadata.labels.gpu}')"
+GPU_LABEL_WAS_PRESENT="$(kubectl get node "${GPU_NODE}" -o go-template='{{if .metadata.labels}}{{if index .metadata.labels "gpu"}}true{{else}}false{{end}}{{else}}false{{end}}')" || {
+  echo "无法记录 gpu 标签是否存在" >&2
+  exit 1
+}
+GPU_LABEL_BEFORE="$(kubectl get node "${GPU_NODE}" -o jsonpath='{.metadata.labels.gpu}')" || {
+  echo "无法记录当前的 gpu 标签" >&2
+  exit 1
+}
 kubectl label node "${GPU_NODE}" gpu=on --overwrite
 ```
 
@@ -184,7 +190,13 @@ helm upgrade --install hami hami-charts/hami \
 > 在部分 ACK Kubernetes 1.36 集群中，如果调度器日志显示 `resource.k8s.io` 权限错误，请应用实验 6 使用的 DRA RBAC 辅助清单：
 >
 > ```bash
-> kubectl apply -f https://raw.githubusercontent.com/Project-HAMi/website/master/tutorials/labs/hami-vllm/hami-scheduler-dra-rbac.yaml
+> RBAC_COMMIT="90ac82510bfabe05894dd8037078c59f02a51553"
+> RBAC_SHA256="e0a77f99422230ccc8958aac0d04694347769279ec26a9d4a5ff729f89efe3d9"
+> RBAC_MANIFEST="hami-scheduler-dra-rbac.yaml"
+> curl -fsSLo "${RBAC_MANIFEST}" \
+>   "https://raw.githubusercontent.com/Project-HAMi/website/${RBAC_COMMIT}/tutorials/labs/hami-vllm/hami-scheduler-dra-rbac.yaml"
+> printf '%s  %s\n' "${RBAC_SHA256}" "${RBAC_MANIFEST}" | sha256sum -c -
+> kubectl apply -f "${RBAC_MANIFEST}"
 > ```
 
 ```bash

--- a/i18n/zh/docusaurus-plugin-content-docs-tutorials/current/labs/hami-sglang.md
+++ b/i18n/zh/docusaurus-plugin-content-docs-tutorials/current/labs/hami-sglang.md
@@ -32,6 +32,7 @@ toc_max_heading_level: 2
 ## 实验概览
 
 ```mermaid
+%% title: HAMi + SGLang 实验流程图
 flowchart LR
     Step1["步骤 1<br/>检查 GPU 集群"] --> Step2["步骤 2<br/>安装 HAMi"]
     Step2 --> Step3["步骤 3<br/>验证 HAMi 资源"]
@@ -45,6 +46,7 @@ flowchart LR
 ## 部署架构
 
 ```mermaid
+%% title: HAMi + SGLang 部署架构
 flowchart TB
     Client["客户端<br/>curl / OpenAI SDK"] --> PF["端口转发 / LoadBalancer"]
     PF --> SVC["SGLang Service<br/>端口 8001"]

--- a/i18n/zh/docusaurus-plugin-content-docs-tutorials/current/labs/hami-sglang.md
+++ b/i18n/zh/docusaurus-plugin-content-docs-tutorials/current/labs/hami-sglang.md
@@ -76,7 +76,22 @@ flowchart TB
 
 ```bash
 kubectl get nodes -o wide
+```
+
+```plaintext
+NAME                      STATUS   ROLES           AGE   VERSION   INTERNAL-IP   OS-IMAGE                       CONTAINER-RUNTIME
+hami-demo-control-plane   Ready    control-plane   2m    v1.36.1   172.19.0.2    Debian GNU/Linux 13 (trixie)   containerd://2.3.1
+```
+
+主机 GPU：
+
+```bash
 nvidia-smi --query-gpu=index,name,memory.total --format=csv
+```
+
+```plaintext
+index, name, memory.total [MiB]
+0, NVIDIA H100 80GB HBM3, 81559 MiB
 ```
 
 安装 HAMi 后，每张物理 GPU 被注册为 10 个可调度共享资源：
@@ -84,6 +99,17 @@ nvidia-smi --query-gpu=index,name,memory.total --format=csv
 ```bash
 kubectl get nodes -o 'custom-columns=NAME:.metadata.name,GPU:.status.allocatable.nvidia\.com/gpu'
 kubectl get pods -n kube-system -l app.kubernetes.io/instance=hami -o wide
+```
+
+```plaintext
+NAME                      GPU
+hami-demo-control-plane   10
+```
+
+```plaintext
+NAME                              READY   STATUS    NODE
+hami-device-plugin-...            2/2     Running   hami-demo-control-plane
+hami-scheduler-...                2/2     Running   hami-demo-control-plane
 ```
 
 ## 步骤 1：检查 GPU 集群
@@ -95,15 +121,13 @@ kubectl describe node | grep -A8 -E "Capacity:|Allocatable:" | grep -E "nvidia.c
 
 HAMi 和厂商 NVIDIA 设备插件会注册相同的 `nvidia.com/gpu` 资源，因此二者不能同时运行在同一 GPU 节点。保留 NVIDIA 驱动、Container Toolkit 和运行时，但在安装 HAMi 前禁用或移除厂商设备插件。
 
-在自管理集群中，先找到、备份并移除现有 DaemonSet：
+先确认现有插件的安装方式。稍后需要使用原始 Helm release、Operator 配置、托管插件设置或源清单来恢复它：
 
 ```bash
 kubectl get daemonsets --all-namespaces | grep -E 'nvidia.*device-plugin'
 
 VENDOR_PLUGIN_NAMESPACE=<namespace>
 VENDOR_PLUGIN_DAEMONSET=<daemonset-name>
-kubectl get daemonset "${VENDOR_PLUGIN_DAEMONSET}" \
-  -n "${VENDOR_PLUGIN_NAMESPACE}" -o yaml >nvidia-device-plugin-backup.yaml
 kubectl delete daemonset "${VENDOR_PLUGIN_DAEMONSET}" \
   -n "${VENDOR_PLUGIN_NAMESPACE}"
 ```
@@ -137,22 +161,18 @@ global:
     gpu: "on"
 
 devicePlugin:
+  # 这是 chart 的默认值。此处显式展示，因为实验会验证 10 个共享资源。
   deviceSplitCount: 10
 
 scheduler:
-  # 与集群 Kubernetes 版本一致；示例为 kind v1.36.1。
-  kubeScheduler:
-    image:
-      tag: "v1.36.1"
   leaderElect: false
 ```
 
-| 配置                                   | 说明                                             |
-| -------------------------------------- | ------------------------------------------------ |
+| 配置 | 说明 |
+| --- | --- |
 | `global.managedNodeSelector.gpu: "on"` | 仅在带 `gpu=on` 标签的节点上运行 HAMi 设备插件。 |
-| `devicePlugin.deviceSplitCount: 10`    | 将每张物理 GPU 注册为 10 个 vGPU。               |
-| `scheduler.kubeScheduler.image.tag`    | 必须与集群 Kubernetes 版本一致。                 |
-| `scheduler.leaderElect: false`         | 本实验使用单副本调度器。                         |
+| `devicePlugin.deviceSplitCount: 10` | 将每张物理 GPU 注册为 10 个 vGPU。该值与当前 chart 默认值一致，并因实验会验证结果而显式设置。 |
+| `scheduler.leaderElect: false` | 本实验使用单副本调度器。 |
 
 ```bash
 helm upgrade --install hami hami-charts/hami \
@@ -291,7 +311,7 @@ kubectl -n sglang port-forward svc/sglang-qwen3-17b 8001:8001
 ## 步骤 6：测试推理
 
 ```bash
-curl -s http://127.0.0.1:8001/v1/models | jq
+curl -s http://127.0.0.1:8001/v1/models | python3 -m json.tool
 
 curl -s http://127.0.0.1:8001/v1/chat/completions \
   -H 'Content-Type: application/json' \
@@ -301,7 +321,7 @@ curl -s http://127.0.0.1:8001/v1/chat/completions \
     "temperature": 0.2,
     "max_tokens": 80,
     "chat_template_kwargs": {"enable_thinking": false}
-  }' | jq
+  }' | python3 -m json.tool
 ```
 
 若响应包含 `choices[0].message.content`，说明 SGLang 推理服务正常工作。
@@ -316,9 +336,35 @@ kubectl exec -n sglang ${POD} -- env | grep -E 'CUDA_DEVICE|NVIDIA_VISIBLE'
 kubectl exec -n sglang ${POD} -- nvidia-smi
 ```
 
+HAMi 注入的环境变量示例：
+
+```plaintext
+NVIDIA_VISIBLE_DEVICES=GPU-04b76a6c-da10-342f-e9f5-5f5684eacb86
+CUDA_DEVICE_MEMORY_LIMIT_0=25000m
+CUDA_DEVICE_SM_LIMIT=30
+```
+
+Pod 内的预期显存视图：
+
+```plaintext
+| GPU  Name                 ... | Memory-Usage          |
+| NVIDIA H100 80GB HBM3     ... | 18213MiB / 25000MiB   |
+```
+
+主机仍显示完整物理容量：
+
+```bash
+nvidia-smi --query-gpu=memory.total,memory.used --format=csv
+```
+
+```plaintext
+memory.total [MiB], memory.used [MiB]
+81559 MiB, 18560 MiB
+```
+
 容器内 `nvidia-smi` 应显示接近 25,000 MiB 的总显存，而主机仍显示物理卡完整容量。这证明 HAMi 的 NVML 拦截公开了所配置的配额，但还不能单独证明超额 CUDA 分配会失败。
 
-请求一次 26 GiB 分配，以验证 CUDA 层的配额实施：
+可以选择从单独进程请求一次 26 GiB 分配，以验证 CUDA 层的配额实施。该请求超过 Pod 的完整 25,000 MiB 配额，因此应失败，并且不会保留显存或改变服务进程：
 
 ```bash
 kubectl exec -i -n sglang ${POD} -- python3 - <<'PY'
@@ -335,7 +381,14 @@ else:
 PY
 ```
 
-预期输出包含 `PASS`。HAMi 通过拦截 CUDA 分配调用实施软件显存配额，这不同于 MIG 等硬件分区；算力限制同样属于软件节流。
+预期输出包含 `PASS`。随后确认实时服务仍然健康：
+
+```bash
+curl --fail --silent http://127.0.0.1:8001/health
+curl --fail --silent http://127.0.0.1:8001/v1/models | python3 -m json.tool
+```
+
+HAMi 通过拦截 CUDA 分配调用实施软件显存配额，这不同于 MIG 等硬件分区；算力限制同样属于软件节流。
 
 ## 故障排除
 
@@ -361,13 +414,13 @@ kubectl delete namespace sglang --ignore-not-found
 helm uninstall hami -n kube-system
 ```
 
-卸载 HAMi 后恢复厂商设备插件。对于上述自管理示例：
+卸载 HAMi 后，使用之前禁用插件时对应的方法恢复厂商设备插件。对于通过清单安装的自管理插件，请应用原始的固定版本源清单，不要使用实时 `kubectl get -o yaml` 导出：
 
 ```bash
-kubectl apply -f nvidia-device-plugin-backup.yaml
+kubectl apply -f <original-version-pinned-device-plugin-manifest>
 ```
 
-对于托管插件或 GPU Operator，请撤销之前的厂商专用禁用操作，并确认只有一个设备插件 DaemonSet 管理 `nvidia.com/gpu`。
+对于 Helm release、GPU Operator 或托管插件，请通过相同的管理机制恢复它，并确认只有一个设备插件 DaemonSet 管理 `nvidia.com/gpu`。
 
 仅当本实验添加了 `gpu=on` 时才移除该标签；请在设置变量的同一 shell 中执行：
 

--- a/i18n/zh/docusaurus-plugin-content-docs-tutorials/current/labs/hami-sglang.md
+++ b/i18n/zh/docusaurus-plugin-content-docs-tutorials/current/labs/hami-sglang.md
@@ -1,0 +1,395 @@
+---
+title: "实验 15：在 HAMi GPU 共享资源上运行 SGLang"
+description: "在 GPU 集群上安装 HAMi，并使用 GPU 切分资源调度 SGLang 推理服务。"
+sidebar_label: "实验 15：SGLang 推理"
+lab:
+  level: Intermediate
+  duration: 约 45 分钟
+  environment: 配备 NVIDIA GPU 的 Kubernetes 集群
+  authors:
+    - rudrakshkarpe
+    - shivaylamba
+  verified: "2026-07-23"
+tags:
+  - sglang
+  - inference
+  - hami
+toc_max_heading_level: 2
+---
+
+本实验演示如何在已有 NVIDIA GPU 的 Kubernetes 集群上安装 HAMi，并使用 HAMi 调度 [SGLang](https://github.com/sgl-project/sglang) 推理服务。完成后，你将获得兼容 OpenAI API 的模型服务，并可验证 HAMi 在 Pod 内实施的软件显存配额和算力节流。
+
+本指南参考[实验 6：在 HAMi GPU 共享资源上运行 vLLM](./hami-vllm)，不依赖特定云厂商。
+
+## 学习目标
+
+- 检查 GPU Kubernetes 集群是否满足 HAMi 和 SGLang 的前置条件
+- 安装 HAMi 调度器和设备插件
+- 使用 `nvidia.com/gpu`、`nvidia.com/gpumem` 和 `nvidia.com/gpucores` 运行 SGLang
+- 通过端口转发测试兼容 OpenAI 的 API
+- 验证容器内可见配额以及超额 CUDA 分配被拒绝
+
+## 实验概览
+
+```mermaid
+flowchart LR
+    Step1["步骤 1<br/>检查 GPU 集群"] --> Step2["步骤 2<br/>安装 HAMi"]
+    Step2 --> Step3["步骤 3<br/>验证 HAMi 资源"]
+    Step3 --> Step4["步骤 4<br/>部署 SGLang"]
+    Step4 --> Step5["步骤 5<br/>公开服务"]
+    Step5 --> Step6["步骤 6<br/>测试推理"]
+    Step6 --> Step7["步骤 7<br/>检查 GPU 分配"]
+    Step7 --> Step8["步骤 8<br/>清理"]
+```
+
+## 部署架构
+
+```mermaid
+flowchart TB
+    Client["客户端<br/>curl / OpenAI SDK"] --> PF["端口转发 / LoadBalancer"]
+    PF --> SVC["SGLang Service<br/>端口 8001"]
+    SVC --> POD["SGLang Pod<br/>Qwen3-1.7B<br/>1 个 GPU 共享 / 25000 MiB / 30% 核心"]
+    subgraph K8S["Kubernetes GPU 集群"]
+      HAMI_S["hami-scheduler"]
+      HAMI_D["hami-device-plugin<br/>DaemonSet"]
+      POD
+      N1["GPU 节点<br/>NVIDIA H100 / L40S / ..."]
+    end
+    HAMI_S --> POD
+    HAMI_D --> N1
+    POD --> N1
+```
+
+## 前置条件
+
+- 正常运行的 Kubernetes 集群
+- 至少一个可用显存超过 25,000 MiB 的 NVIDIA GPU 节点（本指南使用 H100 80GB）。使用 A10 时，需将所有 `nvidia.com/gpumem` 请求和限制降低到 `nvidia-smi` 显示的容量以下
+- 已连接集群的 `kubectl` 和 Helm 3.x
+- GPU 节点已安装 NVIDIA 驱动、Container Toolkit 和容器运行时支持
+- 集群能够拉取 `lmsysorg/sglang` 镜像并下载 Hugging Face 模型权重
+
+> **kind 提示：** 使用 GPU 直通时，需在 kind 节点内配置 `nvidia-container-toolkit`，并在安装 HAMi 前将 containerd 的 `default_runtime_name` 设为 `nvidia`。
+
+## 示例集群状态
+
+本指南在由一张 NVIDIA H100 80GB 支持的 kind 控制平面节点上完成验证。
+
+```bash
+kubectl get nodes -o wide
+nvidia-smi --query-gpu=index,name,memory.total --format=csv
+```
+
+安装 HAMi 后，每张物理 GPU 被注册为 10 个可调度共享资源：
+
+```bash
+kubectl get nodes -o 'custom-columns=NAME:.metadata.name,GPU:.status.allocatable.nvidia\.com/gpu'
+kubectl get pods -n kube-system -l app.kubernetes.io/instance=hami -o wide
+```
+
+## 步骤 1：检查 GPU 集群
+
+```bash
+kubectl get nodes -o wide
+kubectl describe node | grep -A8 -E "Capacity:|Allocatable:" | grep -E "nvidia.com/gpu|cpu:|memory:"
+```
+
+HAMi 和厂商 NVIDIA 设备插件会注册相同的 `nvidia.com/gpu` 资源，因此二者不能同时运行在同一 GPU 节点。保留 NVIDIA 驱动、Container Toolkit 和运行时，但在安装 HAMi 前禁用或移除厂商设备插件。
+
+在自管理集群中，先找到、备份并移除现有 DaemonSet：
+
+```bash
+kubectl get daemonsets --all-namespaces | grep -E 'nvidia.*device-plugin'
+
+VENDOR_PLUGIN_NAMESPACE=<namespace>
+VENDOR_PLUGIN_DAEMONSET=<daemonset-name>
+kubectl get daemonset "${VENDOR_PLUGIN_DAEMONSET}" \
+  -n "${VENDOR_PLUGIN_NAMESPACE}" -o yaml >nvidia-device-plugin-backup.yaml
+kubectl delete daemonset "${VENDOR_PLUGIN_DAEMONSET}" \
+  -n "${VENDOR_PLUGIN_NAMESPACE}"
+```
+
+> 如果 DaemonSet 由 GPU Operator 或托管 Kubernetes 插件管理，请通过相应的 Operator/插件配置禁用它，否则控制器会重新创建 DaemonSet。不要卸载主机驱动或 NVIDIA 容器运行时。
+
+记录 `gpu=on` 标签是否已存在，然后标记 GPU 节点：
+
+```bash
+GPU_NODE=<gpu-node-name>
+GPU_LABEL_BEFORE="$(kubectl get node "${GPU_NODE}" -o jsonpath='{.metadata.labels.gpu}')"
+if [ "${GPU_LABEL_BEFORE}" != "on" ]; then
+  export HAMI_LAB_ADDED_GPU_LABEL=true
+fi
+kubectl label node "${GPU_NODE}" gpu=on --overwrite
+```
+
+## 步骤 2：安装 HAMi
+
+```bash
+helm repo add hami-charts https://project-hami.github.io/HAMi
+helm repo update hami-charts
+```
+
+保存为 `hami-values.yaml`：
+
+```yaml
+global:
+  managedNodeSelectorEnable: true
+  managedNodeSelector:
+    gpu: "on"
+
+devicePlugin:
+  deviceSplitCount: 10
+
+scheduler:
+  # 与集群 Kubernetes 版本一致；示例为 kind v1.36.1。
+  kubeScheduler:
+    image:
+      tag: "v1.36.1"
+  leaderElect: false
+```
+
+| 配置                                   | 说明                                             |
+| -------------------------------------- | ------------------------------------------------ |
+| `global.managedNodeSelector.gpu: "on"` | 仅在带 `gpu=on` 标签的节点上运行 HAMi 设备插件。 |
+| `devicePlugin.deviceSplitCount: 10`    | 将每张物理 GPU 注册为 10 个 vGPU。               |
+| `scheduler.kubeScheduler.image.tag`    | 必须与集群 Kubernetes 版本一致。                 |
+| `scheduler.leaderElect: false`         | 本实验使用单副本调度器。                         |
+
+```bash
+helm upgrade --install hami hami-charts/hami \
+  -n kube-system \
+  -f hami-values.yaml \
+  --version 2.9.0
+
+kubectl rollout status deployment/hami-scheduler -n kube-system
+kubectl rollout status daemonset/hami-device-plugin -n kube-system
+```
+
+## 步骤 3：验证 HAMi 资源
+
+```bash
+kubectl get pods -n kube-system -l app.kubernetes.io/instance=hami -o wide
+kubectl get nodes -o 'custom-columns=NAME:.metadata.name,GPU:.status.allocatable.nvidia\.com/gpu'
+```
+
+预期 HAMi 调度器和设备插件为 `Running`，GPU 节点显示 `nvidia.com/gpu=10`。
+
+## 步骤 4：使用 HAMi 资源部署 SGLang
+
+本实验部署 Qwen3-1.7B，请求一个 HAMi GPU 共享、25,000 MiB 显存和 30% GPU 核心。
+
+```bash
+kubectl apply -f - <<'EOF'
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: sglang
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: sglang-qwen3-17b
+  namespace: sglang
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: sglang-qwen3-17b
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: sglang-qwen3-17b
+      annotations:
+        hami.io/node-scheduler-policy: binpack
+        hami.io/gpu-scheduler-policy: binpack
+    spec:
+      schedulerName: hami-scheduler
+      containers:
+        - name: sglang
+          image: lmsysorg/sglang:v0.5.7
+          imagePullPolicy: IfNotPresent
+          command:
+            - python3
+            - -m
+            - sglang.launch_server
+            - --model-path=Qwen/Qwen3-1.7B
+            - --host=0.0.0.0
+            - --port=30000
+            - --mem-fraction-static=0.7
+            - --context-length=8192
+            - --attention-backend=triton
+          ports:
+            - name: http
+              containerPort: 30000
+          resources:
+            requests:
+              cpu: "2"
+              memory: 8Gi
+              nvidia.com/gpu: "1"
+              nvidia.com/gpumem: "25000"
+              nvidia.com/gpucores: "30"
+            limits:
+              cpu: "8"
+              memory: 32Gi
+              nvidia.com/gpu: "1"
+              nvidia.com/gpumem: "25000"
+              nvidia.com/gpucores: "30"
+          readinessProbe:
+            httpGet:
+              path: /health
+              port: 30000
+            initialDelaySeconds: 30
+            periodSeconds: 10
+            timeoutSeconds: 5
+            failureThreshold: 90
+          volumeMounts:
+            - name: dshm
+              mountPath: /dev/shm
+      volumes:
+        - name: dshm
+          emptyDir:
+            medium: Memory
+            sizeLimit: 8Gi
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: sglang-qwen3-17b
+  namespace: sglang
+spec:
+  type: ClusterIP
+  selector:
+    app.kubernetes.io/name: sglang-qwen3-17b
+  ports:
+    - name: http
+      port: 8001
+      targetPort: http
+EOF
+```
+
+| 配置 | 说明 |
+| --- | --- |
+| `schedulerName: hami-scheduler` | 将调度明确交给 HAMi。 |
+| `nvidia.com/gpumem: "25000"` | 以 MiB 为单位的软件 CUDA 显存配额，也通过被拦截的 NVML 调用显示。 |
+| `nvidia.com/gpucores: "30"` | 应用目标为 30% SM 使用率的软件算力节流。 |
+| `--attention-backend=triton` | 使用在 H100 验证集群上测试的 Triton 后端；其他 GPU 应选择其 SGLang 版本和架构支持的后端。 |
+| `/dev/shm` | 为 SGLang 提供更大的共享内存。 |
+
+```bash
+kubectl rollout status deployment/sglang-qwen3-17b -n sglang --timeout=30m
+kubectl describe pod -n sglang -l app.kubernetes.io/name=sglang-qwen3-17b \
+  | grep -E "hami-scheduler|Filtering|Binding" -A2
+```
+
+## 步骤 5：公开 SGLang 服务
+
+```bash
+kubectl -n sglang port-forward svc/sglang-qwen3-17b 8001:8001
+```
+
+在另一个终端中执行后续测试。
+
+## 步骤 6：测试推理
+
+```bash
+curl -s http://127.0.0.1:8001/v1/models | jq
+
+curl -s http://127.0.0.1:8001/v1/chat/completions \
+  -H 'Content-Type: application/json' \
+  -d '{
+    "model": "Qwen/Qwen3-1.7B",
+    "messages": [{"role": "user", "content": "Explain GPU sharing in one sentence."}],
+    "temperature": 0.2,
+    "max_tokens": 80,
+    "chat_template_kwargs": {"enable_thinking": false}
+  }' | jq
+```
+
+若响应包含 `choices[0].message.content`，说明 SGLang 推理服务正常工作。
+
+## 步骤 7：检查 GPU 分配
+
+```bash
+POD=$(kubectl get pod -n sglang -l app.kubernetes.io/name=sglang-qwen3-17b -o jsonpath='{.items[0].metadata.name}')
+kubectl get pod -n sglang ${POD} \
+  -o jsonpath='{.spec.schedulerName}{"\n"}{.spec.containers[0].resources.limits}{"\n"}'
+kubectl exec -n sglang ${POD} -- env | grep -E 'CUDA_DEVICE|NVIDIA_VISIBLE'
+kubectl exec -n sglang ${POD} -- nvidia-smi
+```
+
+容器内 `nvidia-smi` 应显示接近 25,000 MiB 的总显存，而主机仍显示物理卡完整容量。这证明 HAMi 的 NVML 拦截公开了所配置的配额，但还不能单独证明超额 CUDA 分配会失败。
+
+请求一次 26 GiB 分配，以验证 CUDA 层的配额实施：
+
+```bash
+kubectl exec -i -n sglang ${POD} -- python3 - <<'PY'
+import torch
+
+try:
+    torch.empty(26 * 1024**3 // 4, dtype=torch.float32, device="cuda")
+except RuntimeError as exc:
+    if "out of memory" not in str(exc).lower():
+        raise
+    print("PASS: over-quota CUDA allocation returned out of memory")
+else:
+    raise SystemExit("FAIL: over-quota CUDA allocation unexpectedly succeeded")
+PY
+```
+
+预期输出包含 `PASS`。HAMi 通过拦截 CUDA 分配调用实施软件显存配额，这不同于 MIG 等硬件分区；算力限制同样属于软件节流。
+
+## 故障排除
+
+| 现象                           | 检查项                                                       |
+| ------------------------------ | ------------------------------------------------------------ |
+| `hami-device-plugin` CrashLoop | NVIDIA Container Toolkit 必须向 Pod 注入驱动库。             |
+| `hami-device-plugin` 未就绪    | 节点缺少 `gpu=on` 标签，或节点选择器不匹配。                 |
+| SGLang Pod Pending             | 检查 HAMi 调度事件，并确认 `gpumem` 不超过物理 GPU 显存。    |
+| 镜像拉取失败或磁盘已满         | SGLang 镜像较大；清理未使用镜像或预先加载固定版本镜像。      |
+| Pod 内仍显示完整显存           | 重新检查 `schedulerName`、资源限制和 HAMi webhook/调度事件。 |
+
+```bash
+kubectl get pods -A -o wide
+kubectl describe pod -n sglang -l app.kubernetes.io/name=sglang-qwen3-17b
+kubectl logs -n sglang -l app.kubernetes.io/name=sglang-qwen3-17b --tail=100
+kubectl logs -n kube-system deploy/hami-scheduler --tail=100
+```
+
+## 清理
+
+```bash
+kubectl delete namespace sglang --ignore-not-found
+helm uninstall hami -n kube-system
+```
+
+卸载 HAMi 后恢复厂商设备插件。对于上述自管理示例：
+
+```bash
+kubectl apply -f nvidia-device-plugin-backup.yaml
+```
+
+对于托管插件或 GPU Operator，请撤销之前的厂商专用禁用操作，并确认只有一个设备插件 DaemonSet 管理 `nvidia.com/gpu`。
+
+仅当本实验添加了 `gpu=on` 时才移除该标签；请在设置变量的同一 shell 中执行：
+
+```bash
+if [ "${HAMI_LAB_ADDED_GPU_LABEL:-false}" = true ]; then
+  kubectl label node "${GPU_NODE}" gpu-
+fi
+```
+
+## 验证结果
+
+| 声明                      | 证据                                                   |
+| ------------------------- | ------------------------------------------------------ |
+| HAMi 接管 GPU 调度        | Pod 使用 `hami-scheduler` 并请求 HAMi GPU 资源。       |
+| SGLang 在 HAMi 资源上运行 | Pod Ready，HAMi 注入显存和 SM 限制变量。               |
+| 容器内可见显存配额        | Pod 内显示 25,000 MiB，而主机显示完整物理容量。        |
+| 超额分配被拒绝            | 26 GiB PyTorch CUDA 分配在 25,000 MiB 配额下返回 OOM。 |
+| 推理服务可访问            | 模型列表和聊天接口均正常返回。                         |
+
+## 后续步骤
+
+- 增加副本数量，观察 HAMi 如何使用 `binpack` 放置多个 SGLang Pod。
+- 降低 `gpumem` 和 `gpucores`，并在同一 GPU 上共置另一个小型工作负载。
+- 参考配套的 [KitOps ModelKit 实验 PR](https://github.com/Project-HAMi/website/pull/655)，从 OCI 注册表交付模型。
+- 有关显存隔离和小切片共享模式，请参阅[实验 3：GPU 切分](./gpu-partitioning)。

--- a/sidebars-tutorials.js
+++ b/sidebars-tutorials.js
@@ -61,6 +61,11 @@ module.exports = {
           id: "labs/topology-aware-scheduling",
           customProps: { level: "Intermediate", duration: "about 45 minutes" },
         },
+        {
+          type: "doc",
+          id: "labs/hami-sglang",
+          customProps: { level: "Intermediate", duration: "about 45 minutes" },
+        },
       ],
     },
   ],

--- a/sidebars-tutorials.js
+++ b/sidebars-tutorials.js
@@ -81,6 +81,11 @@ module.exports = {
           id: "labs/composable-scheduler-policies-gke",
           customProps: { level: "Intermediate", duration: "about 60 minutes" },
         },
+        {
+          type: "doc",
+          id: "labs/hami-sglang",
+          customProps: { level: "Intermediate", duration: "about 45 minutes" },
+        },
       ],
     },
   ],

--- a/tutorials/labs/hami-sglang.md
+++ b/tutorials/labs/hami-sglang.md
@@ -1,0 +1,547 @@
+---
+title: "Lab 11: Run SGLang on HAMi GPU Shares"
+description: "Install HAMi on a GPU cluster and schedule SGLang inference services with GPU partitioning."
+sidebar_label: "Lab 11: SGLang Inference"
+lab:
+  level: Intermediate
+  duration: about 45 minutes
+  environment: Kubernetes cluster with NVIDIA GPUs
+  authors:
+    - rudrakshkarpe
+    - shivaylamba
+  verified: "2026-07-23"
+tags:
+  - sglang
+  - inference
+  - hami
+toc_max_heading_level: 2
+---
+
+This lab demonstrates how to install HAMi on a Kubernetes cluster that already has NVIDIA GPUs, and use HAMi to schedule an [SGLang](https://github.com/sgl-project/sglang) inference service. Upon completion, you will have an OpenAI-compatible model service that can be verified through `/v1/models` and `/v1/chat/completions`, with HAMi enforcing GPU memory and compute caps inside the Pod.
+
+This guide is modeled after [Lab 6: Run vLLM on HAMi GPU Shares](./hami-vllm). The steps are not tied to a specific cloud vendor. As long as your Kubernetes cluster has available NVIDIA GPUs, NVIDIA drivers, and container runtime support, you can reproduce the same setup.
+
+## Learning Objectives
+
+- Verify that an existing GPU Kubernetes cluster meets the prerequisites for HAMi and SGLang
+- Install HAMi scheduler and device plugin
+- Add labels required by the HAMi DaemonSet to GPU nodes
+- Run SGLang using HAMi's `nvidia.com/gpu`, `nvidia.com/gpumem`, and `nvidia.com/gpucores` resources
+- Test the SGLang OpenAI-compatible API via port forwarding
+- Confirm that `nvidia.com/gpumem` is enforced inside the SGLang Pod
+
+## Lab Overview
+
+```mermaid
+%% title: HAMi + SGLang Lab Flowchart
+flowchart LR
+    Step1["Step 1<br/>Check GPU Cluster"] --> Step2["Step 2<br/>Install HAMi"]
+    Step2 --> Step3["Step 3<br/>Verify HAMi Resources"]
+    Step3 --> Step4["Step 4<br/>Deploy SGLang"]
+    Step4 --> Step5["Step 5<br/>Expose Service"]
+    Step5 --> Step6["Step 6<br/>Test Inference"]
+    Step6 --> Step7["Step 7<br/>Check GPU Allocation"]
+    Step7 --> Step8["Step 8<br/>Cleanup"]
+```
+
+## Deployment Architecture
+
+```mermaid
+%% title: HAMi + SGLang Deployment Architecture
+flowchart TB
+    Client["Client<br/>curl / OpenAI SDK"] --> PF["port-forward / LoadBalancer"]
+    PF --> SVC["SGLang Service<br/>port 8001"]
+    SVC --> POD["SGLang Pod<br/>Qwen3-1.7B<br/>1 GPU share / 25000 MiB / 30% cores"]
+
+    subgraph K8S["Kubernetes GPU Cluster"]
+      HAMI_S["hami-scheduler"]
+      HAMI_D["hami-device-plugin<br/>DaemonSet"]
+      POD
+      N1["GPU Node<br/>NVIDIA H100 / A10 / ..."]
+    end
+
+    HAMI_S --> POD
+    HAMI_D --> N1
+    POD --> N1
+```
+
+## Prerequisites
+
+You need to prepare in advance:
+
+- A working Kubernetes cluster
+- At least 1 NVIDIA GPU node with enough free memory for the model (this guide uses a single NVIDIA H100 80GB; an A10/L40S-class GPU also works if you keep the small model and `gpumem` values)
+- `kubectl` connected to the cluster
+- `helm` 3.x
+- GPU nodes with NVIDIA drivers and NVIDIA Container Toolkit / runtime support installed
+- The cluster can pull the SGLang image (`lmsysorg/sglang`) and download model weights (Hugging Face Hub or a mirror)
+
+> **Kind note:** If you use [kind](https://kind.sigs.k8s.io/) with GPU passthrough, install and configure `nvidia-container-toolkit` **inside** the kind node and set `default_runtime_name = "nvidia"` for containerd before installing HAMi. On managed GPU clusters this is usually already handled by the vendor GPU operator / device plugin stack.
+
+## Example Cluster State
+
+Below is the verification cluster used for this guide: one kind control-plane node backed by a host NVIDIA H100 80GB HBM3.
+
+```bash
+kubectl get nodes -o wide
+```
+
+```plaintext
+NAME                      STATUS   ROLES           AGE   VERSION   INTERNAL-IP   OS-IMAGE                       CONTAINER-RUNTIME
+hami-demo-control-plane   Ready    control-plane   2m    v1.36.1   172.19.0.2    Debian GNU/Linux 13 (trixie)   containerd://2.3.1
+```
+
+Host GPU:
+
+```bash
+nvidia-smi --query-gpu=index,name,memory.total --format=csv
+```
+
+```plaintext
+index, name, memory.total [MiB]
+0, NVIDIA H100 80GB HBM3, 81559 MiB
+```
+
+After HAMi is installed (see steps below), each physical GPU is registered as 10 schedulable shares:
+
+```bash
+kubectl get nodes -o 'custom-columns=NAME:.metadata.name,GPU:.status.allocatable.nvidia\.com/gpu'
+```
+
+```plaintext
+NAME                      GPU
+hami-demo-control-plane   10
+```
+
+HAMi component status:
+
+```bash
+kubectl get pods -n kube-system -l app.kubernetes.io/instance=hami -o wide
+```
+
+```plaintext
+NAME                              READY   STATUS    NODE
+hami-device-plugin-...            2/2     Running   hami-demo-control-plane
+hami-scheduler-...                2/2     Running   hami-demo-control-plane
+```
+
+## Step 1: Check the GPU Cluster
+
+Confirm that Kubernetes can see the GPU nodes:
+
+```bash
+kubectl get nodes -o wide
+kubectl describe node | grep -A8 -E "Capacity:|Allocatable:" | grep -E "nvidia.com/gpu|cpu:|memory:"
+```
+
+If the cluster already has a vendor NVIDIA device plugin installed, you may already see `nvidia.com/gpu`. After installing HAMi, `nvidia.com/gpu` becomes the number of vGPUs exposed by HAMi.
+
+HAMi's device plugin matches `gpu=on` when managed node selectors are enabled. Label your GPU nodes:
+
+```bash
+kubectl label node <gpu-node-name> gpu=on --overwrite
+```
+
+On Alibaba Cloud ACK, you can also select by vendor labels, for example:
+
+```bash
+kubectl label nodes \
+  -l aliyun.accelerator/xpu_type=nvidia \
+  gpu=on \
+  --overwrite
+```
+
+## Step 2: Install HAMi
+
+Add the HAMi Helm repo:
+
+```bash
+helm repo add hami-charts https://project-hami.github.io/HAMi
+helm repo update hami-charts
+```
+
+Create a values file (save as `hami-values.yaml`):
+
+```yaml
+device:
+  nvidia:
+    driver:
+      enabled: false
+
+global:
+  managedNodeSelectorEnable: true
+  managedNodeSelector:
+    gpu: "on"
+
+devicePlugin:
+  deviceSplitCount: 10
+
+scheduler:
+  # Match your cluster Kubernetes minor version (example: kind v1.36.1).
+  kubeScheduler:
+    imageTag: "v1.36.1"
+  leaderElect: false
+```
+
+Key configuration details:
+
+| Configuration | Description |
+| --- | --- |
+| `device.nvidia.driver.enabled: false` | Nodes already have NVIDIA drivers. |
+| `global.managedNodeSelector.gpu: "on"` | Only schedule the HAMi device plugin to GPU nodes labeled `gpu=on`. |
+| `devicePlugin.deviceSplitCount: 10` | Register each physical GPU as 10 vGPUs. |
+| `scheduler.kubeScheduler.imageTag` | Must match the cluster Kubernetes version. |
+| `scheduler.leaderElect: false` | Single-replica lab scheduler; avoids extender leader-election waits. |
+
+Install HAMi:
+
+```bash
+helm upgrade --install hami hami-charts/hami \
+  -n kube-system \
+  -f hami-values.yaml \
+  --version 2.9.0
+```
+
+> On some ACK Kubernetes 1.36 clusters, the built-in kube-scheduler in HAMi also needs DRA-related RBAC. If the scheduler logs show `resource.k8s.io` permission errors, apply the same DRA RBAC helper used in [Lab 6](./hami-vllm).
+
+Wait for components to be running:
+
+```bash
+kubectl rollout status deployment/hami-scheduler -n kube-system
+kubectl rollout status daemonset/hami-device-plugin -n kube-system
+```
+
+Expected result:
+
+```plaintext
+deployment "hami-scheduler" successfully rolled out
+daemon set "hami-device-plugin" successfully rolled out
+```
+
+## Step 3: Verify HAMi Resources
+
+```bash
+kubectl get pods -n kube-system -l app.kubernetes.io/instance=hami -o wide
+kubectl get nodes -o 'custom-columns=NAME:.metadata.name,GPU:.status.allocatable.nvidia\.com/gpu'
+```
+
+You should see `hami-scheduler` and `hami-device-plugin` Running, and each GPU node advertising `nvidia.com/gpu` equal to `deviceSplitCount` (10 in this lab).
+
+If the device plugin is not Ready, check labels and DaemonSet node selector:
+
+```bash
+kubectl get nodes -L gpu
+kubectl get ds hami-device-plugin -n kube-system -o wide
+kubectl logs -n kube-system -l app.kubernetes.io/instance=hami -c device-plugin --tail=50
+```
+
+## Step 4: Deploy SGLang with HAMi Resources
+
+This lab deploys **Qwen3-1.7B** with SGLang. The Pod requests one HAMi GPU share, **25000 MiB** GPU memory, and **30%** GPU cores so multiple inference workloads can still share a large GPU.
+
+Apply the manifests (self-contained):
+
+```bash
+kubectl apply -f - <<'EOF'
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: sglang
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: sglang-qwen3-17b
+  namespace: sglang
+  labels:
+    app.kubernetes.io/name: sglang-qwen3-17b
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: sglang-qwen3-17b
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: sglang-qwen3-17b
+      annotations:
+        hami.io/node-scheduler-policy: binpack
+        hami.io/gpu-scheduler-policy: binpack
+    spec:
+      schedulerName: hami-scheduler
+      containers:
+        - name: sglang
+          image: lmsysorg/sglang:latest
+          imagePullPolicy: IfNotPresent
+          command:
+            - python3
+            - -m
+            - sglang.launch_server
+            - --model-path=Qwen/Qwen3-1.7B
+            - --host=0.0.0.0
+            - --port=30000
+            - --mem-fraction-static=0.7
+            - --context-length=8192
+            - --attention-backend=triton
+          ports:
+            - name: http
+              containerPort: 30000
+          resources:
+            requests:
+              cpu: "2"
+              memory: 8Gi
+              nvidia.com/gpu: "1"
+              nvidia.com/gpumem: "25000"
+              nvidia.com/gpucores: "30"
+            limits:
+              cpu: "8"
+              memory: 32Gi
+              nvidia.com/gpu: "1"
+              nvidia.com/gpumem: "25000"
+              nvidia.com/gpucores: "30"
+          readinessProbe:
+            httpGet:
+              path: /health
+              port: 30000
+            initialDelaySeconds: 30
+            periodSeconds: 10
+            timeoutSeconds: 5
+            failureThreshold: 90
+          volumeMounts:
+            - name: dshm
+              mountPath: /dev/shm
+      volumes:
+        - name: dshm
+          emptyDir:
+            medium: Memory
+            sizeLimit: 8Gi
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: sglang-qwen3-17b
+  namespace: sglang
+spec:
+  type: ClusterIP
+  selector:
+    app.kubernetes.io/name: sglang-qwen3-17b
+  ports:
+    - name: http
+      port: 8001
+      targetPort: http
+EOF
+```
+
+Key points:
+
+| Configuration | Description |
+| --- | --- |
+| `schedulerName: hami-scheduler` | Explicitly delegate scheduling to HAMi. |
+| `nvidia.com/gpu: "1"` | Request 1 HAMi GPU device share. |
+| `nvidia.com/gpumem: "25000"` | Hard GPU memory cap in MiB visible inside the container. |
+| `nvidia.com/gpucores: "30"` | Cap SM/compute usage to 30%. |
+| `hami.io/*-scheduler-policy: binpack` | Prefer packing workloads onto the same physical GPU. |
+| `/dev/shm` Memory emptyDir | SGLang benefits from a larger shared-memory mount. |
+
+Wait for SGLang to become Ready (first start downloads the model and captures CUDA graphs):
+
+```bash
+kubectl rollout status deployment/sglang-qwen3-17b -n sglang --timeout=30m
+kubectl get pods -n sglang -o wide
+```
+
+Example output:
+
+```plaintext
+NAME                               READY   STATUS    NODE
+sglang-qwen3-17b-6d894b9655-ppxrw  1/1     Running   hami-demo-control-plane
+```
+
+Check HAMi scheduling events:
+
+```bash
+kubectl describe pod -n sglang -l app.kubernetes.io/name=sglang-qwen3-17b \
+  | grep -E "hami-scheduler|Filtering|Binding" -A2
+```
+
+You should see events such as:
+
+```plaintext
+Successfully assigned sglang/... to hami-demo-control-plane
+FilteringSucceed ... find fit node(hami-demo-control-plane)...
+BindingSucceed ... Successfully binding node [hami-demo-control-plane] ...
+```
+
+## Step 5: Expose the SGLang Service
+
+For local verification, use port forwarding:
+
+```bash
+kubectl -n sglang port-forward svc/sglang-qwen3-17b 8001:8001
+```
+
+In another terminal:
+
+```bash
+curl http://127.0.0.1:8001/v1/models
+```
+
+On cloud clusters you can also create a `LoadBalancer` Service or Ingress in front of `sglang-qwen3-17b`. Verify with port-forward first, then wire public exposure.
+
+## Step 6: Test Inference
+
+List models:
+
+```bash
+curl -s http://127.0.0.1:8001/v1/models | python3 -m json.tool
+```
+
+Example output from the verification cluster:
+
+```json
+{
+  "object": "list",
+  "data": [
+    {
+      "id": "Qwen/Qwen3-1.7B",
+      "object": "model",
+      "owned_by": "sglang",
+      "max_model_len": 8192
+    }
+  ]
+}
+```
+
+Send a chat completion request:
+
+```bash
+curl -s http://127.0.0.1:8001/v1/chat/completions \
+  -H "Content-Type: application/json" \
+  -d '{
+    "model": "Qwen/Qwen3-1.7B",
+    "messages": [
+      {"role": "user", "content": "Explain in one sentence how HAMi and SGLang work together."}
+    ],
+    "max_tokens": 128,
+    "temperature": 0.2,
+    "chat_template_kwargs": {"enable_thinking": false}
+  }' | python3 -m json.tool
+```
+
+If the response contains `choices[0].message.content`, the SGLang inference service is working.
+
+> Qwen3 models may emit a thinking/reasoning channel depending on the chat template. Passing `"chat_template_kwargs": {"enable_thinking": false}` keeps the demo answer concise.
+
+## Step 7: Check GPU Allocation
+
+Confirm the Pod used HAMi scheduling and the expected resource limits:
+
+```bash
+POD=$(kubectl get pod -n sglang -l app.kubernetes.io/name=sglang-qwen3-17b -o jsonpath='{.items[0].metadata.name}')
+kubectl get pod -n sglang ${POD} \
+  -o jsonpath='{.spec.schedulerName}{"\n"}{.spec.containers[0].resources.limits}{"\n"}'
+```
+
+Expected:
+
+```plaintext
+hami-scheduler
+... nvidia.com/gpu:1 nvidia.com/gpumem:25000 nvidia.com/gpucores:30 ...
+```
+
+Check environment variables injected by HAMi:
+
+```bash
+kubectl exec -n sglang ${POD} -- env | grep -E 'CUDA_DEVICE|NVIDIA_VISIBLE'
+```
+
+Example from the verification cluster:
+
+```plaintext
+NVIDIA_VISIBLE_DEVICES=GPU-04b76a6c-da10-342f-e9f5-5f5684eacb86
+CUDA_DEVICE_MEMORY_LIMIT_0=25000m
+CUDA_DEVICE_SM_LIMIT=30
+```
+
+Finally, check `nvidia-smi` **inside** the container:
+
+```bash
+kubectl exec -n sglang ${POD} -- nvidia-smi
+```
+
+When `gpumem` is in effect, the total GPU memory visible inside the container is close to **25000 MiB**, not the full physical card (81559 MiB on the H100 verification host):
+
+```plaintext
+| GPU  Name                 ... | Memory-Usage          |
+| NVIDIA H100 80GB HBM3     ... | 18213MiB / 25000MiB   |
+```
+
+On the host, the same card still reports the full capacity:
+
+```bash
+nvidia-smi --query-gpu=memory.total,memory.used --format=csv
+```
+
+```plaintext
+memory.total [MiB], memory.used [MiB]
+81559 MiB, 18560 MiB
+```
+
+That contrast — full card on the host, capped slice in the Pod — is the key evidence that HAMi memory virtualization is working for SGLang.
+
+## Troubleshooting
+
+| Symptom | What to Check |
+| --- | --- |
+| `hami-device-plugin` CrashLoop / FailedPostStartHook | NVIDIA Container Toolkit must inject driver libs into Pods. On kind, configure the nvidia runtime inside the node. |
+| `hami-device-plugin` not Ready | Node missing `gpu=on`, or node selector mismatch. |
+| SGLang Pod Pending | `kubectl describe pod` for HAMi filter/bind events; confirm `gpumem` does not exceed physical GPU memory. |
+| Image pull fails / disk full | `lmsysorg/sglang` images are large. Prune unused images or `kind load docker-image` from a pre-pulled host image. |
+| SGLang starts slowly | First-time Hugging Face download + CUDA graph capture can take several minutes. Watch Pod logs. |
+| `/v1/models` empty / connection refused | Wait until readiness probe passes; use `kubectl logs` and `kubectl port-forward` to the Pod port `30000` if the Service is wrong. |
+| In-pod `nvidia-smi` still shows full GPU memory | Pod is not on the HAMi memory-limit path. Recheck `schedulerName`, resource limits, and HAMi webhook/scheduler events. |
+
+Common troubleshooting commands:
+
+```bash
+kubectl get pods -A -o wide
+kubectl describe pod -n sglang -l app.kubernetes.io/name=sglang-qwen3-17b
+kubectl logs -n sglang -l app.kubernetes.io/name=sglang-qwen3-17b --tail=100
+kubectl logs -n kube-system deploy/hami-scheduler --tail=100
+kubectl get ds hami-device-plugin -n kube-system -o wide
+```
+
+## Cleanup
+
+```bash
+kubectl delete namespace sglang --ignore-not-found
+```
+
+If this cluster is only used for this lab, you can also uninstall HAMi:
+
+```bash
+helm uninstall hami -n kube-system
+```
+
+Optional label cleanup:
+
+```bash
+kubectl label node <gpu-node-name> gpu-
+```
+
+## Verification Results
+
+| Claim | Evidence |
+| --- | --- |
+| HAMi has taken over GPU scheduling | SGLang Pod uses `schedulerName: hami-scheduler` and requests `nvidia.com/gpu`, `nvidia.com/gpumem`, `nvidia.com/gpucores`. |
+| GPU node runs HAMi device plugin | `hami-device-plugin` is Ready and advertises `nvidia.com/gpu=10`. |
+| SGLang runs on HAMi resources | Pod Ready; HAMi injects `CUDA_DEVICE_MEMORY_LIMIT_0=25000m` and `CUDA_DEVICE_SM_LIMIT=30`. |
+| Memory cap is visible in-container | In-pod `nvidia-smi` shows `... / 25000MiB` while host still shows `81559 MiB`. |
+| Inference service is accessible | `/v1/models` returns `Qwen/Qwen3-1.7B`; chat endpoint returns content. |
+
+## Next Steps
+
+- Increase `replicas` and observe how HAMi packs multiple SGLang Pods with `binpack`.
+- Lower `nvidia.com/gpumem` / `nvidia.com/gpucores` further and co-locate another small workload on the same GPU.
+- Continue with [Lab 12: Serve Models from a KitOps ModelKit on HAMi](./hami-kitops) to replace the runtime Hugging Face download with an OCI ModelKit.
+- For memory isolation and small-slice sharing patterns, see [Lab 3: GPU Partitioning](./gpu-partitioning).

--- a/tutorials/labs/hami-sglang.md
+++ b/tutorials/labs/hami-sglang.md
@@ -543,5 +543,5 @@ kubectl label node <gpu-node-name> gpu-
 
 - Increase `replicas` and observe how HAMi packs multiple SGLang Pods with `binpack`.
 - Lower `nvidia.com/gpumem` / `nvidia.com/gpucores` further and co-locate another small workload on the same GPU.
-- Continue with [Lab 12: Serve Models from a KitOps ModelKit on HAMi](./hami-kitops) to replace the runtime Hugging Face download with an OCI ModelKit.
+- Deliver the model from an OCI registry instead of Hugging Face: a companion **KitOps ModelKit** lab replaces the runtime download with a `kitops-init` initContainer ([website#561](https://github.com/Project-HAMi/website/issues/561)).
 - For memory isolation and small-slice sharing patterns, see [Lab 3: GPU Partitioning](./gpu-partitioning).

--- a/tutorials/labs/hami-sglang.md
+++ b/tutorials/labs/hami-sglang.md
@@ -136,15 +136,13 @@ kubectl describe node | grep -A8 -E "Capacity:|Allocatable:" | grep -E "nvidia.c
 
 If the cluster already has a vendor NVIDIA device plugin installed, you may already see `nvidia.com/gpu`. HAMi's device plugin registers the same resource, so the two device plugins must not run on the same GPU nodes. Keep the NVIDIA drivers, Container Toolkit, and runtime installed, but disable or remove the vendor device-plugin DaemonSet before installing HAMi.
 
-First identify the existing plugin. On a self-managed cluster, record and remove it as follows, substituting the discovered namespace and DaemonSet name:
+First identify how the existing plugin was installed. You will need the original Helm release, Operator configuration, managed add-on setting, or source manifest to restore it later:
 
 ```bash
 kubectl get daemonsets --all-namespaces | grep -E 'nvidia.*device-plugin'
 
 VENDOR_PLUGIN_NAMESPACE=<namespace>
 VENDOR_PLUGIN_DAEMONSET=<daemonset-name>
-kubectl get daemonset "${VENDOR_PLUGIN_DAEMONSET}" \
-  -n "${VENDOR_PLUGIN_NAMESPACE}" -o yaml >nvidia-device-plugin-backup.yaml
 kubectl delete daemonset "${VENDOR_PLUGIN_DAEMONSET}" \
   -n "${VENDOR_PLUGIN_NAMESPACE}"
 ```
@@ -189,13 +187,10 @@ global:
     gpu: "on"
 
 devicePlugin:
+  # This is the chart default, shown explicitly because the lab verifies 10 shares.
   deviceSplitCount: 10
 
 scheduler:
-  # Match your cluster Kubernetes minor version (example: kind v1.36.1).
-  kubeScheduler:
-    image:
-      tag: "v1.36.1"
   leaderElect: false
 ```
 
@@ -204,8 +199,7 @@ Key configuration details:
 | Configuration | Description |
 | --- | --- |
 | `global.managedNodeSelector.gpu: "on"` | Only schedule the HAMi device plugin to GPU nodes labeled `gpu=on`. |
-| `devicePlugin.deviceSplitCount: 10` | Register each physical GPU as 10 vGPUs. |
-| `scheduler.kubeScheduler.image.tag` | Must match the cluster Kubernetes version. |
+| `devicePlugin.deviceSplitCount: 10` | Register each physical GPU as 10 vGPUs. This matches the current chart default and is explicit because the lab verifies the resulting value. |
 | `scheduler.leaderElect: false` | Single-replica lab scheduler; avoids extender leader-election waits. |
 
 Install HAMi:
@@ -505,7 +499,7 @@ memory.total [MiB], memory.used [MiB]
 
 That contrast confirms that HAMi's NVML interception exposes the configured quota. It is supporting evidence, but it does not by itself prove that an over-quota CUDA allocation is rejected.
 
-Verify CUDA-level enforcement by requesting a single 26 GiB allocation, which exceeds this Pod's 25,000 MiB quota:
+Optionally verify CUDA-level enforcement by requesting a single 26 GiB allocation from a separate process. The request exceeds this Pod's entire 25,000 MiB quota, so it should fail without retaining memory or changing the serving process:
 
 ```bash
 kubectl exec -i -n sglang ${POD} -- python3 - <<'PY'
@@ -522,7 +516,14 @@ else:
 PY
 ```
 
-Expected output includes `PASS: over-quota CUDA allocation returned out of memory`. HAMi enforces the memory quota by intercepting CUDA allocation calls; this is software enforcement, not a hardware partition such as MIG. Compute limiting is likewise a software throttle.
+Expected output includes `PASS: over-quota CUDA allocation returned out of memory`. Confirm that the live server remains healthy after the failed allocation:
+
+```bash
+curl --fail --silent http://127.0.0.1:8001/health
+curl --fail --silent http://127.0.0.1:8001/v1/models | python3 -m json.tool
+```
+
+HAMi enforces the memory quota by intercepting CUDA allocation calls; this is software enforcement, not a hardware partition such as MIG. Compute limiting is likewise a software throttle.
 
 ## Troubleshooting
 
@@ -558,13 +559,13 @@ If this cluster is only used for this lab, you can also uninstall HAMi:
 helm uninstall hami -n kube-system
 ```
 
-Restore the vendor device plugin after HAMi is removed. For the self-managed example above:
+Restore the vendor device plugin after HAMi is removed by reversing the method used to disable it. For a self-managed plugin installed from a manifest, apply the original version-pinned source manifest, not a live `kubectl get -o yaml` export:
 
 ```bash
-kubectl apply -f nvidia-device-plugin-backup.yaml
+kubectl apply -f <original-version-pinned-device-plugin-manifest>
 ```
 
-For a managed add-on or GPU Operator, reverse the vendor-specific change used to disable it and confirm exactly one device-plugin DaemonSet owns `nvidia.com/gpu`.
+For a Helm release, GPU Operator, or managed add-on, restore it through that same management mechanism. Confirm that exactly one device-plugin DaemonSet owns `nvidia.com/gpu`.
 
 Remove `gpu=on` only when this lab added it. Run this in the same shell that set `HAMI_LAB_ADDED_GPU_LABEL`:
 

--- a/tutorials/labs/hami-sglang.md
+++ b/tutorials/labs/hami-sglang.md
@@ -153,20 +153,9 @@ HAMi's device plugin matches `gpu=on` when managed node selectors are enabled. R
 
 ```bash
 GPU_NODE=<gpu-node-name>
+GPU_LABEL_WAS_PRESENT="$(kubectl get node "${GPU_NODE}" -o go-template='{{if hasKey .metadata.labels "gpu"}}true{{else}}false{{end}}')"
 GPU_LABEL_BEFORE="$(kubectl get node "${GPU_NODE}" -o jsonpath='{.metadata.labels.gpu}')"
-if [ "${GPU_LABEL_BEFORE}" != "on" ]; then
-  export HAMI_LAB_ADDED_GPU_LABEL=true
-fi
 kubectl label node "${GPU_NODE}" gpu=on --overwrite
-```
-
-On Alibaba Cloud ACK, you can also select by vendor labels, for example:
-
-```bash
-kubectl label nodes \
-  -l aliyun.accelerator/xpu_type=nvidia \
-  gpu=on \
-  --overwrite
 ```
 
 ## Step 2: Install HAMi
@@ -211,7 +200,11 @@ helm upgrade --install hami hami-charts/hami \
   --version 2.9.0
 ```
 
-> On some ACK Kubernetes 1.36 clusters, the built-in kube-scheduler in HAMi also needs DRA-related RBAC. If the scheduler logs show `resource.k8s.io` permission errors, apply the same DRA RBAC helper used in [Lab 6](./hami-vllm).
+> On some ACK Kubernetes 1.36 clusters, the built-in kube-scheduler in HAMi also needs DRA-related RBAC. If the scheduler logs show `resource.k8s.io` permission errors, apply the helper used in [Lab 6](./hami-vllm):
+>
+> ```bash
+> kubectl apply -f https://raw.githubusercontent.com/Project-HAMi/website/master/tutorials/labs/hami-vllm/hami-scheduler-dra-rbac.yaml
+> ```
 
 Wait for components to be running:
 
@@ -499,14 +492,19 @@ memory.total [MiB], memory.used [MiB]
 
 That contrast confirms that HAMi's NVML interception exposes the configured quota. It is supporting evidence, but it does not by itself prove that an over-quota CUDA allocation is rejected.
 
-Optionally verify CUDA-level enforcement by requesting a single 26 GiB allocation from a separate process. The request exceeds this Pod's entire 25,000 MiB quota, so it should fail without retaining memory or changing the serving process:
+Optionally verify CUDA-level enforcement from a separate process. Set `GPU_QUOTA_MIB` to the `nvidia.com/gpumem` value used in your manifest. The probe requests 1024 MiB more than that quota, so it remains valid if you lower the quota for another GPU:
 
 ```bash
-kubectl exec -i -n sglang ${POD} -- python3 - <<'PY'
+GPU_QUOTA_MIB=25000
+OVER_QUOTA_MIB=$((GPU_QUOTA_MIB + 1024))
+kubectl exec -i -n sglang ${POD} -- \
+  env OVER_QUOTA_MIB="${OVER_QUOTA_MIB}" python3 - <<'PY'
+import os
 import torch
 
+allocation_mib = int(os.environ["OVER_QUOTA_MIB"])
 try:
-    torch.empty(26 * 1024**3 // 4, dtype=torch.float32, device="cuda")
+    torch.empty(allocation_mib * 1024**2 // 4, dtype=torch.float32, device="cuda")
 except RuntimeError as exc:
     if "out of memory" not in str(exc).lower():
         raise
@@ -516,7 +514,7 @@ else:
 PY
 ```
 
-Expected output includes `PASS: over-quota CUDA allocation returned out of memory`. Confirm that the live server remains healthy after the failed allocation:
+Expected output includes `PASS: over-quota CUDA allocation returned out of memory`. The failed request should not retain memory or change the serving process. Confirm that the live server remains healthy:
 
 ```bash
 curl --fail --silent http://127.0.0.1:8001/health
@@ -567,10 +565,12 @@ kubectl apply -f <original-version-pinned-device-plugin-manifest>
 
 For a Helm release, GPU Operator, or managed add-on, restore it through that same management mechanism. Confirm that exactly one device-plugin DaemonSet owns `nvidia.com/gpu`.
 
-Remove `gpu=on` only when this lab added it. Run this in the same shell that set `HAMI_LAB_ADDED_GPU_LABEL`:
+Restore the original `gpu` label state. Run this in the same shell that recorded `GPU_LABEL_WAS_PRESENT` and `GPU_LABEL_BEFORE`:
 
 ```bash
-if [ "${HAMI_LAB_ADDED_GPU_LABEL:-false}" = true ]; then
+if [ "${GPU_LABEL_WAS_PRESENT}" = true ]; then
+  kubectl label node "${GPU_NODE}" "gpu=${GPU_LABEL_BEFORE}" --overwrite
+else
   kubectl label node "${GPU_NODE}" gpu-
 fi
 ```
@@ -583,7 +583,7 @@ fi
 | GPU node runs HAMi device plugin | `hami-device-plugin` is Ready and advertises `nvidia.com/gpu=10`. |
 | SGLang runs on HAMi resources | Pod Ready; HAMi injects `CUDA_DEVICE_MEMORY_LIMIT_0=25000m` and `CUDA_DEVICE_SM_LIMIT=30`. |
 | Memory quota is visible in-container | In-pod `nvidia-smi` shows `... / 25000MiB` while host still shows `81559 MiB`. |
-| Over-quota allocation is rejected | A 26 GiB PyTorch CUDA allocation returns an out-of-memory error under the 25,000 MiB quota. |
+| Over-quota allocation is rejected | A PyTorch CUDA allocation 1024 MiB above the configured quota returns an out-of-memory error. |
 | Inference service is accessible | `/v1/models` returns `Qwen/Qwen3-1.7B`; chat endpoint returns content. |
 
 ## Next Steps

--- a/tutorials/labs/hami-sglang.md
+++ b/tutorials/labs/hami-sglang.md
@@ -153,8 +153,14 @@ HAMi's device plugin matches `gpu=on` when managed node selectors are enabled. R
 
 ```bash
 GPU_NODE=<gpu-node-name>
-GPU_LABEL_WAS_PRESENT="$(kubectl get node "${GPU_NODE}" -o go-template='{{if hasKey .metadata.labels "gpu"}}true{{else}}false{{end}}')"
-GPU_LABEL_BEFORE="$(kubectl get node "${GPU_NODE}" -o jsonpath='{.metadata.labels.gpu}')"
+GPU_LABEL_WAS_PRESENT="$(kubectl get node "${GPU_NODE}" -o go-template='{{if .metadata.labels}}{{if index .metadata.labels "gpu"}}true{{else}}false{{end}}{{else}}false{{end}}')" || {
+  echo "Failed to record whether the gpu label exists" >&2
+  exit 1
+}
+GPU_LABEL_BEFORE="$(kubectl get node "${GPU_NODE}" -o jsonpath='{.metadata.labels.gpu}')" || {
+  echo "Failed to record the current gpu label" >&2
+  exit 1
+}
 kubectl label node "${GPU_NODE}" gpu=on --overwrite
 ```
 
@@ -203,7 +209,13 @@ helm upgrade --install hami hami-charts/hami \
 > On some ACK Kubernetes 1.36 clusters, the built-in kube-scheduler in HAMi also needs DRA-related RBAC. If the scheduler logs show `resource.k8s.io` permission errors, apply the helper used in [Lab 6](./hami-vllm):
 >
 > ```bash
-> kubectl apply -f https://raw.githubusercontent.com/Project-HAMi/website/master/tutorials/labs/hami-vllm/hami-scheduler-dra-rbac.yaml
+> RBAC_COMMIT="90ac82510bfabe05894dd8037078c59f02a51553"
+> RBAC_SHA256="e0a77f99422230ccc8958aac0d04694347769279ec26a9d4a5ff729f89efe3d9"
+> RBAC_MANIFEST="hami-scheduler-dra-rbac.yaml"
+> curl -fsSLo "${RBAC_MANIFEST}" \
+>   "https://raw.githubusercontent.com/Project-HAMi/website/${RBAC_COMMIT}/tutorials/labs/hami-vllm/hami-scheduler-dra-rbac.yaml"
+> printf '%s  %s\n' "${RBAC_SHA256}" "${RBAC_MANIFEST}" | sha256sum -c -
+> kubectl apply -f "${RBAC_MANIFEST}"
 > ```
 
 Wait for components to be running:

--- a/tutorials/labs/hami-sglang.md
+++ b/tutorials/labs/hami-sglang.md
@@ -1,7 +1,7 @@
 ---
-title: "Lab 11: Run SGLang on HAMi GPU Shares"
+title: "Lab 15: Run SGLang on HAMi GPU Shares"
 description: "Install HAMi on a GPU cluster and schedule SGLang inference services with GPU partitioning."
-sidebar_label: "Lab 11: SGLang Inference"
+sidebar_label: "Lab 15: SGLang Inference"
 lab:
   level: Intermediate
   duration: about 45 minutes
@@ -17,7 +17,7 @@ tags:
 toc_max_heading_level: 2
 ---
 
-This lab demonstrates how to install HAMi on a Kubernetes cluster that already has NVIDIA GPUs, and use HAMi to schedule an [SGLang](https://github.com/sgl-project/sglang) inference service. Upon completion, you will have an OpenAI-compatible model service that can be verified through `/v1/models` and `/v1/chat/completions`, with HAMi enforcing GPU memory and compute caps inside the Pod.
+This lab demonstrates how to install HAMi on a Kubernetes cluster that already has NVIDIA GPUs, and use HAMi to schedule an [SGLang](https://github.com/sgl-project/sglang) inference service. Upon completion, you will have an OpenAI-compatible model service that can be verified through `/v1/models` and `/v1/chat/completions`, with HAMi enforcing a software-based GPU memory quota and compute throttle inside the Pod.
 
 This guide is modeled after [Lab 6: Run vLLM on HAMi GPU Shares](./hami-vllm). The steps are not tied to a specific cloud vendor. As long as your Kubernetes cluster has available NVIDIA GPUs, NVIDIA drivers, and container runtime support, you can reproduce the same setup.
 
@@ -57,7 +57,7 @@ flowchart TB
       HAMI_S["hami-scheduler"]
       HAMI_D["hami-device-plugin<br/>DaemonSet"]
       POD
-      N1["GPU Node<br/>NVIDIA H100 / A10 / ..."]
+      N1["GPU Node<br/>NVIDIA H100 / L40S / ..."]
     end
 
     HAMI_S --> POD
@@ -70,7 +70,7 @@ flowchart TB
 You need to prepare in advance:
 
 - A working Kubernetes cluster
-- At least 1 NVIDIA GPU node with enough free memory for the model (this guide uses a single NVIDIA H100 80GB; an A10/L40S-class GPU also works if you keep the small model and `gpumem` values)
+- At least 1 NVIDIA GPU node with more than 25,000 MiB of usable VRAM (this guide uses a single NVIDIA H100 80GB). For an A10, lower every `nvidia.com/gpumem` request and limit below the memory reported by `nvidia-smi`.
 - `kubectl` connected to the cluster
 - `helm` 3.x
 - GPU nodes with NVIDIA drivers and NVIDIA Container Toolkit / runtime support installed
@@ -134,12 +134,32 @@ kubectl get nodes -o wide
 kubectl describe node | grep -A8 -E "Capacity:|Allocatable:" | grep -E "nvidia.com/gpu|cpu:|memory:"
 ```
 
-If the cluster already has a vendor NVIDIA device plugin installed, you may already see `nvidia.com/gpu`. After installing HAMi, `nvidia.com/gpu` becomes the number of vGPUs exposed by HAMi.
+If the cluster already has a vendor NVIDIA device plugin installed, you may already see `nvidia.com/gpu`. HAMi's device plugin registers the same resource, so the two device plugins must not run on the same GPU nodes. Keep the NVIDIA drivers, Container Toolkit, and runtime installed, but disable or remove the vendor device-plugin DaemonSet before installing HAMi.
 
-HAMi's device plugin matches `gpu=on` when managed node selectors are enabled. Label your GPU nodes:
+First identify the existing plugin. On a self-managed cluster, record and remove it as follows, substituting the discovered namespace and DaemonSet name:
 
 ```bash
-kubectl label node <gpu-node-name> gpu=on --overwrite
+kubectl get daemonsets --all-namespaces | grep -E 'nvidia.*device-plugin'
+
+VENDOR_PLUGIN_NAMESPACE=<namespace>
+VENDOR_PLUGIN_DAEMONSET=<daemonset-name>
+kubectl get daemonset "${VENDOR_PLUGIN_DAEMONSET}" \
+  -n "${VENDOR_PLUGIN_NAMESPACE}" -o yaml >nvidia-device-plugin-backup.yaml
+kubectl delete daemonset "${VENDOR_PLUGIN_DAEMONSET}" \
+  -n "${VENDOR_PLUGIN_NAMESPACE}"
+```
+
+> If a GPU Operator or managed Kubernetes add-on owns the DaemonSet, disable that component through its operator/add-on configuration instead; otherwise its controller may recreate the DaemonSet. Do not uninstall the host driver or NVIDIA container runtime.
+
+HAMi's device plugin matches `gpu=on` when managed node selectors are enabled. Record whether the label already existed, then label the GPU node:
+
+```bash
+GPU_NODE=<gpu-node-name>
+GPU_LABEL_BEFORE="$(kubectl get node "${GPU_NODE}" -o jsonpath='{.metadata.labels.gpu}')"
+if [ "${GPU_LABEL_BEFORE}" != "on" ]; then
+  export HAMI_LAB_ADDED_GPU_LABEL=true
+fi
+kubectl label node "${GPU_NODE}" gpu=on --overwrite
 ```
 
 On Alibaba Cloud ACK, you can also select by vendor labels, for example:
@@ -163,11 +183,6 @@ helm repo update hami-charts
 Create a values file (save as `hami-values.yaml`):
 
 ```yaml
-device:
-  nvidia:
-    driver:
-      enabled: false
-
 global:
   managedNodeSelectorEnable: true
   managedNodeSelector:
@@ -179,7 +194,8 @@ devicePlugin:
 scheduler:
   # Match your cluster Kubernetes minor version (example: kind v1.36.1).
   kubeScheduler:
-    imageTag: "v1.36.1"
+    image:
+      tag: "v1.36.1"
   leaderElect: false
 ```
 
@@ -187,10 +203,9 @@ Key configuration details:
 
 | Configuration | Description |
 | --- | --- |
-| `device.nvidia.driver.enabled: false` | Nodes already have NVIDIA drivers. |
 | `global.managedNodeSelector.gpu: "on"` | Only schedule the HAMi device plugin to GPU nodes labeled `gpu=on`. |
 | `devicePlugin.deviceSplitCount: 10` | Register each physical GPU as 10 vGPUs. |
-| `scheduler.kubeScheduler.imageTag` | Must match the cluster Kubernetes version. |
+| `scheduler.kubeScheduler.image.tag` | Must match the cluster Kubernetes version. |
 | `scheduler.leaderElect: false` | Single-replica lab scheduler; avoids extender leader-election waits. |
 
 Install HAMi:
@@ -271,7 +286,7 @@ spec:
       schedulerName: hami-scheduler
       containers:
         - name: sglang
-          image: lmsysorg/sglang:latest
+          image: lmsysorg/sglang:v0.5.7
           imagePullPolicy: IfNotPresent
           command:
             - python3
@@ -338,9 +353,10 @@ Key points:
 | --- | --- |
 | `schedulerName: hami-scheduler` | Explicitly delegate scheduling to HAMi. |
 | `nvidia.com/gpu: "1"` | Request 1 HAMi GPU device share. |
-| `nvidia.com/gpumem: "25000"` | Hard GPU memory cap in MiB visible inside the container. |
-| `nvidia.com/gpucores: "30"` | Cap SM/compute usage to 30%. |
+| `nvidia.com/gpumem: "25000"` | Software-enforced CUDA memory quota in MiB, also reported through intercepted NVML calls. |
+| `nvidia.com/gpucores: "30"` | Apply a software compute throttle targeting 30% SM usage. |
 | `hami.io/*-scheduler-policy: binpack` | Prefer packing workloads onto the same physical GPU. |
+| `--attention-backend=triton` | Uses the Triton attention backend verified on the H100 test cluster; choose a backend supported by your SGLang version and GPU architecture. |
 | `/dev/shm` Memory emptyDir | SGLang benefits from a larger shared-memory mount. |
 
 Wait for SGLang to become Ready (first start downloads the model and captures CUDA graphs):
@@ -487,7 +503,26 @@ memory.total [MiB], memory.used [MiB]
 81559 MiB, 18560 MiB
 ```
 
-That contrast — full card on the host, capped slice in the Pod — is the key evidence that HAMi memory virtualization is working for SGLang.
+That contrast confirms that HAMi's NVML interception exposes the configured quota. It is supporting evidence, but it does not by itself prove that an over-quota CUDA allocation is rejected.
+
+Verify CUDA-level enforcement by requesting a single 26 GiB allocation, which exceeds this Pod's 25,000 MiB quota:
+
+```bash
+kubectl exec -i -n sglang ${POD} -- python3 - <<'PY'
+import torch
+
+try:
+    torch.empty(26 * 1024**3 // 4, dtype=torch.float32, device="cuda")
+except RuntimeError as exc:
+    if "out of memory" not in str(exc).lower():
+        raise
+    print("PASS: over-quota CUDA allocation returned out of memory")
+else:
+    raise SystemExit("FAIL: over-quota CUDA allocation unexpectedly succeeded")
+PY
+```
+
+Expected output includes `PASS: over-quota CUDA allocation returned out of memory`. HAMi enforces the memory quota by intercepting CUDA allocation calls; this is software enforcement, not a hardware partition such as MIG. Compute limiting is likewise a software throttle.
 
 ## Troubleshooting
 
@@ -523,10 +558,20 @@ If this cluster is only used for this lab, you can also uninstall HAMi:
 helm uninstall hami -n kube-system
 ```
 
-Optional label cleanup:
+Restore the vendor device plugin after HAMi is removed. For the self-managed example above:
 
 ```bash
-kubectl label node <gpu-node-name> gpu-
+kubectl apply -f nvidia-device-plugin-backup.yaml
+```
+
+For a managed add-on or GPU Operator, reverse the vendor-specific change used to disable it and confirm exactly one device-plugin DaemonSet owns `nvidia.com/gpu`.
+
+Remove `gpu=on` only when this lab added it. Run this in the same shell that set `HAMI_LAB_ADDED_GPU_LABEL`:
+
+```bash
+if [ "${HAMI_LAB_ADDED_GPU_LABEL:-false}" = true ]; then
+  kubectl label node "${GPU_NODE}" gpu-
+fi
 ```
 
 ## Verification Results
@@ -536,12 +581,13 @@ kubectl label node <gpu-node-name> gpu-
 | HAMi has taken over GPU scheduling | SGLang Pod uses `schedulerName: hami-scheduler` and requests `nvidia.com/gpu`, `nvidia.com/gpumem`, `nvidia.com/gpucores`. |
 | GPU node runs HAMi device plugin | `hami-device-plugin` is Ready and advertises `nvidia.com/gpu=10`. |
 | SGLang runs on HAMi resources | Pod Ready; HAMi injects `CUDA_DEVICE_MEMORY_LIMIT_0=25000m` and `CUDA_DEVICE_SM_LIMIT=30`. |
-| Memory cap is visible in-container | In-pod `nvidia-smi` shows `... / 25000MiB` while host still shows `81559 MiB`. |
+| Memory quota is visible in-container | In-pod `nvidia-smi` shows `... / 25000MiB` while host still shows `81559 MiB`. |
+| Over-quota allocation is rejected | A 26 GiB PyTorch CUDA allocation returns an out-of-memory error under the 25,000 MiB quota. |
 | Inference service is accessible | `/v1/models` returns `Qwen/Qwen3-1.7B`; chat endpoint returns content. |
 
 ## Next Steps
 
 - Increase `replicas` and observe how HAMi packs multiple SGLang Pods with `binpack`.
 - Lower `nvidia.com/gpumem` / `nvidia.com/gpucores` further and co-locate another small workload on the same GPU.
-- Deliver the model from an OCI registry instead of Hugging Face: a companion **KitOps ModelKit** lab replaces the runtime download with a `kitops-init` initContainer ([website#561](https://github.com/Project-HAMi/website/issues/561)).
+- Deliver the model from an OCI registry instead of Hugging Face: the companion [KitOps ModelKit lab PR](https://github.com/Project-HAMi/website/pull/655) replaces the runtime download with a `kitops-init` initContainer.
 - For memory isolation and small-slice sharing patterns, see [Lab 3: GPU Partitioning](./gpu-partitioning).


### PR DESCRIPTION
## What type of PR is this?

/kind documentation

## What this PR does

Adds **Lab 15: Run SGLang on HAMi GPU Shares**, an intermediate tutorial for installing HAMi on an existing NVIDIA GPU cluster and scheduling an SGLang inference service on a HAMi GPU share.

The lab covers:

- checking cluster and GPU prerequisites
- safely handing GPU resource ownership from a vendor NVIDIA device plugin to HAMi
- installing HAMi 2.9.0 with ten explicit GPU shares
- deploying Qwen3-1.7B with pinned SGLang v0.5.7
- testing the OpenAI-compatible API
- verifying the visible 25,000 MiB quota and optional over-quota CUDA behavior
- restoring the original device plugin and preserving pre-existing node labels during cleanup
- equivalent English and Chinese instructions

## Related issue

Fixes #528

## Merge order

This PR should merge before #655. It becomes Lab 15, and the dependent KitOps tutorial becomes Lab 16.

## Validation

- [x] `npm run lint`
- [x] `npm run format:check`
- [x] `npm test` with 73 tests passing
- [x] English and Chinese production build
- [x] Chinese translation added
- [x] SGLang image pinned and confirmed available
- [x] Commits signed off

Verified environment: kind with an NVIDIA H100 80GB cluster. Original command output was captured on 2026-07-23. The over-quota CUDA allocation added during review is documented as an optional diagnostic and includes a post-test service health check.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added Lab 15, a hands-on tutorial for running SGLang inference services with HAMi GPU sharing.
  * Covers prerequisites, HAMi installation, GPU partitioning, service deployment, API testing, resource verification, troubleshooting, cleanup, and next steps.
  * Added a Chinese-language version and listed the tutorial in the Labs sidebar as intermediate, with an estimated duration of 45 minutes.
  * Improved cleanup instructions to restore existing GPU labels and made quota verification configurable.
  * Added the required DRA RBAC application command for supported clusters.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->