### PR TITLE
fix: remove the Docker Hub pull count fetch

### DIFF
--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -375,7 +375,8 @@ export default function Home() {
   const { i18n } = useDocusaurusContext();
   const isZh = i18n.currentLocale === "zh";
   const [starsCount, setStarsCount] = useState(3100);
-  const [dockerPulls, setDockerPulls] = useState(325000);
+  // Static: Docker Hub's API sends no CORS header, so it cannot be read from the browser.
+  const dockerPulls = 325000;
   const kubernetesLogo = useBaseUrl("img/kubernetes-logo.svg");
   const hamiLogo = useBaseUrl("img/hami-graph-color.svg");
   const hamiHorizontalLogoLight = useBaseUrl("img/hami-horizontal-color-black.svg");
@@ -431,23 +432,7 @@ export default function Home() {
       }
     };
 
-    const fetchDockerPulls = async () => {
-      try {
-        const response = await fetch("https://hub.docker.com/v2/repositories/projecthami/hami/", {
-          signal: controller.signal,
-        });
-        if (!response.ok) return;
-        const data = await response.json();
-        if (typeof data?.pull_count === "number") {
-          setDockerPulls(data.pull_count);
-        }
-      } catch (error) {
-        // Keep fallback value when API is unavailable.
-      }
-    };
-
     fetchGitHubStars();
-    fetchDockerPulls();
 
     return () => controller.abort();
   }, []);


### PR DESCRIPTION
Docker Hub's API sends no `Access-Control-Allow-Origin` header, so this fetch is blocked by the browser on every homepage load:

```
Access to fetch at 'https://hub.docker.com/v2/repositories/projecthami/hami/'
has been blocked by CORS policy: No 'Access-Control-Allow-Origin' header is present
```

The `catch` block hid the failure, so the displayed count always stayed at the hardcoded fallback while still logging a console error. Removing the fetch keeps the same number on screen and clears the error.

The GitHub stars fetch is left alone, `api.github.com` does send the header.

Verified with `npm ci`, `npm run build` and `npm run format:check`.