### PR TITLE
ci: label pull requests from their changed paths

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -1,0 +1,46 @@
+area/docs:
+  - changed-files:
+      - any-glob-to-any-file:
+          - "docs/**"
+          - "versioned_docs/**"
+          - "versioned_sidebars/**"
+          - "tutorials/**"
+          - "sidebars.js"
+          - "sidebars-tutorials.js"
+          - "versions.json"
+
+area/ui:
+  - changed-files:
+      - any-glob-to-any-file: "src/**"
+
+area/blog:
+  - changed-files:
+      - any-glob-to-any-file: "blog/**"
+
+area/i18n:
+  - changed-files:
+      - any-glob-to-any-file: "i18n/**"
+
+area/edge-functions:
+  - changed-files:
+      - any-glob-to-any-file:
+          - "netlify/**"
+          - "netlify.toml"
+
+area/ci-infra:
+  - changed-files:
+      - any-glob-to-any-file:
+          - ".github/**"
+          - "scripts/**"
+          - "package.json"
+          - "package-lock.json"
+          - ".markdownlint.json"
+          - ".prettierrc"
+          - ".prettierignore"
+
+area/seo:
+  - changed-files:
+      - any-glob-to-any-file:
+          - "static/robots.txt"
+          - "static/llms.txt"
+          - "docusaurus.config.js"

--- a/.github/workflows/pr-labeler.yml
+++ b/.github/workflows/pr-labeler.yml
@@ -1,0 +1,22 @@
+name: PR Labeler
+
+# pull_request_target is used so that pull requests opened from forks get
+# labeled too. A pull_request run from a fork has a read-only token and cannot
+# add labels. This workflow never checks out or executes pull request code, it
+# only reads the changed file list, so the elevated token is not exposed to it.
+on:
+  pull_request_target:
+    types: [opened, synchronize, reopened]
+
+permissions:
+  contents: read
+  pull-requests: write
+
+jobs:
+  label:
+    name: Label by changed paths
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/labeler@bf12e9b00b37c5c0ca2b87b79b2daf7891dbda13 # v7.0.0
+        with:
+          sync-labels: false


### PR DESCRIPTION
## Why

Issue labels were applied in a single manual pass. Pull requests carry no `area/*` label at all, and nothing keeps either up to date as new work arrives.

Mapping a changed path to an area needs no judgement, so it can run on its own. Priority and difficulty still cannot, and are left alone.

## What it does

`.github/labeler.yml` maps paths to the `area/*` labels.

| Label | Paths |
|---|---|
| `area/docs` | `docs/`, `versioned_docs/`, `versioned_sidebars/`, `tutorials/`, `sidebars*.js`, `versions.json` |
| `area/ui` | `src/` |
| `area/blog` | `blog/` |
| `area/i18n` | `i18n/` |
| `area/edge-functions` | `netlify/`, `netlify.toml` |
| `area/ci-infra` | `.github/`, `scripts/`, `package*.json`, lint and format config |
| `area/seo` | `static/robots.txt`, `static/llms.txt`, `docusaurus.config.js` |

`area/ui` is new, created to cover `src/` (React components, pages, theme, css), which is the largest source directory here and had no area label. It uses the same colour as the rest of the `area/*` family. Every other label already existed.

## Dry run against merged pull requests

Ran the rules against the actual changed file lists:

| PR | Files | Result |
|---|---|---|
| #679 | `.github/ISSUE_TEMPLATE/*` | `area/ci-infra` |
| #678 | `src/pages/index.js` | `area/ui` |
| #677 | `.github/workflows/docs-health.yml` | `area/ci-infra` |
| #673 | `package.json`, `package-lock.json` | `area/ci-infra` |
| #655 | `i18n/…`, `tutorials/…`, `sidebars-tutorials.js` | `area/i18n`, `area/docs` |

Every merged pull request checked now lands on at least one area.

## Notes

`pull_request_target` is used because a `pull_request` run from a fork gets a read-only token and cannot add labels. The workflow never checks out or executes pull request code, it only reads the changed file list, so the elevated token is not exposed to contributor code. The action is pinned by commit SHA, matching the convention in `docs-health.yml`.

`sync-labels: false` means labels are only added, never removed, so a manually applied label is not stripped on the next push.

`npm run format:check` passes.