### PR TITLE
fix: `npm run fetch-changelog` fails on a fresh clone

### DIFF
--- a/src/scripts/fetch-changelog.js
+++ b/src/scripts/fetch-changelog.js
@@ -205,8 +205,11 @@ function fetchFromWebPage() {
 async function updateAuthorsJson(contributors) {
   const authorsPath = path.join(process.cwd(), "changelog", "source", "authors.json");
   try {
-    const authorsContent = fs.readFileSync(authorsPath, "utf8");
-    const authors = JSON.parse(authorsContent);
+    // changelog/source is gitignored and only generated at build time, so it may not exist yet
+    fs.mkdirSync(path.dirname(authorsPath), { recursive: true });
+    const authors = fs.existsSync(authorsPath)
+      ? JSON.parse(fs.readFileSync(authorsPath, "utf8"))
+      : {};
     let updated = false;
     for (const contributor of contributors) {
       if (!authors[contributor.username]) {


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

**What this PR does / why we need it**:

This PR fixes `npm run fetch-changelog <version>` failing on a fresh clone.

It exits 1 on a clean checkout. `updateAuthorsJson()` reads `changelog/source/authors.json`
without checking it exists, and the catch re-throws, so `main()` bails before anything gets
written, including `CHANGELOG.md`. `changelog/source/` is gitignored and only generated by the
changelog plugin at build time, so it isn't there on a fresh clone or in CI.

The fix, in `updateAuthorsJson()`: make the directory first, and start from an empty map when
`authors.json` isn't there yet.

**Which issue(s) this PR fixes**:

Fixes #693

**Checklist**:

- [x] `npm run lint` and `npm run format:check` pass (prettier run on the changed file via npx,
      repo deps aren't installed locally; markdownlint only covers `docs/`, `tutorials/`, `blog/`)
- [x] `npm run build` succeeds for both `en` and `zh` (not run, this is a standalone release
      script and nothing in the Docusaurus build imports it)
- [x] Chinese translation updated if English docs changed (or noted why not) (n/a, no docs touched)
- [x] Commits are signed off (`git commit -s`)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved changelog author updates by creating missing directories and handling absent author records automatically.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->