### PR TITLE
chore: pin CodeRabbit label vocabulary to the kind/* scheme

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -1,0 +1,27 @@
+# yaml-language-server: $schema=https://coderabbit.ai/integrations/schema.v2.json
+#
+# Label vocabulary for CodeRabbit. Without this file CodeRabbit infers labels
+# from past pull requests, which is how the flat `enhancement` label kept coming
+# back after it was deleted. With `labeling_instructions` set, CodeRabbit only
+# suggests labels from the list below.
+#
+# Scope is limited to `kind/*` on purpose. `area/*` is applied deterministically
+# by path globs in .github/labeler.yml, and `priority/*` is a maintainer call.
+
+reviews:
+  labeling_instructions:
+    - label: kind/bug
+      instructions: Apply when the pull request fixes broken behavior on the site, such as a wrong link, a rendering fault, a build failure, or a script that does not work as documented.
+    - label: kind/feature
+      instructions: Apply when the pull request adds new site functionality or a new component, page, or build step. Also apply for performance work that changes how assets are produced or served.
+    - label: kind/documentation
+      instructions: Apply when the pull request only changes documentation, blog, tutorial, or translation content, including corrections to prose, tables, and front matter.
+    - label: kind/cleanup
+      instructions: Apply when the pull request refactors, reformats, or updates configuration and dependencies without changing behavior for site visitors.
+  mutually_exclusive_groups:
+    kind:
+      - kind/bug
+      - kind/feature
+      - kind/documentation
+      - kind/cleanup
+  auto_apply_labels: true


### PR DESCRIPTION
**What type of PR is this?**

/kind cleanup

**What this PR does / why we need it**:

Follow-up to the label discussion in #679. The flat `bug`, `enhancement` and `documentation` labels were deleted and the four issues that carried `enhancement` are on `kind/feature`, but the delete does not hold on its own: CodeRabbit auto-applies labels here and, with no config in the repo, infers them from past PRs. Adding a missing label through the GitHub API recreates it, so `enhancement` came straight back (see the label timeline on this PR, #682 and #684).

This pins the vocabulary:

- suggestions restricted to `kind/bug`, `kind/feature`, `kind/documentation` and `kind/cleanup`
- the four marked mutually exclusive, so a PR cannot end up with two type labels
- `auto_apply_labels: true` keeps the current behavior, only with the right labels

`area/*` is left to the path globs in `.github/labeler.yml` and `priority/*` stays a maintainer call, so this file does not touch either.

**On `kind/cleanup`**: `.github/PULL_REQUEST_TEMPLATE.md` offers `/kind bug`, `/kind cleanup`, `/kind documentation` and `/kind feature`, but `kind/cleanup` did not exist as a label. Prow silently rejected it, which is the same class of bug #679 describes for the issue templates. The label now exists, so it belongs in this list too.

**Note on scope**: CodeRabbit only reads `.coderabbit.yaml` from the base branch for open source repos, so this has no effect until it lands on `master`. Until then `enhancement` keeps reappearing on new PRs. Deleting that label again after merge is the last step.

**Which issue(s) this PR fixes**:

Relates to #679

**Checklist**:

- [x] `npm run lint` and `npm run format:check` pass
- [x] `npm run build` succeeds for both `en` and `zh`
- [x] Chinese translation updated if English docs changed (or noted why not)
- [x] Commits are signed off (`git commit -s`)

Notes on the checklist:

- `prettier --check` passes on the new file, and the config validates against the CodeRabbit v2 config schema (`schema.v2.json`).
- `Docs Health Check / Lint, Format, Build & Links` passed on CI, which covers lint, format and the build for both locales. `.coderabbit.yaml` is read by CodeRabbit only, it is not an input to Docusaurus.
- No English docs changed, so no translation work.