### PR TITLE
chore: group react and react-dom dependabot updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,6 +6,10 @@ updates:
       interval: weekly
     open-pull-requests-limit: 5
     groups:
+      react:
+        patterns:
+          - "react"
+          - "react-dom"
       npm-minor-patch:
         applies-to: version-updates
         patterns:


### PR DESCRIPTION
## What

Add a `react` group to `.github/dependabot.yml` covering `react` and `react-dom`.

## Why

Dependabot opened the React 19 bump as two separate pull requests, #670 and #671. Each pinned one half of the pair while the other half stayed on 18, so `npm ci` failed on both:

```
npm error While resolving: react-dom@19.2.8
npm error Found: react@18.3.1
npm error Could not resolve dependency:
npm error peer react@"^19.2.8" from react-dom@19.2.8
```

Neither PR could ever go green on its own, so both were closed.

The existing `npm-minor-patch` group is limited to `minor` and `patch` update types, which left major bumps ungrouped and split per package. The new `react` group carries no `update-types` filter, so it applies to every update type and keeps the two packages in a single pull request.

`@docusaurus/core@3.10.2` already declares `react: "^18.0.0 || ^19.0.0"`, so a combined React 19 pull request resolves cleanly. Verified locally with `npm install --package-lock-only react@^19.2.8 react-dom@^19.2.8`: no ERESOLVE, and `npm audit` unchanged.