### PR TITLE
docs: improve in-container resource control wording

### DIFF
--- a/docs/core-concepts/architecture.md
+++ b/docs/core-concepts/architecture.md
@@ -11,7 +11,7 @@ HAMi consists of the following components:
 - HAMi MutatingWebhook
 - HAMi scheduler-extender
 - Device-plugin (HAMi-device-plugin)
-- In container resource control (HAMi-Core)
+- In-container resource control (HAMi-Core)
 
 ## HAMi MutatingWebhook {#hami-mutatingwebhook}
 
@@ -27,4 +27,4 @@ The device-plugin layer obtains the scheduling result from the annotations field
 
 ## HAMi-Core {#hami-core}
 
-The In container resource control is responsible for monitoring the resource usage within the container and providing hard isolation capabilities.
+The in-container resource control is responsible for monitoring the resource usage within the container and providing hard isolation capabilities.

--- a/versioned_docs/version-v2.9.0/core-concepts/architecture.md
+++ b/versioned_docs/version-v2.9.0/core-concepts/architecture.md
@@ -11,7 +11,7 @@ HAMi consists of the following components:
 - HAMi MutatingWebhook
 - HAMi scheduler-extender
 - Device-plugin (HAMi-device-plugin)
-- In container resource control (HAMi-Core)
+- In-container resource control (HAMi-Core)
 
 ## HAMi MutatingWebhook {#hami-mutatingwebhook}
 
@@ -27,4 +27,4 @@ The device-plugin layer obtains the scheduling result from the annotations field
 
 ## HAMi-Core {#hami-core}
 
-The In container resource control is responsible for monitoring the resource usage within the container and providing hard isolation capabilities.
+The in-container resource control is responsible for monitoring the resource usage within the container and providing hard isolation capabilities.


### PR DESCRIPTION
## Description

This PR improves the wording of the in-container resource control documentation.

### Changes

* Changed **“In container resource control”** to **“in-container resource control”** for grammatical clarity.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **Documentation**
  * Clarified architecture terminology by standardizing “In-container” wording and resource-control component capitalization across current and versioned documentation.

issue: `#711`
<!-- end of auto-generated comment: release notes by coderabbit.ai -->