### PR TITLE
fix(edge): only rewrite complete 200 responses to markdown

### DIFF
--- a/netlify/edge-functions/markdown-negotiation.js
+++ b/netlify/edge-functions/markdown-negotiation.js
@@ -270,7 +270,10 @@ export default async (request, context) => {
   const response = await context.next();
   const contentType = response.headers.get("content-type") || "";
 
-  if (!response.ok || !contentType.toLowerCase().includes("text/html")) {
+  // Only a complete 200 is safe to rewrite. A 206 carries a Content-Range
+  // describing the HTML byte range, which stops matching once the body becomes
+  // Markdown, and a 204 can't take a body at all.
+  if (response.status !== 200 || !contentType.toLowerCase().includes("text/html")) {
     return response;
   }
 


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

**What this PR does / why we need it**:

The rewrite is gated on `!response.ok`, which is true for any 2xx, so 206 and 204 both land in the transform path.

For a 206 the body gets rewritten to Markdown but `Content-Range` still describes the HTML:

```
$ curl -sS -D - -H 'Accept: text/markdown' -H 'Range: bytes=0-99' https://project-hami.io/docs
HTTP/2 206
content-range: bytes 0-99/35231
content-type: text/markdown; charset=utf-8
etag: "6ccfc61102f25e67310496e2434ba699-ssl"

# HAMi

Source: https://project-hami.io/docs

<html lang="en" dir="ltr" class="docs-wrapper plugin-docs plugin-id-default docs-ver
```

Range says 100 bytes, 131 come back, and the ETag is still the HTML's. The truncated fragment has no `<main>`, so `htmlToMarkdown` falls back to the whole fragment and the raw `<html ...>` tag ends up in the output.

204 throws instead, since `new Response(body, { status: 204 })` isn't valid. I only hit that with a mocked origin, not on the live site, so treat it as defensive.

`response.status !== 200` is what the check should have been. 304 and non-2xx keep passing through as before.

**Impact** : almost nobody sends `Range` alongside `Accept: text/markdown`, so this probably isn't affecting anyone today. Opening it anyway because the response contradicts itself and the fix is one word.

Checked against mocked 200 / 206 / 204 / 304 / 404 responses and a plain `Accept: text/html`.

**Which issue(s) this PR fixes**:

No separate issue opened for this one. The change is 5 lines fix.

**Checklist**:

- [x] `npm run lint` and `npm run format:check` pass
- [x] `npm run build` succeeds for both `en` and `zh`
- [x] Chinese translation updated if English docs changed (or noted why not)
- [x] Commits are signed off (`git commit -s`)
