### PR TITLE
fix(events): generalize event landing page routes from data

### DIFF
--- a/src/components/EventLanding.js
+++ b/src/components/EventLanding.js
@@ -95,10 +95,7 @@ export default function EventLanding({ slug }) {
   };
 
   return (
-    <Layout
-      title={isZh ? event.title.zh : event.title.en}
-      description={isZh ? event.description.zh : event.description.en}
-    >
+    <Layout title={pick(locale, event.title)} description={pick(locale, event.description)}>
       {bannerUrl && (
         <Head>
           <meta property="og:image" content={`${siteConfig.url}${bannerUrl}`} />

--- a/src/pages/landing/kcd-vietnam.js
+++ b/src/pages/landing/kcd-vietnam.js
@@ -1,3 +1,0 @@
-import EventLanding from "@site/src/components/EventLanding";
-
-export default () => <EventLanding slug="kcd-vietnam" />;

--- a/src/pages/landing/kubecon-japan.js
+++ b/src/pages/landing/kubecon-japan.js
@@ -1,3 +1,0 @@
-import EventLanding from "@site/src/components/EventLanding";
-
-export default () => <EventLanding slug="kubecon-japan" />;

--- a/src/plugins/events/index.js
+++ b/src/plugins/events/index.js
@@ -1,4 +1,5 @@
 import ical from "node-ical";
+import landingEvents from "../../data/events";
 
 export default function pluginEvents(context, options) {
   const { sources } = options;
@@ -10,6 +11,10 @@ export default function pluginEvents(context, options) {
 
   return {
     name: "plugin-events",
+
+    getPathsToWatch() {
+      return [require.resolve("../../data/events")];
+    },
 
     async loadContent() {
       const now = new Date();
@@ -59,6 +64,19 @@ export default function pluginEvents(context, options) {
 
     async contentLoaded({ content, actions }) {
       actions.setGlobalData({ events: content });
+      const basePath = context.baseUrl.endsWith("/")
+        ? context.baseUrl.slice(0, -1)
+        : context.baseUrl;
+      for (const event of landingEvents) {
+        actions.addRoute({
+          path: `${basePath}/landing/${event.slug}`,
+          component: "@site/src/components/EventLanding.js",
+          exact: true,
+          props: {
+            slug: event.slug,
+          },
+        });
+      }
     },
   };
 }


### PR DESCRIPTION
**What type of PR is this?** 
/kind cleanup

**What this PR does / why we need it**: 
Generalizes event landing page routes by dynamically registering `/landing/${event.slug}` routes in `plugin-events` using Docusaurus `actions.addRoute` with `props: { slug: event.slug }`. Passes `slug` directly to `<EventLanding />` without relying on URL path parsing or magic. Also adds `getPathsToWatch` so additions to `src/data/events.js` trigger hot-reloading during development, and removes redundant static wrapper files under `src/pages/landing/`.

**Which issue(s) this PR fixes**: Fixes #653

**Checklist**:

- [x] `npm run lint` and `npm run format:check` pass
- [x] `npm run build` succeeds for both `en` and `zh`
- [x] Chinese translation updated if English docs changed (or noted why not) (N/A: no doc changes)
- [x] Commits are signed off (`git commit -s`)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added dynamic landing pages for configured events at `/landing/:slug`.
  * Landing page titles and descriptions now display consistently across supported languages.

* **Bug Fixes**
  * Removed outdated KubeCon Japan and KCD Vietnam landing pages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->