### PR TITLE
fix(tutorials): use static Translate ids for lab card durations

### DIFF
--- a/i18n/zh/code.json
+++ b/i18n/zh/code.json
@@ -695,17 +695,21 @@
     "message": "时长：",
     "description": "Lab duration label"
   },
-  "about 30 minutes": {
-    "message": "约 30 分钟"
+  "tutorials.lab.duration.30min": {
+    "message": "约 30 分钟",
+    "description": "Lab duration of about 30 minutes"
   },
-  "about 40 minutes": {
-    "message": "约 40 分钟"
+  "tutorials.lab.duration.40min": {
+    "message": "约 40 分钟",
+    "description": "Lab duration of about 40 minutes"
   },
-  "about 45 minutes": {
-    "message": "约 45 分钟"
+  "tutorials.lab.duration.45min": {
+    "message": "约 45 分钟",
+    "description": "Lab duration of about 45 minutes"
   },
-  "about 60 minutes": {
-    "message": "约 60 分钟"
+  "tutorials.lab.duration.60min": {
+    "message": "约 60 分钟",
+    "description": "Lab duration of about 60 minutes"
   },
   "tutorials.lab.environment": {
     "message": "环境：",

--- a/src/components/labs/LabCardGridAuto.js
+++ b/src/components/labs/LabCardGridAuto.js
@@ -9,7 +9,8 @@
  * Field sources (single source of truth each):
  *   - title, description: the lab doc itself (per-locale)
  *   - href: the resolved sidebar link (per-locale)
- *   - level, duration: the sidebar entry's `customProps` (localized at render)
+ *   - level, duration: the sidebar entry's `customProps`, mapped to translated
+ *     labels below and in LevelBadge
  *
  * `useDocsVersion().docs` intentionally omits `frontMatter`, so level/duration
  * are read from sidebar `customProps` instead of the `lab:` front matter block.
@@ -24,6 +25,32 @@ import {
 } from "@docusaurus/plugin-content-docs/client";
 import LevelBadge from "./LevelBadge";
 import styles from "./LabCardGrid.module.css";
+
+// Keyed by the English label, like LEVELS in LevelBadge. The ids have to be
+// static or `write-translations` has nothing to extract; passing the sidebar
+// value straight to <Translate> leaves the extractor with a runtime expression.
+const DURATIONS = {
+  "about 30 minutes": (
+    <Translate id="tutorials.lab.duration.30min" description="Lab duration of about 30 minutes">
+      about 30 minutes
+    </Translate>
+  ),
+  "about 40 minutes": (
+    <Translate id="tutorials.lab.duration.40min" description="Lab duration of about 40 minutes">
+      about 40 minutes
+    </Translate>
+  ),
+  "about 45 minutes": (
+    <Translate id="tutorials.lab.duration.45min" description="Lab duration of about 45 minutes">
+      about 45 minutes
+    </Translate>
+  ),
+  "about 60 minutes": (
+    <Translate id="tutorials.lab.duration.60min" description="Lab duration of about 60 minutes">
+      about 60 minutes
+    </Translate>
+  ),
+};
 
 // Match the labs category by the doc ids it contains (locale-independent),
 // not by its (possibly translated) label.
@@ -73,9 +100,7 @@ export default function LabCardGridAuto() {
           </div>
           {card.description && <p className={styles.cardDescription}>{card.description}</p>}
           {card.duration && (
-            <div className={styles.cardFooter}>
-              <Translate>{card.duration}</Translate>
-            </div>
+            <div className={styles.cardFooter}>{DURATIONS[card.duration] ?? card.duration}</div>
           )}
         </Link>
       ))}


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

**What this PR does / why we need it**:

`LabCardGridAuto` passed the sidebar duration straight to `<Translate>`, so the extractor had nothing static to work with and `write-translations` warned about it. zh only looked right because the four strings in use had been added to `i18n/zh/code.json` by hand.

This PR maps the English label to a static `<Translate id="…">`, same as `LevelBadge` does for levels, and swaps the bare keys in `code.json` for the new ids. `sidebars-tutorials.js` is untouched.

`write-translations` now runs clean and emits all four ids. Rendered output is unchanged in en and zh.

One caveat: a duration that isn't in the map still falls back to English on zh. That's a line next to four others now rather than an undocumented `code.json` edit, but nothing enforces it. A single interpolated id (`about {minutes} minutes`) would cover any value instead, at the cost of the sidebar carrying the number rather than the label. Happy to switch if you'd rather have that.

**Which issue(s) this PR fixes**:

Fixes #702

**Checklist**:

- [x] `npm run lint` and `npm run format:check` pass
- [x] `npm run build` succeeds for both `en` and `zh`
- [x] Chinese translation updated if English docs changed (or noted why not)
- [x] Commits are signed off (`git commit -s`)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected duration labels displayed on lab cards when filtering by sidebar options.
  * Added reliable translations for 30-, 40-, 45-, and 60-minute lab durations, including Chinese localization.
  * Preserved the displayed duration value when no translation is available.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->