### PR TITLE
chore: patch brace-expansion DoS in the serve-handler path

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7990,9 +7990,9 @@
       }
     },
     "node_modules/brace-expansion": {
-      "version": "1.1.16",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.16.tgz",
-      "integrity": "sha512-IDw48K2/2kRkg9LdJxurvq3lV3aBgq0REY89duEqFRthjlPdXHKMj7EnQOXVckxzgisinf3nHfrcE2FufFLXMw==",
+      "version": "1.1.17",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.17.tgz",
+      "integrity": "sha512-w+aeW/mkgM4PyRMOJCgi3fOrTm5Q8QY1OSfn2TO2iuDj3ezIHqejmuxbjfPrqUkgqRew1iqkyAn0tr0ZwHD9+w==",
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^1.0.0",

--- a/package.json
+++ b/package.json
@@ -82,6 +82,11 @@
     },
     "sockjs": {
       "uuid": "11.1.1"
+    },
+    "serve-handler": {
+      "minimatch": {
+        "brace-expansion": "1.1.17"
+      }
     }
   }
 }


### PR DESCRIPTION
## What

Pin `brace-expansion` to `1.1.17` inside the `serve-handler > minimatch` path so the last open npm audit finding is resolved.

## Why

`npm audit` on master reports 20 high findings, all tracing back to a single copy of `brace-expansion@1.1.16`:

```
brace-expansion  <=5.0.7   high   CVE-2026-14257
  minimatch 2.0.0 - 10.0.2
    serve-handler >=1.1.0
      @docusaurus/core *
```

`serve-handler@6.1.7` (latest, pulled in by `@docusaurus/core`) hard-pins `minimatch@3.1.5`, which pins `brace-expansion@^1.1.7`.

The advisory lists `5.0.8` as the first patched version, but that release cannot be used on this path: `5.0.8` is ESM-first and its CommonJS build exports `{ expand, EXPANSION_MAX, ... }`, while `minimatch@3` does `require('brace-expansion')` and calls the result directly. Forcing `5.0.8` here throws `expand is not a function` at runtime and breaks `npm run serve`.

`1.1.17` is the upstream backport of the same fix to the 1.x line. Its `index.js` adds the `EXPANSION_MAX_LENGTH` bound and names CVE-2026-14257 in the code comment, and it keeps the callable CommonJS export.

## Note on npm audit output

`npm audit` will keep listing this finding until the advisory range is split per major, because the published range `<=5.0.7` covers `1.1.17` by plain semver comparison even though 1.1.17 contains the fix. The installed code is patched.

## Verification

- `npm ci` clean
- `npm run build` succeeds
- `npm run serve` returns HTTP 200 on `/` and on a docs page, which exercises the `serve-handler > minimatch > brace-expansion` path
- `npm run format:check` passes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated package configuration to improve installation reliability and maintain consistent behavior across supported environments.
  - No user-facing feature changes or updates to the application interface.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->