### PR TITLE
Update KubeCon Japan event metadata and add talk slides

### DIFF
--- a/src/components/EventLanding.js
+++ b/src/components/EventLanding.js
@@ -1,4 +1,5 @@
 import Layout from "@theme/Layout";
+import Head from "@docusaurus/Head";
 import useDocusaurusContext from "@docusaurus/useDocusaurusContext";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import { faDiscord, faGithub } from "@fortawesome/free-brands-svg-icons";
@@ -60,7 +61,7 @@ function formatDateRange(startStr, endStr, locale) {
 }
 
 export default function EventLanding({ slug }) {
-  const { i18n } = useDocusaurusContext();
+  const { i18n, siteConfig } = useDocusaurusContext();
   const isZh = isChinese(i18n.currentLocale);
   const locale = i18n.currentLocale;
   const event = events.find((e) => e.slug === slug);
@@ -89,7 +90,7 @@ export default function EventLanding({ slug }) {
       }),
     },
     description: pick(locale, event.description),
-    image: event.banner ? `https://project-hami.io${event.banner}` : undefined,
+    image: bannerUrl ? `${siteConfig.url}${bannerUrl}` : undefined,
     eventAttendanceMode: "https://schema.org/OfflineEventAttendanceMode",
   };
 
@@ -97,8 +98,12 @@ export default function EventLanding({ slug }) {
     <Layout
       title={isZh ? event.title.zh : event.title.en}
       description={isZh ? event.description.zh : event.description.en}
-      image={bannerUrl || undefined}
     >
+      {bannerUrl && (
+        <Head>
+          <meta property="og:image" content={`${siteConfig.url}${bannerUrl}`} />
+        </Head>
+      )}
       <script
         type="application/ld+json"
         dangerouslySetInnerHTML={{ __html: JSON.stringify(eventJsonLd) }}

--- a/src/components/EventLanding.js
+++ b/src/components/EventLanding.js
@@ -97,7 +97,7 @@ export default function EventLanding({ slug }) {
     <Layout
       title={isZh ? event.title.zh : event.title.en}
       description={isZh ? event.description.zh : event.description.en}
-      image={event.banner}
+      image={bannerUrl || undefined}
     >
       <script
         type="application/ld+json"

--- a/src/components/EventLanding.js
+++ b/src/components/EventLanding.js
@@ -102,6 +102,7 @@ export default function EventLanding({ slug }) {
       {bannerUrl && (
         <Head>
           <meta property="og:image" content={`${siteConfig.url}${bannerUrl}`} />
+          <meta name="twitter:image" content={`${siteConfig.url}${bannerUrl}`} />
         </Head>
       )}
       <script

--- a/src/data/events.js
+++ b/src/data/events.js
@@ -69,6 +69,11 @@ const events = [
         zh: "社区宣传册",
         url: "/resources/flyers/community-flyer.pdf",
       },
+      talkSlides: {
+        en: "Talk Slides",
+        zh: "演讲幻灯片",
+        url: "/resources/2026-kubecon-japan/snow_corp_cncf.pdf",
+      },
     },
     caseStudy: {
       company: "SNOW Corp.",

--- a/static/resources/2026-kubecon-japan/snow_corp_cncf.pdf
+++ b/static/resources/2026-kubecon-japan/snow_corp_cncf.pdf
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:60e88662fe8b777804aa5a22a9013e852884e506c722484b3796b9243c1deba2
+size 5604712


### PR DESCRIPTION
- **fix(events): correct OG image fallback and add KubeCon Japan talk slides**
- **fix(EventLanding): set og:image from event banner via Head, use siteConfig.url**

**What type of PR is this?**

/kind feature

**What this PR does / why we need it**:

fix eventlanding metadata(for linking, etc) and add KubeCon Japan talk slides


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Talk Slides resources for the KubeCon Japan event, including English/Chinese labels and a PDF link.
  * Improved social sharing previews by generating event-specific Open Graph and Twitter image metadata when a banner image is available.
* **Bug Fixes**
  * Ensured shared and Schema.org image URLs use the site’s configured base URL for correct absolute links.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->