### PR TITLE
Add recap for HAMi at KubeCon + CloudNativeCon Japan 2026 and update community flyer

### DIFF
--- a/blog/kubecon-japan-2026-recap/index.md
+++ b/blog/kubecon-japan-2026-recap/index.md
@@ -16,7 +16,7 @@ For the full overview, talk slides, and the SNOW case study, see the [KubeCon Ja
 
 ![HAMi appeared in the keynote slides of Chris Aniszczyk and Jonathan Bryce at KubeCon Japan 2026](/img/kubecon-japan-2026-recap/keynote.jpg)
 
-HAMi was featured in the opening keynote, appearing in the slides of CNCF CTO Chris Aniszczyk and CNCF Executive Director Jonathan Bryce.
+HAMi was featured in the opening keynote, appearing in the slides of CNCF CTO Chris Aniszczyk and Jonathan Bryce, Executive Director, Cloud and Infrastructure, The Linux Foundation.
 
 ## On Stage: Shared GPU Scheduling + Proactive Autoscaling
 

--- a/blog/kubecon-japan-2026-recap/index.md
+++ b/blog/kubecon-japan-2026-recap/index.md
@@ -6,7 +6,7 @@ tags: ["KubeCon", "GPU", "Kubernetes", "AI", "Japan"]
 authors: [hami_community]
 ---
 
-[KubeCon + CloudNativeCon Japan 2026](https://events.linuxfoundation.org/kubecon-cloudnativecon-japan/) was held July 28-30 at the Pacifico Yokohama. HAMi took part with a main-stage session and a booth in the Project Pavilion. [Reza Jelveh](https://github.com/fishman) presented the session and staffed the booth.
+[KubeCon + CloudNativeCon Japan 2026](https://events.linuxfoundation.org/kubecon-cloudnativecon-japan/) was held July 28-30 at Pacifico Yokohama. HAMi took part with a main-stage session and a booth in the Project Pavilion. [Reza Jelveh](https://github.com/fishman) presented the session and staffed the booth.
 
 For the full overview, talk slides, and the SNOW case study, see the [KubeCon Japan 2026 page](/landing/kubecon-japan).
 
@@ -26,8 +26,6 @@ The session [**Shared GPU Scheduling & Proactive Autoscaling: A Production Bluep
 
 The session described how SNOW serves Snow, Epik, and B612, three widely used AI applications reaching more than 200 million users, on over 1000 NVIDIA A100 GPUs. The architecture combines HAMi for GPU sharing with KEDA for proactive autoscaling, halving the GPUs required for the same traffic and improving recovery under load.
 
-The complete metrics, the SNOW case study, and the [talk slides](/resources/2026-kubecon-japan/snow_corp_cncf.pdf) are available on the [KubeCon Japan page](/landing/kubecon-japan).
-
 ## At the Booth
 
 ![The HAMi booth at the KubeCon Japan 2026 Project Pavilion](/img/kubecon-japan-2026-recap/hami-booth.jpg)
@@ -40,4 +38,4 @@ At the HAMi booth in the Project Pavilion, engineers stopped by with questions i
 
 ## Learn More
 
-The talk, case study, slides, and ways to get involved are collected on the [KubeCon Japan 2026 page](/landing/kubecon-japan). To join the discussion, visit the [HAMi community](/community/).
+The talk, SNOW case study, complete metrics, slides, and ways to get involved are available on the [KubeCon Japan 2026 page](/landing/kubecon-japan). To join the discussion, visit the [HAMi community](/community).

--- a/blog/kubecon-japan-2026-recap/index.md
+++ b/blog/kubecon-japan-2026-recap/index.md
@@ -1,0 +1,43 @@
+---
+title: "HAMi at KubeCon + CloudNativeCon Japan 2026"
+date: "2026-08-01"
+description: "A recap of HAMi's presence at KubeCon + CloudNativeCon Japan 2026 in Yokohama, including a main-stage session on the SNOW 1000-GPU production blueprint and the HAMi booth."
+tags: ["KubeCon", "GPU", "Kubernetes", "AI", "Japan"]
+authors: [hami_community]
+---
+
+[KubeCon + CloudNativeCon Japan 2026](https://events.linuxfoundation.org/kubecon-cloudnativecon-japan/) was held July 28-30 at the Pacifico Yokohama. HAMi took part with a main-stage session and a booth in the Project Pavilion. [Reza Jelveh](https://github.com/fishman) presented the session and staffed the booth.
+
+For the full overview, talk slides, and the SNOW case study, see the [KubeCon Japan 2026 page](/landing/kubecon-japan).
+
+<!-- truncate -->
+
+## HAMi in the Keynote
+
+![HAMi appeared in the keynote slides of Chris Aniszczyk and Jonathan Bryce at KubeCon Japan 2026](/img/kubecon-japan-2026-recap/keynote.jpg)
+
+HAMi was featured in the opening keynote, appearing in the slides of CNCF CTO Chris Aniszczyk and CNCF Executive Director Jonathan Bryce.
+
+## On Stage: Shared GPU Scheduling + Proactive Autoscaling
+
+![Reza Jelveh (Dynamia) and Jeonghyun Kim (SNOW) presenting at KubeCon Japan 2026](/img/kubecon-japan-2026-recap/reza-snow.jpg)
+
+The session [**Shared GPU Scheduling & Proactive Autoscaling: A Production Blueprint for 1000+ GPUs**](https://events.linuxfoundation.org/kubecon-cloudnativecon-japan/program/schedule/?id=1182713) was presented by Jeonghyun Kim (AI Engineer at SNOW) and Reza Jelveh.
+
+The session described how SNOW serves Snow, Epik, and B612, three widely used AI applications reaching more than 200 million users, on over 1000 NVIDIA A100 GPUs. The architecture combines HAMi for GPU sharing with KEDA for proactive autoscaling, halving the GPUs required for the same traffic and improving recovery under load.
+
+The complete metrics, the SNOW case study, and the [talk slides](/resources/2026-kubecon-japan/snow_corp_cncf.pdf) are available on the [KubeCon Japan page](/landing/kubecon-japan).
+
+## At the Booth
+
+![The HAMi booth at the KubeCon Japan 2026 Project Pavilion](/img/kubecon-japan-2026-recap/hami-booth.jpg)
+
+At the HAMi booth in the Project Pavilion, engineers stopped by with questions including:
+
+- How to introduce HAMi into an existing cluster
+- How HAMi interoperates with **Volcano**, **Kueue**, and the **NVIDIA KAI Scheduler**
+- Practical GPU scheduling problems: memory fragmentation, idle GPUs behind batch jobs, and inference workloads unable to obtain a predictable GPU slice
+
+## Learn More
+
+The talk, case study, slides, and ways to get involved are collected on the [KubeCon Japan 2026 page](/landing/kubecon-japan). To join the discussion, visit the [HAMi community](/community/).

--- a/i18n/zh/docusaurus-plugin-content-blog/kubecon-japan-2026-recap/index.md
+++ b/i18n/zh/docusaurus-plugin-content-blog/kubecon-japan-2026-recap/index.md
@@ -1,0 +1,43 @@
+---
+title: "HAMi 亮相 KubeCon + CloudNativeCon 日本 2026"
+date: "2026-08-01"
+description: "回顾 HAMi 在横滨 KubeCon + CloudNativeCon 日本 2026 的亮相：一场关于 SNOW 千卡生产蓝图的主舞台分享，以及 HAMi 展台。"
+tags: ["KubeCon", "GPU", "Kubernetes", "AI", "Japan"]
+authors: [hami_community]
+---
+
+[KubeCon + CloudNativeCon 日本 2026](https://events.linuxfoundation.org/kubecon-cloudnativecon-japan/) 于 7 月 28 至 30 日在 Pacifico Yokohama 举办。HAMi 以一场主舞台分享和 Project Pavilion 的展台参与本届大会。[Reza Jelveh](https://github.com/fishman) 登台分享，并在展台值守。
+
+完整的回顾、演讲幻灯片与 SNOW 案例，请见 [KubeCon 日本 2026 专页](/zh/landing/kubecon-japan)。
+
+<!-- truncate -->
+
+## Keynote 中的 HAMi
+
+![HAMi 出现在 Chris Aniszczyk 与 Jonathan Bryce 在 KubeCon 日本 2026 的 Keynote 幻灯片中](/img/kubecon-japan-2026-recap/keynote.jpg)
+
+HAMi 出现在开场 Keynote 中，CNCF 首席技术官 Chris Aniszczyk 与 CNCF 执行董事 Jonathan Bryce 的幻灯片对其进行了介绍。
+
+## 主舞台：共享 GPU 调度与主动自动伸缩
+
+![Reza Jelveh（密瓜智能）与 Jeonghyun Kim（SNOW）在 KubeCon 日本 2026 的分享](/img/kubecon-japan-2026-recap/reza-snow.jpg)
+
+[**Shared GPU Scheduling & Proactive Autoscaling: A Production Blueprint for 1000+ GPUs**](https://events.linuxfoundation.org/kubecon-cloudnativecon-japan/program/schedule/?id=1182713) 这场分享，由 Jeonghyun Kim（SNOW AI 工程师）与 Reza Jelveh 共同呈现。
+
+该分享介绍了 SNOW 如何以超过 1000 张 NVIDIA A100 GPU，服务 Snow、Epik、B612 三款覆盖超过 2 亿用户的 AI 应用。其架构以 HAMi 完成 GPU 共享，以 KEDA 实现主动式扩容，在相同流量下将 GPU 需求减半，并提升了负载波动下的恢复能力。
+
+完整的指标、SNOW 案例与[演讲幻灯片](/resources/2026-kubecon-japan/snow_corp_cncf.pdf) 均可在 [KubeCon 日本专页](/zh/landing/kubecon-japan) 查看。
+
+## 展台
+
+![KubeCon 日本 2026 Project Pavilion 的 HAMi 展台](/img/kubecon-japan-2026-recap/hami-booth.jpg)
+
+在 Project Pavilion 的 HAMi 展台，前来交流的工程师主要关注以下问题：
+
+- 如何将 HAMi 引入现有集群
+- HAMi 与 **Volcano**、**Kueue**、**NVIDIA KAI Scheduler** 如何协同
+- 实际的 GPU 调度难题：显存碎片化、批处理任务导致的 GPU 闲置，以及推理工作负载难以获得稳定的 GPU 切片
+
+## 进一步了解
+
+本次活动的演讲、案例、幻灯片与参与方式，已汇总于 [KubeCon 日本 2026 专页](/zh/landing/kubecon-japan)。如需参与讨论，欢迎加入 [HAMi 社区](/zh/community/)。

--- a/i18n/zh/docusaurus-plugin-content-blog/kubecon-japan-2026-recap/index.md
+++ b/i18n/zh/docusaurus-plugin-content-blog/kubecon-japan-2026-recap/index.md
@@ -26,8 +26,6 @@ HAMi 出现在开场 Keynote 中，CNCF 首席技术官 Chris Aniszczyk 与 Linu
 
 该分享介绍了 SNOW 如何以超过 1000 张 NVIDIA A100 GPU，服务 Snow、Epik、B612 三款覆盖超过 2 亿用户的 AI 应用。其架构以 HAMi 完成 GPU 共享，以 KEDA 实现主动式扩容，在相同流量下将 GPU 需求减半，并提升了负载波动下的恢复能力。
 
-完整的指标、SNOW 案例与[演讲幻灯片](/resources/2026-kubecon-japan/snow_corp_cncf.pdf) 均可在 [KubeCon 日本专页](/zh/landing/kubecon-japan) 查看。
-
 ## 展台
 
 ![KubeCon 日本 2026 Project Pavilion 的 HAMi 展台](/img/kubecon-japan-2026-recap/hami-booth.jpg)
@@ -40,4 +38,4 @@ HAMi 出现在开场 Keynote 中，CNCF 首席技术官 Chris Aniszczyk 与 Linu
 
 ## 进一步了解
 
-本次活动的演讲、案例、幻灯片与参与方式，已汇总于 [KubeCon 日本 2026 专页](/zh/landing/kubecon-japan)。如需参与讨论，欢迎加入 [HAMi 社区](/zh/community/)。
+本次活动的演讲、SNOW 案例、完整指标、幻灯片与参与方式，均可在 [KubeCon 日本 2026 专页](/zh/landing/kubecon-japan) 查看。如需参与讨论，欢迎加入 [HAMi 社区](/zh/community)。

--- a/i18n/zh/docusaurus-plugin-content-blog/kubecon-japan-2026-recap/index.md
+++ b/i18n/zh/docusaurus-plugin-content-blog/kubecon-japan-2026-recap/index.md
@@ -16,7 +16,7 @@ authors: [hami_community]
 
 ![HAMi 出现在 Chris Aniszczyk 与 Jonathan Bryce 在 KubeCon 日本 2026 的 Keynote 幻灯片中](/img/kubecon-japan-2026-recap/keynote.jpg)
 
-HAMi 出现在开场 Keynote 中，CNCF 首席技术官 Chris Aniszczyk 与 CNCF 执行董事 Jonathan Bryce 的幻灯片对其进行了介绍。
+HAMi 出现在开场 Keynote 中，CNCF 首席技术官 Chris Aniszczyk 与 Linux 基金会云与基础设施执行董事 Jonathan Bryce 的幻灯片对其进行了介绍。
 
 ## 主舞台：共享 GPU 调度与主动自动伸缩
 

--- a/i18n/zh/docusaurus-plugin-content-blog/tags.yml
+++ b/i18n/zh/docusaurus-plugin-content-blog/tags.yml
@@ -55,6 +55,9 @@
 "India":
   label: "India"
   permalink: "/india"
+"Japan":
+  label: "Japan"
+  permalink: "/japan"
 "KAI Scheduler":
   label: "KAI Scheduler"
   permalink: "/kai-scheduler"

--- a/static/img/kubecon-japan-2026-recap/hami-booth.jpg
+++ b/static/img/kubecon-japan-2026-recap/hami-booth.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:3a67adc41333236d3bdbcec7e697401423029c7867292ac4280e744ce01811ee
+size 220698

--- a/static/img/kubecon-japan-2026-recap/keynote.jpg
+++ b/static/img/kubecon-japan-2026-recap/keynote.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:6c907baac39c7721e6d75cafd7c3d2eb8d7cd68f190b9c40c3f15d1822bab406
+size 147227

--- a/static/img/kubecon-japan-2026-recap/reza-snow.jpg
+++ b/static/img/kubecon-japan-2026-recap/reza-snow.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:3ade34f13fb3b89b0a3c7283eb164b06cd177930235608412cc0500fa2118ea2
+size 297238

--- a/static/resources/flyers/community-flyer.pdf
+++ b/static/resources/flyers/community-flyer.pdf
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:664dbc6f176ead6fa3a62fef8f5bd0b7cc8099b844b26e9a255658659f4a5251
-size 1154356
+oid sha256:11c3fefb26c13362f12fc07e872c1a00816928aa1a0e3a33cd6ee9114a241b36
+size 755034


### PR DESCRIPTION
Introduce a recap of HAMi's participation at KubeCon + CloudNativeCon Japan 2026, including key sessions and booth interactions. Update the community flyer PDF with a new version and reduced size.

cc/ @fishman 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Documentation

* Added English and Chinese blog posts recapping HAMi’s participation in KubeCon + CloudNativeCon Japan 2026.
* Highlighted keynote coverage, SNOW’s production GPU sharing and autoscaling architecture, Project Pavilion discussions, and related event resources.
* Included links to the event page, presentation slides, case study, and community resources.
* Added a Japan tag to improve discovery and navigation of related blog content.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->