### PR TITLE
fix: patch brace-expansion, fast-uri, and postcss CVEs disclosed 2026-08-03

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -34,7 +34,7 @@
         "swc-loader": "^0.2.7"
       },
       "engines": {
-        "node": ">=20.18.1"
+        "node": ">=20.19.0"
       }
     },
     "node_modules/@11ty/gray-matter": {
@@ -7955,9 +7955,9 @@
       }
     },
     "node_modules/brace-expansion": {
-      "version": "5.0.8",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.8.tgz",
-      "integrity": "sha512-JZyDyq3D4AUifKTPOB7DELf6XsB3WdPuNxCtob1vFXPsSXhdAiHBWJ/tJ8HAc9aH84BK+5JFZLNkJKx3G9kzQg==",
+      "version": "5.0.9",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.9.tgz",
+      "integrity": "sha512-ScQ4IuvIEF1TMlP7Zt+vjJ//9zlPb2SDcxWxM3bk8s6t6GGdJ7KO1dCcTidOPJKePW30LE/2cT7wCyPho9/Wxg==",
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^4.0.2"
@@ -10801,9 +10801,9 @@
       "license": "MIT"
     },
     "node_modules/fast-uri": {
-      "version": "3.1.4",
-      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.4.tgz",
-      "integrity": "sha512-8JnbkQ4juDyvYs4mgFGQqg4yCYtFDtUtmp2QIQq11ZZe5CFQ5wcqm1rqDgAh/QdMySuBnPzMUiJUNZG5N/AiQw==",
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.5.tgz",
+      "integrity": "sha512-gHwA1O9LDIcKunMKhObS/HimwtehO1nPUECKAu5TpKgaO19fcWEl4bliWe1jWxVFvIXztJjjQ4L8XQ1EU9f7Jw==",
       "funding": [
         {
           "type": "github",
@@ -16736,9 +16736,9 @@
       }
     },
     "node_modules/postcss": {
-      "version": "8.5.19",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.19.tgz",
-      "integrity": "sha512-Mz8SaolMd8nB+G13WkORcxQKHZ/NE4xXevtkJHVuG+guo9/wYKlIMTKAqGdEmYOXR2ijPjTYNHssizdaVSUNdQ==",
+      "version": "8.5.25",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.25.tgz",
+      "integrity": "sha512-DTPx3RWSSnWyzLxQnlH0rJP+EW5ekl16ZU4/psbIhA0e53kJfdgaN5vKM+xP7yJtXVu+nfdVFmlgFDEKAe4Pyw==",
       "funding": [
         {
           "type": "opencollective",
@@ -16755,7 +16755,7 @@
       ],
       "license": "MIT",
       "dependencies": {
-        "nanoid": "^3.3.12",
+        "nanoid": "^3.3.16",
         "picocolors": "^1.1.1",
         "source-map-js": "^1.2.1"
       },

--- a/package.json
+++ b/package.json
@@ -84,6 +84,8 @@
     "sockjs": {
       "uuid": "11.1.1"
     },
-    "brace-expansion": "5.0.8"
+    "brace-expansion": "5.0.9",
+    "fast-uri": "3.1.5",
+    "postcss": "8.5.25"
   }
 }


### PR DESCRIPTION
/kind bug

Three new advisories were published on 2026-08-03 against dependencies already pinned in the lockfile:

- **brace-expansion** (CVE-2026-69152, GHSA-rgw5-rvv9-x895): DoS via unbounded intermediate arrays. This bypasses the CVE-2026-14257 mitigation that the existing `5.0.8` override was pinned to. Affected `< 5.0.9`.
- **fast-uri** (CVE-2026-18446): host confusion via a backslash authority introducer lets an attacker bypass host allowlist / SSRF checks that rely on fast-uri's parsing. Affected `3.0.0 - <3.1.5`; pulled in transitively via `ajv`.
- **postcss** (GHSA-fxqj-rqcc-2cmp): an incomplete fix of GHSA-6g55-p6wh-862q. `PreviousMap.loadFile()` can still be made to read an arbitrary source-map file when `from` is unset. Affected `<=8.5.22`.

Fix: bump the existing `brace-expansion` override to the patched `5.0.9`, and add `fast-uri` and `postcss` overrides pinned to their patched versions, following the same pattern already used for `brace-expansion`, `markdownlint-cli`, etc.