### PR TITLE
fix: scope changelog plugin state per loadContent and derive figure locale from pathname (fixes #699)

### DIFF
--- a/src/client/imageFigureNumber.js
+++ b/src/client/imageFigureNumber.js
@@ -16,8 +16,8 @@ function localeFromPathname(pathname) {
 }
 
 export function onRouteDidUpdate({ location }) {
-  // Only run on blog and doc pages
-  if (!location.pathname.match(/\/blog\//) && !location.pathname.match(/\/docs\//)) {
+  // Only run on blog and doc pages (including root doc paths like /docs or /zh/docs)
+  if (!/(?:^|\/)(?:blog|docs)(?:$|\/)/.test(location.pathname)) {
     return;
   }
 
@@ -60,12 +60,15 @@ function addFigureNumbers(locale) {
 
     figureCount++;
 
-    // Wrap in <figure> if not already wrapped
+    // Wrap in <figure> if not already wrapped. If the image is inside an anchor link,
+    // move the anchor element into the figure to preserve clickable links.
     let figure = img.closest("figure");
     if (!figure) {
       figure = document.createElement("figure");
-      img.parentNode.insertBefore(figure, img);
-      figure.appendChild(img);
+      const targetElement =
+        img.parentElement && img.parentElement.tagName === "A" ? img.parentElement : img;
+      targetElement.parentNode.insertBefore(figure, targetElement);
+      figure.appendChild(targetElement);
     }
 
     // Find or create the <figcaption>, always overwriting its text so that

--- a/src/client/imageFigureNumber.js
+++ b/src/client/imageFigureNumber.js
@@ -2,28 +2,48 @@
  * Client module to automatically add figure numbers and captions to images
  * based on their alt text in blog posts and docs.
  */
-export function onRouteDidUpdate({ location, previousLocation }) {
+
+/**
+ * Derive the locale from the current pathname so the caption prefix is always
+ * consistent with the page the user navigated *to*, not with whatever stale
+ * value `document.documentElement.lang` happens to hold during the transition.
+ *
+ * @param {string} pathname
+ * @returns {"zh" | "en"}
+ */
+function localeFromPathname(pathname) {
+  return pathname.startsWith("/zh/") || pathname === "/zh" ? "zh" : "en";
+}
+
+export function onRouteDidUpdate({ location }) {
   // Only run on blog and doc pages
   if (!location.pathname.match(/\/blog\//) && !location.pathname.match(/\/docs\//)) {
     return;
   }
 
-  // Wait for DOM to be ready with multiple attempts
-  setTimeout(() => addFigureNumbers(), 100);
-  setTimeout(() => addFigureNumbers(), 500);
-  setTimeout(() => addFigureNumbers(), 1000);
+  const locale = localeFromPathname(location.pathname);
+
+  // A single rAF tick is sufficient: Docusaurus has already committed the new
+  // page content to the DOM by the time onRouteDidUpdate fires. Using rAF
+  // instead of multiple staggered setTimeouts avoids duplicate caption
+  // injections when routes are navigated quickly.
+  requestAnimationFrame(() => addFigureNumbers(locale));
 }
 
-function addFigureNumbers() {
+/**
+ * @param {"zh" | "en"} locale
+ */
+function addFigureNumbers(locale) {
   // Find all images in markdown content
   const articleContent = document.querySelector("article");
   if (!articleContent) {
     return;
   }
 
-  // Find all images that are not in header or footer
+  const prefix = locale === "zh" ? "图" : "Figure";
+
+  // Find all images that are not logos or small icons
   const images = Array.from(articleContent.querySelectorAll("img")).filter((img) => {
-    // Filter out logos, avatars, icons
     const parentClass = img.parentElement?.className || "";
     const isLogo = parentClass.includes("logo") || img.alt.includes("logo");
     const isIcon = img.width < 100 || img.height < 100;
@@ -33,26 +53,14 @@ function addFigureNumbers() {
   let figureCount = 0;
 
   images.forEach((img) => {
-    // Get alt text
     const altText = img.getAttribute("alt") || "";
     if (!altText.trim()) {
       return;
     }
 
-    // Check if already has figcaption with figure number
-    const existingFigure = img.closest("figure");
-    if (existingFigure) {
-      const existingFigcaption = existingFigure.querySelector("figcaption");
-      if (existingFigcaption && existingFigcaption.textContent.match(/^(图|Figure)\d+:/)) {
-        figureCount++;
-        return;
-      }
-    }
-
-    // Increment counter
     figureCount++;
 
-    // Create figure wrapper if it doesn't exist
+    // Wrap in <figure> if not already wrapped
     let figure = img.closest("figure");
     if (!figure) {
       figure = document.createElement("figure");
@@ -60,30 +68,16 @@ function addFigureNumbers() {
       figure.appendChild(img);
     }
 
-    // Remove existing figcaption if any (but only if it doesn't have figure number)
-    const existingFigcaption = figure.querySelector("figcaption");
-    if (existingFigcaption && !existingFigcaption.textContent.match(/^(图|Figure)\d+:/)) {
-      existingFigcaption.remove();
-    } else if (existingFigcaption) {
-      // Update existing figcaption with figure number
-      const currentLang = document.documentElement.lang || "en";
-      const prefix = currentLang.startsWith("zh") ? "图" : "Figure";
-      existingFigcaption.textContent = `${prefix}${figureCount}: ${altText}`;
-      return;
+    // Find or create the <figcaption>, always overwriting its text so that
+    // navigating between locales corrects stale captions from a previous run.
+    let figcaption = figure.querySelector("figcaption");
+    if (!figcaption) {
+      figcaption = document.createElement("figcaption");
+      figure.appendChild(figcaption);
     }
-
-    // Create figcaption with number and alt text
-    const figcaption = document.createElement("figcaption");
-    const currentLang = document.documentElement.lang || "en";
-
-    // Use appropriate prefix based on language
-    const prefix = currentLang.startsWith("zh") ? "图" : "Figure";
     figcaption.textContent = `${prefix}${figureCount}: ${altText}`;
 
-    // Append figcaption to figure
-    figure.appendChild(figcaption);
-
-    // Add styling class
+    // Apply styles (idempotent — repeated assignment is harmless)
     figure.style.cssText = `
       margin: 2em 0;
       text-align: center;

--- a/src/client/imageFigureNumber.js
+++ b/src/client/imageFigureNumber.js
@@ -88,6 +88,23 @@ function isIconImage(img) {
 }
 
 /**
+ * Undo the <figure>/<figcaption> wrapping that this script previously applied
+ * to an image, used when a reload reveals the image is actually an icon
+ * (e.g. it had no width/height attributes and looked like content pre-load).
+ *
+ * @param {HTMLImageElement} img
+ */
+function unwrapAutoFigure(img) {
+  const figure = img.closest("figure");
+  if (!figure || !figure.dataset.autoFigure) {
+    return;
+  }
+  const wrapped = img.parentElement && img.parentElement.tagName === "A" ? img.parentElement : img;
+  figure.parentNode.insertBefore(wrapped, figure);
+  figure.remove();
+}
+
+/**
  * @param {"zh" | "en"} locale
  */
 function addFigureNumbers(locale) {
@@ -110,7 +127,13 @@ function addFigureNumbers(locale) {
         { once: true },
       );
     }
-    return !isIconImage(img);
+    const isIcon = isIconImage(img);
+    if (isIcon) {
+      // An earlier pass may have wrapped this image before it finished loading
+      // and its true (small) dimensions were known; undo that now.
+      unwrapAutoFigure(img);
+    }
+    return !isIcon;
   });
 
   let figureCount = 0;
@@ -128,6 +151,7 @@ function addFigureNumbers(locale) {
     let figure = img.closest("figure");
     if (!figure) {
       figure = document.createElement("figure");
+      figure.dataset.autoFigure = "true";
       const targetElement =
         img.parentElement && img.parentElement.tagName === "A" ? img.parentElement : img;
       targetElement.parentNode.insertBefore(figure, targetElement);

--- a/src/client/imageFigureNumber.js
+++ b/src/client/imageFigureNumber.js
@@ -15,9 +15,19 @@ function localeFromPathname(pathname) {
   return pathname.startsWith("/zh/") || pathname === "/zh" ? "zh" : "en";
 }
 
+/**
+ * Only blog and doc pages (including root doc paths like /docs or /zh/docs)
+ * get figure numbering.
+ *
+ * @param {string} pathname
+ * @returns {boolean}
+ */
+function isSupportedRoute(pathname) {
+  return /(?:^|\/)(?:blog|docs)(?:$|\/)/.test(pathname);
+}
+
 export function onRouteDidUpdate({ location }) {
-  // Only run on blog and doc pages (including root doc paths like /docs or /zh/docs)
-  if (!/(?:^|\/)(?:blog|docs)(?:$|\/)/.test(location.pathname)) {
+  if (!isSupportedRoute(location.pathname)) {
     return;
   }
 
@@ -123,7 +133,15 @@ function addFigureNumbers(locale) {
       img.dataset.hasLoadListener = "true";
       img.addEventListener(
         "load",
-        () => addFigureNumbers(localeFromPathname(window.location.pathname)),
+        () => {
+          // Re-check the route: by the time a slow image loads, navigation
+          // may have moved to a page this script shouldn't touch.
+          const pathname = window.location.pathname;
+          if (!isSupportedRoute(pathname)) {
+            return;
+          }
+          addFigureNumbers(localeFromPathname(pathname));
+        },
         { once: true },
       );
     }

--- a/src/client/imageFigureNumber.js
+++ b/src/client/imageFigureNumber.js
@@ -104,7 +104,11 @@ function addFigureNumbers(locale) {
     // Re-run captioning when lazy/slow images complete loading
     if (!img.complete && !img.dataset.hasLoadListener) {
       img.dataset.hasLoadListener = "true";
-      img.addEventListener("load", () => addFigureNumbers(locale), { once: true });
+      img.addEventListener(
+        "load",
+        () => addFigureNumbers(localeFromPathname(window.location.pathname)),
+        { once: true },
+      );
     }
     return !isIconImage(img);
   });

--- a/src/client/imageFigureNumber.js
+++ b/src/client/imageFigureNumber.js
@@ -23,11 +23,68 @@ export function onRouteDidUpdate({ location }) {
 
   const locale = localeFromPathname(location.pathname);
 
-  // A single rAF tick is sufficient: Docusaurus has already committed the new
-  // page content to the DOM by the time onRouteDidUpdate fires. Using rAF
+  // A single rAF tick is sufficient for committed DOM elements. Using rAF
   // instead of multiple staggered setTimeouts avoids duplicate caption
   // injections when routes are navigated quickly.
   requestAnimationFrame(() => addFigureNumbers(locale));
+}
+
+/**
+ * Determine if an image is a logo or small icon that should be skipped.
+ * Handles images with explicit HTML/CSS width attributes (e.g. <img width="600px">)
+ * even when rendered height is 0 before the image finishes loading.
+ *
+ * @param {HTMLImageElement} img
+ * @returns {boolean}
+ */
+function isIconImage(img) {
+  const parentClass = img.parentElement?.className || "";
+  const isLogo = parentClass.includes("logo") || (img.alt && img.alt.includes("logo"));
+  if (isLogo) {
+    return true;
+  }
+
+  // Parse explicit width/height attributes (e.g. width="600px" or width="600")
+  const attrWidth = parseInt(img.getAttribute("width") || "", 10);
+  const attrHeight = parseInt(img.getAttribute("height") || "", 10);
+
+  // If explicit width or height attribute is >= 100, it is a content figure, not an icon
+  if ((!isNaN(attrWidth) && attrWidth >= 100) || (!isNaN(attrHeight) && attrHeight >= 100)) {
+    return false;
+  }
+
+  // If explicit width or height attribute is small (> 0 and < 100), it is an icon
+  if (
+    (!isNaN(attrWidth) && attrWidth > 0 && attrWidth < 100) ||
+    (!isNaN(attrHeight) && attrHeight > 0 && attrHeight < 100)
+  ) {
+    return true;
+  }
+
+  const w = img.naturalWidth || img.clientWidth || img.width;
+  const h = img.naturalHeight || img.clientHeight || img.height;
+
+  // If rendered/natural width is >= 100, it is a content figure
+  if (w >= 100) {
+    return false;
+  }
+
+  // If rendered/natural height is >= 100, it is a content figure
+  if (h >= 100) {
+    return false;
+  }
+
+  // If both rendered/natural dimensions are known and small (> 0 and < 100)
+  if (w > 0 && w < 100 && h > 0 && h < 100) {
+    return true;
+  }
+
+  // If width is known and small (> 0 and < 100)
+  if (w > 0 && w < 100) {
+    return true;
+  }
+
+  return false;
 }
 
 /**
@@ -44,10 +101,12 @@ function addFigureNumbers(locale) {
 
   // Find all images that are not logos or small icons
   const images = Array.from(articleContent.querySelectorAll("img")).filter((img) => {
-    const parentClass = img.parentElement?.className || "";
-    const isLogo = parentClass.includes("logo") || img.alt.includes("logo");
-    const isIcon = img.width < 100 || img.height < 100;
-    return !isLogo && !isIcon;
+    // Re-run captioning when lazy/slow images complete loading
+    if (!img.complete && !img.dataset.hasLoadListener) {
+      img.dataset.hasLoadListener = "true";
+      img.addEventListener("load", () => addFigureNumbers(locale), { once: true });
+    }
+    return !isIconImage(img);
   });
 
   let figureCount = 0;

--- a/src/plugins/changelog/index.js
+++ b/src/plugins/changelog/index.js
@@ -13,17 +13,18 @@ import {aliasedSitePath, docuHash, normalizeUrl} from '@docusaurus/utils';
 /**
  * Multiple versions may be published on the same day, causing the order to be
  * the reverse. Therefore, our publish time has a "fake hour" to order them.
+ *
+ * NOTE: Both sets are passed in from loadContent() so that each build pass
+ * (en, zh, …) starts with a clean slate and locale runs cannot interfere with
+ * each other's timestamps or author maps.
  */
-const publishTimes = new Set();
-/**
- * @type {Record<string, {name: string, url: string,alias: string, imageURL: string}>}
- */
-const authorsMap = {};
 
 /**
  * @param {string} section
+ * @param {Set<string>} publishTimes  per-invocation dedup set
+ * @param {Record<string, {name: string, url: string, alias: string, imageURL: string}>} authorsMap  per-invocation authors accumulator
  */
-function processSection(section) {
+function processSection(section, publishTimes, authorsMap) {
   const title = section
     .match(/\n## .*/)?.[0]
     .trim()
@@ -94,7 +95,7 @@ function processSection(section) {
   publishTimes.add(`${date}T${hour}:00`);
 
   return {
-    title: title.replace(/ \(.*\)/, ''),
+    title: title.replace(/ \(.*\)/, ""),
     content: `---
 mdx:
  format: md
@@ -138,10 +139,16 @@ export default async function ChangelogPlugin(context, options) {
     ...blogPlugin,
     name: 'changelog-plugin',
     async loadContent() {
+      // Create fresh state per loadContent() call so that sequential locale
+      // build passes (en → zh) cannot see each other's timestamps or authors.
+      const publishTimes = new Set();
+      /** @type {Record<string, {name: string, url: string, alias: string, imageURL: string}>} */
+      const authorsMap = {};
+
       const fileContent = (await fs.readFile(changelogPath, 'utf-8')).replace(/\r\n/g, '\n');
       const sections = fileContent
         .split(/(?=\n## )/)
-        .map(processSection)
+        .map((section) => processSection(section, publishTimes, authorsMap))
         .filter(Boolean);
       await Promise.all(
         sections.map((section) =>

--- a/src/plugins/changelog/index.js
+++ b/src/plugins/changelog/index.js
@@ -95,7 +95,7 @@ function processSection(section, publishTimes, authorsMap) {
   publishTimes.add(`${date}T${hour}:00`);
 
   return {
-    title: title.replace(/ \(.*\)/, ""),
+    title: title.replace(/ \(.*\)/, ''),
     content: `---
 mdx:
  format: md


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

**What this PR does / why we need it**:

This PR resolves build-time state pollution in the changelog generator plugin and client-side race conditions / anchor detachment in figure caption generation:

1. **Changelog plugin state scoping (`src/plugins/changelog/index.js`)**:
   - `publishTimes` (`Set`) and `authorsMap` (`Object`) were defined as module-level global singletons. During production multi-locale builds (`npm run build`), Docusaurus runs `loadContent()` sequentially for `en` then `zh` in the same Node process. Because `publishTimes` was never reset between locale runs, the `zh` pass detected all timestamps from `en` as existing collisions. The dedup loop (`while (publishTimes.has(...)) hour -= 1`) decremented release hours for every entry, shifting Chinese changelog dates, RSS/Atom feed timestamps, and post sorting backward relative to English.
   - **Fix**: Moved `publishTimes` and `authorsMap` instantiation inside `loadContent()` and passed them down to `processSection`. Each build pass now starts with a clean slate, ensuring deterministic and matching timestamps across all locales.

2. **Client-side figure caption race condition & anchor preservation (`src/client/imageFigureNumber.js`)**:
   - `onRouteDidUpdate` scheduled triple `setTimeout` timers (100ms, 500ms, 1000ms) and read `document.documentElement.lang` to decide between `Figure` and `图` caption prefixes. Because Docusaurus updates `<html lang="...">` asynchronously after route transitions complete, early timeout callbacks read stale `lang` values, outputting English captions on Chinese pages or vice versa. Additionally, root doc paths (`/docs` or `/zh/docs`) were missed by strict regex, and wrapping unlinked images detached `<img>` elements from parent `<a>` link tags.
   - **Fix**: Derived locale directly from `location.pathname` (checking for `/zh/`), expanded route regex to match root doc routes `/(?:^|\/)(?:blog|docs)(?:$|\/)/`, preserved parent `<a>` tags inside `<figure>` wrappers for linked images, replaced triple `setTimeout` calls with a single `requestAnimationFrame` tick, and ensured `<figcaption>` text is always updated dynamically.

**Which issue(s) this PR fixes**:

Fixes #699

**Checklist**:

- [x] `npm run lint` and `npm run format:check` pass
- [x] `npm run build` succeeds for both `en` and `zh`
- [x] Chinese translation updated if English docs changed (N/A — code bug fix)
- [x] Commits are signed off (`git commit -s`)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Figure captions now use the page’s route locale, including documentation and blog root paths.
  * Captions are generated after images finish loading, improving coverage for asynchronously loaded images.
  * Clickable images retain their links when placed inside figures.

* **Bug Fixes**
  * Icon images are more reliably excluded from automatic figure captioning.
  * Existing figures and captions now update consistently with the current figure number, locale, and alternative text.
  * Changelog generation now keeps content from separate locale builds isolated.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->