### PR TITLE
ci: run docs health check on pushes to master

### DIFF
--- a/.github/workflows/docs-health.yml
+++ b/.github/workflows/docs-health.yml
@@ -1,6 +1,8 @@
 name: Docs Health Check
 
 on:
+  push:
+    branches: [master]
   pull_request:
     branches: [master]
   schedule:


### PR DESCRIPTION
Add a `push` trigger on `master` to the Docs Health Check workflow.

The workflow currently runs only on pull requests and on the weekly Monday cron, so nothing builds `master` after a merge.

Two pull requests can each pass on their own and still break once combined, because each one is tested against the base as it was when the branch was created, not against the tree it actually lands on. Dependency updates that land close together are the common case: this repo merged four of them today.

Right now that breakage would sit on `master` until the next Monday run, or until someone opened an unrelated pull request and noticed.

With the push trigger, `master` is linted, formatted, built and link-checked within minutes of every merge.
