### PR TITLE
fix: Format blog and case study dates in UTC

### DIFF
--- a/src/pages/case-studies.js
+++ b/src/pages/case-studies.js
@@ -10,6 +10,7 @@ function formatDate(date, locale) {
     year: "numeric",
     month: "short",
     day: "numeric",
+    timeZone: "UTC",
   });
 }
 

--- a/src/theme/BlogPostItem/Header/index.js
+++ b/src/theme/BlogPostItem/Header/index.js
@@ -15,6 +15,7 @@ function formatDate(date, locale) {
     year: "numeric",
     month: "numeric",
     day: "numeric",
+    timeZone: "UTC",
   });
 }
 

--- a/src/utils/date.js
+++ b/src/utils/date.js
@@ -5,6 +5,7 @@ export function formatDate(dateStr, locale) {
     year: "numeric",
     month: "long",
     day: "numeric",
+    timeZone: "UTC",
   }).format(new Date(dateStr));
 }
 
@@ -13,9 +14,11 @@ export function formatDateRange(startStr, endStr, locale) {
     year: "numeric",
     month: "long",
     day: "numeric",
+    timeZone: "UTC",
   }).formatRange(new Date(startStr), new Date(endStr));
 }
 
+// These take local Dates from the events calendar, so no UTC here.
 export function formatDay(date, locale) {
   return date.toLocaleDateString(LOCALE_MAP[locale], { day: "numeric" });
 }


### PR DESCRIPTION
**What this PR does / why we need it**:

`metadata.date` and `publishedAt` are both UTC midnight, but the `formatDate` helpers in `src/theme/BlogPostItem/Header/index.js` and `src/pages/case-studies.js` rendered them in the viewer's timezone. Anyone at a negative offset got the previous day, so a post dated 2026-07-16 read as 7/15/2026 across the Americas. Added `timeZone: "UTC"` to both.

`formatDate`/`formatDateRange` in `src/utils/date.js` have the same omission, so I fixed those too. Nothing imports them today, but they're exported and would reintroduce this. The other helpers in that file take Dates the events calendar already built in local time, or render a wall-clock time, so those deliberately stay local.

Nothing changes for readers at UTC or east of it. I diffed every rendered date in `build/` before and after and they're identical. Ran the fixed formatters under UTC, Shanghai, Kolkata, Berlin, New York, LA and Honolulu and they now all agree, which also clears the hydration mismatch since the static output can no longer differ from what the client computes.

I didn't move this to `useDateTimeFormat`, which is what upstream and `BlogArchivePage` use. It doesn't default to UTC either, so it'd be this same change plus a refactor, and it's a hook so `formatDate` would have to move into the component. Happy to do that separately if you'd rather have the consistency.

**Which issue(s) this PR fixes**:

Fixes #659

**Checklist**:

- [x] `npm run lint` and `npm run format:check` pass
- [x] `npm run build` succeeds for both `en` and `zh`
- [ ] Chinese translation updated if English docs changed (or noted why not) — no doc content changed, formatting only
- [ ] Commits are signed off (`git commit -s`)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected date displays to consistently use UTC, preventing dates from shifting based on the viewer’s local time zone.
  * Standardized date and date-range formatting across case studies, blog posts, and event calendars.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->