### PR TITLE
fix(edge): nested lists and attribute > leaks in markdown negotiation

### DIFF
--- a/netlify/edge-functions/markdown-negotiation.js
+++ b/netlify/edge-functions/markdown-negotiation.js
@@ -314,11 +314,13 @@ function toMarkdownTable(tableHtml) {
 }
 
 function htmlToMarkdown(html, pageUrl) {
-  const rawTitle = html.match(/<title[^>]*>([\s\S]*?)<\/title>/i)?.[1] ?? "";
-  const rawDescription =
-    html.match(/<meta[^>]+name=["']description["'][^>]+content=["']([^"']*)["'][^>]*>/i)?.[1] ?? "";
+  html = protectQuotedAngles(html);
+  const rawTitle = restoreQuotedAngles(html.match(/<title[^>]*>([\s\S]*?)<\/title>/i)?.[1] ?? "");
+  const rawDescription = restoreQuotedAngles(
+    html.match(/<meta[^>]+name=["']description["'][^>]+content=["']([^"']*)["'][^>]*>/i)?.[1] ?? "",
+  );
 
-  let content = protectQuotedAngles(html.match(/<main[^>]*>([\s\S]*?)<\/main>/i)?.[1] ?? html);
+  let content = html.match(/<main[^>]*>([\s\S]*?)<\/main>/i)?.[1] ?? html;
 
   content = content
     .replace(/<script[\s\S]*?<\/script>/gi, "")

--- a/netlify/edge-functions/markdown-negotiation.js
+++ b/netlify/edge-functions/markdown-negotiation.js
@@ -83,6 +83,53 @@ function createBlockStore() {
   };
 }
 
+// Same idea as the block-store marker: hide `>` inside quoted attrs so `[^>]*`
+// tag scans don't stop early.
+const ATTR_GT = "\u0001";
+
+function findTagClose(html, openIndex) {
+  let quote = null;
+  for (let i = openIndex + 1; i < html.length; i++) {
+    const c = html[i];
+    if (quote) {
+      if (c === quote) {
+        quote = null;
+      }
+      continue;
+    }
+    if (c === '"' || c === "'") {
+      quote = c;
+    } else if (c === ">") {
+      return i;
+    }
+  }
+  return -1;
+}
+
+function protectQuotedAngles(html) {
+  let result = "";
+  let cursor = 0;
+  for (let i = 0; i < html.length; i++) {
+    if (html[i] !== "<") {
+      continue;
+    }
+    const close = findTagClose(html, i);
+    if (close === -1) {
+      break;
+    }
+    result += html.slice(cursor, i);
+    result += html.slice(i, close).replace(/>/g, ATTR_GT);
+    result += ">";
+    cursor = close + 1;
+    i = close;
+  }
+  return result + html.slice(cursor);
+}
+
+function restoreQuotedAngles(text) {
+  return text.includes(ATTR_GT) ? text.replace(/\u0001/g, ">") : text;
+}
+
 // Depth-tracked because the TOC containers nest divs, so the first closing tag
 // isn't the matching one.
 function dropElements(html, tagName, classPattern) {
@@ -108,6 +155,105 @@ function dropElements(html, tagName, classPattern) {
     result += html.slice(cursor, match.index);
     cursor = end;
     tag.lastIndex = end;
+  }
+
+  return result + html.slice(cursor);
+}
+
+function findListClose(html, innerStart) {
+  const token = /<\/?(?:ul|ol)\b[^>]*>/gi;
+  token.lastIndex = innerStart;
+  let depth = 1;
+  let match;
+  while ((match = token.exec(html))) {
+    depth += match[0].startsWith("</") ? -1 : 1;
+    if (depth === 0) {
+      return { innerEnd: match.index, after: match.index + match[0].length };
+    }
+  }
+  return null;
+}
+
+function extractDirectLis(inner) {
+  const items = [];
+  const token = /<\/?(?:ul|ol|li)\b[^>]*>/gi;
+  let listDepth = 0;
+  let liStart = null;
+  let match;
+
+  while ((match = token.exec(inner))) {
+    const isClose = match[0].startsWith("</");
+    const tag = match[0].match(/<\/?([a-z]+)/i)[1].toLowerCase();
+
+    if (tag === "ul" || tag === "ol") {
+      listDepth += isClose ? -1 : 1;
+      continue;
+    }
+    if (listDepth !== 0) {
+      continue;
+    }
+    if (!isClose) {
+      if (liStart === null) {
+        liStart = match.index + match[0].length;
+      }
+      continue;
+    }
+    if (liStart !== null) {
+      items.push(inner.slice(liStart, match.index));
+      liStart = null;
+    }
+  }
+
+  return items;
+}
+
+function formatListItem(marker, content) {
+  const lines = content
+    .replace(/^\n+/, "")
+    .replace(/\n+$/, "")
+    .split("\n")
+    .filter((line) => line.trim() !== "");
+  if (lines.length === 0) {
+    return `\n${marker.trimEnd()}`;
+  }
+  const indent = " ".repeat(marker.length);
+  let out = `\n${marker}${lines[0].trimStart()}`;
+  for (let i = 1; i < lines.length; i++) {
+    out += `\n${indent}${lines[i].trimStart()}`;
+  }
+  return out;
+}
+
+function renderList(inner, ordered) {
+  const items = extractDirectLis(inner);
+  if (items.length === 0) {
+    return "";
+  }
+  return items
+    .map((item, index) => {
+      const marker = ordered ? `${index + 1}. ` : `- `;
+      return formatListItem(marker, convertLists(item));
+    })
+    .join("");
+}
+
+function convertLists(html) {
+  const open = /<(ul|ol)\b[^>]*>/gi;
+  let result = "";
+  let cursor = 0;
+  let match;
+
+  while ((match = open.exec(html))) {
+    result += html.slice(cursor, match.index);
+    const ordered = match[1].toLowerCase() === "ol";
+    const closed = findListClose(html, match.index + match[0].length);
+    if (!closed) {
+      result += html.slice(match.index);
+      return result;
+    }
+    result += renderList(html.slice(match.index + match[0].length, closed.innerEnd), ordered);
+    cursor = closed.after;
+    open.lastIndex = closed.after;
   }
 
   return result + html.slice(cursor);
@@ -172,7 +318,7 @@ function htmlToMarkdown(html, pageUrl) {
   const rawDescription =
     html.match(/<meta[^>]+name=["']description["'][^>]+content=["']([^"']*)["'][^>]*>/i)?.[1] ?? "";
 
-  let content = html.match(/<main[^>]*>([\s\S]*?)<\/main>/i)?.[1] ?? html;
+  let content = protectQuotedAngles(html.match(/<main[^>]*>([\s\S]*?)<\/main>/i)?.[1] ?? html);
 
   content = content
     .replace(/<script[\s\S]*?<\/script>/gi, "")
@@ -202,11 +348,6 @@ function htmlToMarkdown(html, pageUrl) {
       /<h([1-6])\b[^>]*>([\s\S]*?)<\/h\1>/gi,
       (match, level, text) => `\n\n${"#".repeat(Number(level))} ${text}\n\n`,
     )
-    .replace(/<ol\b[^>]*>([\s\S]*?)<\/ol>/gi, (match, items) => {
-      let index = 0;
-      return items.replace(/<li\b[^>]*>([\s\S]*?)<\/li>/gi, (_, item) => `\n${++index}. ${item}`);
-    })
-    .replace(/<li\b[^>]*>([\s\S]*?)<\/li>/gi, "\n- $1")
     .replace(/<p\b[^>]*>([\s\S]*?)<\/p>/gi, "\n\n$1\n\n")
     .replace(/<br\s*\/?>/gi, "\n")
     .replace(/<img\b[^>]*>/gi, (tag) => {
@@ -214,8 +355,10 @@ function htmlToMarkdown(html, pageUrl) {
       const alt = tag.match(/\balt="([^"]*)"/i)?.[1] ?? "";
       return src ? `![${alt}](${src})` : alt;
     });
+  markdown = convertLists(markdown);
 
-  markdown = normalizeWhitespace(inlineToMarkdown(markdown).replace(/[ \t]{2,}/g, " "));
+  // Keep leading indent so nested list markers aren't collapsed.
+  markdown = normalizeWhitespace(inlineToMarkdown(markdown).replace(/(\S)[ \t]{2,}/g, "$1 "));
 
   const title =
     normalizeWhitespace(rawTitle)
@@ -247,7 +390,7 @@ function htmlToMarkdown(html, pageUrl) {
   header.push("", `Source: ${pageUrl}`);
 
   // Restore last, so the stashed blocks aren't re-normalized.
-  return `${store.restore(`${header.join("\n")}\n\n${markdown}`)}\n`;
+  return restoreQuotedAngles(`${store.restore(`${header.join("\n")}\n\n${markdown}`)}\n`);
 }
 
 function estimateTokens(markdown) {

--- a/netlify/edge-functions/markdown-negotiation.js
+++ b/netlify/edge-functions/markdown-negotiation.js
@@ -83,9 +83,8 @@ function createBlockStore() {
   };
 }
 
-// Same idea as the block-store marker: hide `>` inside quoted attrs so `[^>]*`
-// tag scans don't stop early.
-const ATTR_GT = "\u0001";
+// Hide `>` inside quoted attrs so `[^>]*` tag scans don't stop early.
+const ATTR_GT = "\uE000ATTRGT\uE000";
 
 function findTagClose(html, openIndex) {
   let quote = null;
@@ -113,12 +112,17 @@ function protectQuotedAngles(html) {
     if (html[i] !== "<") {
       continue;
     }
+    // Skip stray `<` in text (`a < b`).
+    const next = html[i + 1];
+    if (!next || !/[a-zA-Z/!?]/.test(next)) {
+      continue;
+    }
     const close = findTagClose(html, i);
     if (close === -1) {
       break;
     }
     result += html.slice(cursor, i);
-    result += html.slice(i, close).replace(/>/g, ATTR_GT);
+    result += html.slice(i, close).split(">").join(ATTR_GT);
     result += ">";
     cursor = close + 1;
     i = close;
@@ -127,7 +131,7 @@ function protectQuotedAngles(html) {
 }
 
 function restoreQuotedAngles(text) {
-  return text.includes(ATTR_GT) ? text.replace(/\u0001/g, ">") : text;
+  return text.includes(ATTR_GT) ? text.split(ATTR_GT).join(">") : text;
 }
 
 // Depth-tracked because the TOC containers nest divs, so the first closing tag
@@ -219,19 +223,19 @@ function formatListItem(marker, content) {
   const indent = " ".repeat(marker.length);
   let out = `\n${marker}${lines[0].trimStart()}`;
   for (let i = 1; i < lines.length; i++) {
-    out += `\n${indent}${lines[i].trimStart()}`;
+    out += `\n${indent}${lines[i]}`;
   }
   return out;
 }
 
-function renderList(inner, ordered) {
+function renderList(inner, ordered, start = 1) {
   const items = extractDirectLis(inner);
   if (items.length === 0) {
     return "";
   }
   return items
     .map((item, index) => {
-      const marker = ordered ? `${index + 1}. ` : `- `;
+      const marker = ordered ? `${start + index}. ` : `- `;
       return formatListItem(marker, convertLists(item));
     })
     .join("");
@@ -246,12 +250,18 @@ function convertLists(html) {
   while ((match = open.exec(html))) {
     result += html.slice(cursor, match.index);
     const ordered = match[1].toLowerCase() === "ol";
+    const startAttr = ordered ? match[0].match(/\bstart\s*=\s*["']?(-?\d+)/i)?.[1] : null;
+    const start = startAttr == null ? 1 : Number.parseInt(startAttr, 10);
     const closed = findListClose(html, match.index + match[0].length);
     if (!closed) {
       result += html.slice(match.index);
       return result;
     }
-    result += renderList(html.slice(match.index + match[0].length, closed.innerEnd), ordered);
+    result += renderList(
+      html.slice(match.index + match[0].length, closed.innerEnd),
+      ordered,
+      Number.isFinite(start) ? start : 1,
+    );
     cursor = closed.after;
     open.lastIndex = closed.after;
   }
@@ -314,11 +324,13 @@ function toMarkdownTable(tableHtml) {
 }
 
 function htmlToMarkdown(html, pageUrl) {
-  const rawTitle = html.match(/<title[^>]*>([\s\S]*?)<\/title>/i)?.[1] ?? "";
-  const rawDescription =
-    html.match(/<meta[^>]+name=["']description["'][^>]+content=["']([^"']*)["'][^>]*>/i)?.[1] ?? "";
+  html = protectQuotedAngles(html);
+  const rawTitle = restoreQuotedAngles(html.match(/<title[^>]*>([\s\S]*?)<\/title>/i)?.[1] ?? "");
+  const rawDescription = restoreQuotedAngles(
+    html.match(/<meta[^>]+name=["']description["'][^>]+content=["']([^"']*)["'][^>]*>/i)?.[1] ?? "",
+  );
 
-  let content = protectQuotedAngles(html.match(/<main[^>]*>([\s\S]*?)<\/main>/i)?.[1] ?? html);
+  let content = html.match(/<main[^>]*>([\s\S]*?)<\/main>/i)?.[1] ?? html;
 
   content = content
     .replace(/<script[\s\S]*?<\/script>/gi, "")

--- a/test/markdown-negotiation.test.mjs
+++ b/test/markdown-negotiation.test.mjs
@@ -257,6 +257,41 @@ describe("block structure", () => {
     );
   });
 
+  // Regression for #688.
+  it("keeps nested lists nested", async () => {
+    assert.equal(
+      await body(
+        "<main><ol><li>Outer step one<ul><li>sub A</li><li>sub B</li></ul></li>" +
+          "<li>Outer step two</li></ol></main>",
+      ),
+      "1. Outer step one\n   - sub A\n   - sub B\n2. Outer step two",
+    );
+  });
+
+  it("keeps nested lists nested when items wrap content in <p>", async () => {
+    assert.equal(
+      await body(
+        "<main><ol><li><p>Install deps</p><ul><li>Node 20</li><li>npm ci</li></ul></li>" +
+          "<li><p>Build the site</p></li></ol></main>",
+      ),
+      "1. Install deps\n   - Node 20\n   - npm ci\n2. Build the site",
+    );
+  });
+
+  it("keeps nested ordered lists nested", async () => {
+    assert.equal(
+      await body("<main><ol><li>A<ol><li>A1</li><li>A2</li></ol></li><li>B</li></ol></main>"),
+      "1. A\n   1. A1\n   2. A2\n2. B",
+    );
+  });
+
+  it("indents nested unordered lists under unordered parents", async () => {
+    assert.equal(
+      await body("<main><ul><li>A<ul><li>A1</li></ul></li><li>B</li></ul></main>"),
+      "- A\n  - A1\n- B",
+    );
+  });
+
   it("converts line breaks", async () => {
     assert.equal(await body("<main><p>one<br>two</p></main>"), "one\ntwo");
   });
@@ -301,6 +336,19 @@ describe("inline formatting", () => {
       ),
       "[Read `values.yaml`](/a)",
     );
+  });
+
+  // Regression for #688.
+  it("does not leak when a quoted attribute value contains `>`", async () => {
+    assert.equal(await body('<main><p><span title="a > b">Hello</span></p></main>'), "Hello");
+    assert.equal(
+      await body('<main><p><a href="/x" title="see > docs">link text</a></p></main>'),
+      "[link text](/x)",
+    );
+  });
+
+  it("still strips tags when the `>` in an attribute is entity-encoded", async () => {
+    assert.equal(await body('<main><p><span title="a &gt; b">Hello</span></p></main>'), "Hello");
   });
 });
 

--- a/test/markdown-negotiation.test.mjs
+++ b/test/markdown-negotiation.test.mjs
@@ -347,6 +347,10 @@ describe("inline formatting", () => {
     );
   });
 
+  it("still finds <main> when a quoted attribute on it contains `>`", async () => {
+    assert.equal(await body('<main data-label="a > b"><p>inside</p></main>'), "inside");
+  });
+
   it("still strips tags when the `>` in an attribute is entity-encoded", async () => {
     assert.equal(await body('<main><p><span title="a &gt; b">Hello</span></p></main>'), "Hello");
   });

--- a/test/markdown-negotiation.test.mjs
+++ b/test/markdown-negotiation.test.mjs
@@ -292,6 +292,26 @@ describe("block structure", () => {
     );
   });
 
+  it("keeps three-level nested lists nested", async () => {
+    assert.equal(
+      await body(
+        "<main><ol><li>One<ul><li>Two<ol><li>Three</li></ol></li></ul></li><li>Four</li></ol></main>",
+      ),
+      "1. One\n   - Two\n     1. Three\n2. Four",
+    );
+  });
+
+  it("honors ol start", async () => {
+    assert.equal(
+      await body('<main><ol start="3"><li>third</li><li>fourth</li></ol></main>'),
+      "3. third\n4. fourth",
+    );
+    assert.equal(
+      await body('<main><ol start="0"><li>zero</li><li>one</li></ol></main>'),
+      "0. zero\n1. one",
+    );
+  });
+
   it("converts line breaks", async () => {
     assert.equal(await body("<main><p>one<br>two</p></main>"), "one\ntwo");
   });
@@ -347,8 +367,16 @@ describe("inline formatting", () => {
     );
   });
 
+  it("still finds <main> when a quoted attribute on it contains `>`", async () => {
+    assert.equal(await body('<main data-label="a > b"><p>inside</p></main>'), "inside");
+  });
+
   it("still strips tags when the `>` in an attribute is entity-encoded", async () => {
     assert.equal(await body('<main><p><span title="a &gt; b">Hello</span></p></main>'), "Hello");
+  });
+
+  it("leaves a stray `<` in text alone", async () => {
+    assert.equal(await body("<main><p>use a &lt; b, not a < b</p></main>"), "use a < b, not a < b");
   });
 });
 


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

**What this PR does / why we need it**:

Fixes the two follow-ups from #688.

Nested lists were getting flattened because `<li>.*?</li>` closed at the first nested `</li>`, so sub-items got promoted and parent steps renumbered. Walk `ul`/`ol`/`li` by depth instead, and unwrap `<p>` before list conversion so Docusaurus-style items don't come out as `1.\n\ntext`.

Quoted `>` in attributes was leaking into the body (`title="a > b"` → `b">…`) because tag scans use `[^>]*`. Mask those before the scans, restore after.

Also keep leading indent when collapsing spaces, otherwise nested list markers get wiped.

**Which issue(s) this PR fixes**:

Fixes #731

**Checklist**:

- [x] `npm run lint` and `npm run format:check` pass
- [x] `npm run build` succeeds for both `en` and `zh`
- [x] Chinese translation updated if English docs changed (or noted why not) (n/a, no docs touched)
- [x] Commits are signed off (`git commit -s`)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved Markdown conversion for nested ordered and unordered lists, multiline items, and incomplete lists.
  - Ordered lists now honor their starting number.
  - Prevented `>` characters inside quoted HTML attributes from disrupting conversion.
  - Preserved indentation more reliably and left stray `<` characters in text unchanged.

- **Tests**
  - Added regression coverage for nested lists, ordered-list numbering, protected angle characters, encoded values, and stray text symbols.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->