### PR TITLE
fix(changelog): normalize CRLF before parsing so committer regex matches

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -6,3 +6,5 @@
 *.mp4 filter=lfs diff=lfs merge=lfs -text
 *.pdf filter=lfs diff=lfs merge=lfs -text
 *.webp filter=lfs diff=lfs merge=lfs -text
+
+CHANGELOG.md text eol=lf

--- a/src/plugins/changelog/index.js
+++ b/src/plugins/changelog/index.js
@@ -138,7 +138,7 @@ export default async function ChangelogPlugin(context, options) {
     ...blogPlugin,
     name: 'changelog-plugin',
     async loadContent() {
-      const fileContent = await fs.readFile(changelogPath, 'utf-8');
+      const fileContent = (await fs.readFile(changelogPath, 'utf-8')).replace(/\r\n/g, '\n');
       const sections = fileContent
         .split(/(?=\n## )/)
         .map(processSection)


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

**What this PR does / why we need it**:

`npm run build` crashes on the `zh` locale on a Windows checkout with the default `core.autocrlf=true`. The changelog plugin extracts committer names from `CHANGELOG.md` with a regex that needs a literal `\n` right after each line; on a CRLF checkout every line ends `\r\n`, so the regex never matches, `authorsMap` stays empty, and `authors.json` gets written out blank. That silently drops contributor bylines from the generated English changelog pages, and it takes down the `zh` build entirely, because the tracked `i18n/zh/docusaurus-plugin-content-blog-changelog/*.md` files still carry an explicit `authors:` list from when they were translated, and the blog plugin can't resolve those aliases against an empty map.

This normalizes `CHANGELOG.md`'s line endings right after reading it, so parsing behaves the same no matter how the file was checked out, and pins `CHANGELOG.md` to LF in `.gitattributes` so a different local git config can't reintroduce this.

Verified locally: before the fix, `changelog/source/authors.json` was `{}` after any build and `npm run build` died mid-way through the `zh` pass with `Can't reference blog post authors by a key (such as 'abstractmj')...`. After the fix, `authors.json` has 84 real contributor entries and both `en` and `zh` builds complete cleanly.

**Which issue(s) this PR fixes**:

Fixes #695

**Checklist**:

- [x] `npm run lint` and `npm run format:check` pass
- [x] `npm run build` succeeds for both `en` and `zh`
- [x] Chinese translation updated if English docs changed (or noted why not) - N/A, no doc content changed
- [x] Commits are signed off (`git commit -s`)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved changelog processing by consistently handling Windows-style line endings.
  * Changelog sections now parse reliably across supported operating systems.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->