### PR TITLE
docs(userguide): add Coscheduling guide and node lock retry flag

### DIFF
--- a/docs/userguide/configure.md
+++ b/docs/userguide/configure.md
@@ -71,6 +71,20 @@ helm install hami hami-charts/hami --set devicePlugin.deviceMemoryScaling=5 -n k
 | `scheduler.defaultSchedulerPolicy.nodeSchedulerPolicy` | String | GPU node scheduling policy: `"binpack"` allocates jobs to the same GPU node as much as possible. `"spread"` allocates jobs to different GPU nodes as much as possible. | `"binpack"` |
 | `scheduler.defaultSchedulerPolicy.gpuSchedulerPolicy` | String | GPU scheduling policy: `"binpack"` allocates jobs to the same GPU as much as possible. `"spread"` allocates jobs to different GPUs as much as possible. `"mutex"` allocates jobs only to GPUs with no other workloads. | `"spread"` |
 
+## Scheduler Configs: extender arguments
+
+The scheduler extender reads flags from `scheduler.extender.extraArgs`. The chart ships `["--debug", "-v=4"]`, and setting the value replaces the whole list, so repeat the entries you want to keep:
+
+```bash
+helm upgrade hami hami-charts/hami -n kube-system --reuse-values \
+  --set-json 'scheduler.extender.extraArgs=["--debug","-v=4","--node-lock-retry-timeout=28s"]'
+```
+
+| Argument | Type | Description | Default |
+| --- | --- | --- | --- |
+| `--node-lock-retry-timeout` | Duration | How long `Bind` retries the node lock when it is held by another member of the same PodGroup. Applies only to pods carrying the `scheduling.x-k8s.io/pod-group` label; other pods fail fast as before. `0` disables the retry. Keep this below the extender `httpTimeout` in the KubeSchedulerConfiguration, which the chart sets to `30s`. See [How to use Coscheduling with HAMi](coscheduling/how-to-use-coscheduling.md). | `28s` |
+| `--node-lock-timeout` | Duration | How long a node lock stays valid before another pod may take it over. Applies to every pod, not only PodGroup members. | `5m` |
+
 ## Pod Configs: Annotations
 
 | Argument | Type | Description | Example |

--- a/docs/userguide/configure.md
+++ b/docs/userguide/configure.md
@@ -82,8 +82,8 @@ helm upgrade hami hami-charts/hami -n kube-system --reuse-values \
 
 | Argument | Type | Description | Default |
 | --- | --- | --- | --- |
-| `--node-lock-retry-timeout` | Duration | How long `Bind` retries the node lock when it is held by another member of the same PodGroup. Applies only to pods carrying the `scheduling.x-k8s.io/pod-group` label; other pods fail fast as before. `0` disables the retry. Keep this below the extender `httpTimeout` in the KubeSchedulerConfiguration, which the chart sets to `30s`. See [How to use Coscheduling with HAMi](coscheduling/how-to-use-coscheduling.md). | `28s` |
-| `--node-lock-timeout` | Duration | How long a node lock stays valid before another pod may take it over. Applies to every pod, not only PodGroup members. | `5m` |
+| `--node-lock-retry-timeout` | Duration | How long `Bind` retries the node lock when it is held by another member of the same PodGroup, polling every 100 ms. Applies only to pods in a PodGroup — those carrying a non-empty `scheduling.x-k8s.io/pod-group` label or setting `spec.schedulingGroup.podGroupName`; other pods fail fast as before. `0` disables the retry. Keep this below the extender `httpTimeout` in the KubeSchedulerConfiguration, which the chart sets to `30s`. Available in builds newer than v2.9.0. See [How to use Coscheduling with HAMi](coscheduling/how-to-use-coscheduling.md). | `28s` |
+| `--node-lock-timeout` | Duration | How long a node lock stays valid before another pod may take it over. Applies to every pod, not only PodGroup members. The chart also exposes `scheduler.nodeLockExpire`, which sets `HAMI_NODELOCK_EXPIRE`, but the scheduler applies this flag after reading that variable, so the flag is the effective setting. | `5m` |
 
 ## Pod Configs: Annotations
 

--- a/docs/userguide/configure.md
+++ b/docs/userguide/configure.md
@@ -73,7 +73,7 @@ helm install hami hami-charts/hami --set devicePlugin.deviceMemoryScaling=5 -n k
 
 ## Scheduler Configs: extender arguments
 
-The scheduler extender reads flags from `scheduler.extender.extraArgs`. The chart ships `["--debug", "-v=4"]`, and setting the value replaces the whole list, so repeat the entries you want to keep:
+The scheduler extender reads flags from `scheduler.extender.extraArgs`. The chart ships `["--debug", "-v=4"]`, and setting the value replaces the whole list, so repeat the entries you want to keep. The following command uses `--set-json`, which requires Helm 3.10 or later:
 
 ```bash
 helm upgrade hami hami-charts/hami -n kube-system --reuse-values \

--- a/docs/userguide/coscheduling/how-to-use-coscheduling.md
+++ b/docs/userguide/coscheduling/how-to-use-coscheduling.md
@@ -25,7 +25,7 @@ These two mechanisms meet at gang release. Coscheduling releases every member in
 
 To close that gap, the extender retries the node lock for Pods that belong to a PodGroup:
 
-- A Pod counts as a group member if it carries a non-empty `scheduling.x-k8s.io/pod-group` label, or sets `spec.schedulingGroup.podGroupName`. Such a Pod polls the lock every 100 ms until `--node-lock-retry-timeout` expires.
+- A Pod counts as a group member if it carries a non-empty `scheduling.x-k8s.io/pod-group` label. Such a Pod polls the lock every 100 ms until `--node-lock-retry-timeout` expires.
 - Any partially acquired lock is released before each retry, so a Pod requesting devices from more than one vendor cannot leave a stale lock behind.
 - Errors that are not lock contention are returned immediately and are not retried.
 - Pods that belong to no group keep the original fail-fast behavior.
@@ -40,7 +40,7 @@ To close that gap, the extender retries the node lock for Pods that belong to a 
 
 - A Kubernetes cluster with GPU nodes and HAMi installed.
 - A [scheduler-plugins release](https://github.com/kubernetes-sigs/scheduler-plugins/releases) built against your Kubernetes minor version. The minor version of scheduler-plugins matches the Kubernetes client packages it is compiled with, so pick the release that matches your cluster from the [compatibility matrix](https://github.com/kubernetes-sigs/scheduler-plugins#compatibility-matrix). The examples below use v0.34.7, which is built against Kubernetes v1.34.
-- Helm 3.
+- Helm 3.10 or later.
 - `kubectl` with cluster-admin rights.
 
 ## 1. Install HAMi with the scheduler-plugins kube-scheduler
@@ -265,5 +265,4 @@ HAMi injects `LD_PRELOAD` pointing at a glibc build of `libvgpu.so`. Images base
 - [Coscheduling plugin](https://github.com/kubernetes-sigs/scheduler-plugins/tree/master/pkg/coscheduling)
 - [scheduler-plugins releases](https://github.com/kubernetes-sigs/scheduler-plugins/releases)
 - [Global Config](../configure.md)
-- [How to use kueue on HAMi](../kueue/how-to-use-kueue.md)
 - [How to use KAI Scheduler with HAMi](../kai-scheduler/how-to-use-kai-scheduler.md)

--- a/docs/userguide/coscheduling/how-to-use-coscheduling.md
+++ b/docs/userguide/coscheduling/how-to-use-coscheduling.md
@@ -23,23 +23,23 @@ The lock serializes device allocation on that node. Without it, two Pods bound a
 
 These two mechanisms meet at gang release. Coscheduling releases every member in the same millisecond, so if several members target the same node, they contend on a lock that is held for only a few tens of milliseconds. The Pod that loses fails its bind, returns to Pending, and comes back through the default kube-scheduler backoff, which is measured in seconds. A five-member gang converges, but it takes several backoff rounds to do it.
 
-To close that gap, the extender retries the node lock for Pods that carry the Coscheduling group label:
+To close that gap, the extender retries the node lock for Pods that belong to a PodGroup:
 
-- A Pod with a non-empty `scheduling.x-k8s.io/pod-group` label polls the lock every 100 ms until `--node-lock-retry-timeout` expires.
+- A Pod counts as a group member if it carries a non-empty `scheduling.x-k8s.io/pod-group` label, or sets `spec.schedulingGroup.podGroupName`. Such a Pod polls the lock every 100 ms until `--node-lock-retry-timeout` expires.
 - Any partially acquired lock is released before each retry, so a Pod requesting devices from more than one vendor cannot leave a stale lock behind.
 - Errors that are not lock contention are returned immediately and are not retried.
-- Pods without the label keep the original fail-fast behavior.
+- Pods that belong to no group keep the original fail-fast behavior.
 
 :::note
 
-`--node-lock-retry-timeout` is available in builds newer than v2.9.0.
+`--node-lock-retry-timeout` is available in builds newer than v2.9.0. Passing it to an older extender makes the container exit on an unknown flag, so only add it once you are running a build that includes it.
 
 :::
 
 ## Prerequisites
 
 - A Kubernetes cluster with GPU nodes and HAMi installed.
-- A [scheduler-plugins release](https://github.com/kubernetes-sigs/scheduler-plugins/releases) built against your Kubernetes minor version. The examples below use v0.34.7 on Kubernetes v1.35.
+- A [scheduler-plugins release](https://github.com/kubernetes-sigs/scheduler-plugins/releases) built against your Kubernetes minor version. The minor version of scheduler-plugins matches the Kubernetes client packages it is compiled with, so pick the release that matches your cluster from the [compatibility matrix](https://github.com/kubernetes-sigs/scheduler-plugins#compatibility-matrix). The examples below use v0.34.7, which is built against Kubernetes v1.34.
 - Helm 3.
 - `kubectl` with cluster-admin rights.
 
@@ -52,7 +52,7 @@ helm repo add hami-charts https://project-hami.github.io/HAMi/
 helm repo update
 
 helm install hami hami-charts/hami \
-  --namespace hami-system --create-namespace \
+  --namespace kube-system \
   --set scheduler.kubeScheduler.image.registry=registry.k8s.io \
   --set scheduler.kubeScheduler.image.repository=scheduler-plugins/kube-scheduler \
   --set scheduler.kubeScheduler.image.tag=v0.34.7 \
@@ -69,12 +69,30 @@ Coscheduling reads `PodGroup` resources. Install the CRD from the same scheduler
 kubectl apply -f https://raw.githubusercontent.com/kubernetes-sigs/scheduler-plugins/v0.34.7/config/crd/bases/scheduling.x-k8s.io_podgroups.yaml
 ```
 
-## 3. Enable Coscheduling in the scheduler config
+## 3. Deploy the scheduler-plugins controller
+
+Gang admission itself does not need the controller: the Coscheduling plugin decides on `PodGroup` spec and its own in-memory bookkeeping. What the controller adds is `PodGroup.status` — it reconciles `phase`, `running`, `succeeded`, and `failed`, which is what `kubectl get podgroup` reports and what you need to follow a group's progress. It ships as a separate image in the same release.
+
+Deploy the controller from the release manifest:
+
+```bash
+kubectl apply -f https://raw.githubusercontent.com/kubernetes-sigs/scheduler-plugins/v0.34.7/manifests/install/all-in-one.yaml
+```
+
+That manifest creates the `scheduler-plugins` namespace, the controller Deployment, and the controller RBAC. It does **not** install a second scheduler, so it is safe to apply alongside the HAMi scheduler. The `system:kube-scheduler:plugins` ClusterRole it also creates is bound to the `system:kube-scheduler` user and does not cover the HAMi scheduler ServiceAccount — [step 5](#5-grant-access-to-podgroups) handles that separately.
+
+Confirm the controller is up:
+
+```bash
+kubectl rollout status deploy/scheduler-plugins-controller -n scheduler-plugins
+```
+
+## 4. Enable Coscheduling in the scheduler config
 
 The chart renders the KubeSchedulerConfiguration into the `hami-scheduler` ConfigMap. Add the plugin to the profile:
 
 ```bash
-kubectl edit configmap hami-scheduler -n hami-system
+kubectl edit configmap hami-scheduler -n kube-system
 ```
 
 The `profiles` entry must look like this:
@@ -110,13 +128,13 @@ The ConfigMap is owned by the chart, so `helm upgrade` overwrites this edit. Re-
 Restart the scheduler to pick up the change:
 
 ```bash
-kubectl rollout restart deploy/hami-scheduler -n hami-system
-kubectl rollout status deploy/hami-scheduler -n hami-system
+kubectl rollout restart deploy/hami-scheduler -n kube-system
+kubectl rollout status deploy/hami-scheduler -n kube-system
 ```
 
-## 4. Grant access to PodGroups
+## 5. Grant access to PodGroups
 
-The scheduler ServiceAccount installed by the chart cannot read `PodGroup` resources. Add the permission:
+The scheduler ServiceAccount installed by the chart cannot read `PodGroup` resources. The Coscheduling plugin only reads them — it resolves a Pod's group, counts siblings, and compares the total against `minMember` — so read-only access is all the scheduler needs:
 
 ```yaml
 apiVersion: rbac.authorization.k8s.io/v1
@@ -126,7 +144,7 @@ metadata:
 rules:
   - apiGroups: ["scheduling.x-k8s.io"]
     resources: ["podgroups"]
-    verbs: ["get", "list", "watch", "create", "update", "patch"]
+    verbs: ["get", "list", "watch"]
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
@@ -139,12 +157,16 @@ roleRef:
 subjects:
   - kind: ServiceAccount
     name: hami-scheduler
-    namespace: hami-system
+    namespace: kube-system
 ```
 
-Without it, `PreFilter` fails for every member and the whole group stays Pending.
+The ServiceAccount is named after the Helm release: a release named `hami` produces `hami-scheduler`. Adjust the `name` and `namespace` if you installed under a different release name or namespace.
 
-## 5. Submit a gang
+Writes to `PodGroup.status` come from the controller deployed in [step 3](#3-deploy-the-scheduler-plugins-controller), which carries its own ServiceAccount and RBAC, so the scheduler never needs `create`, `update`, or `patch` here.
+
+Without this ClusterRole the scheduler's PodGroup lister stays empty. `PreFilter` still passes — it treats a group it cannot resolve as no group at all — but `Permit` then rejects every member with `PodGroup not found`, and the group stays Pending.
+
+## 6. Submit a gang
 
 Create a `PodGroup` and label every member with its name. Each member requests vGPU resources as usual:
 
@@ -176,7 +198,7 @@ spec:
           nvidia.com/gpucores: "30"
 ```
 
-The manifest above defines one member. Create `minMember` Pods from the same template with distinct names, otherwise the group never reaches its quorum and every member stays Pending.
+The manifest above defines one Pod that belongs to the gang. Create additional Pods with the same `scheduling.x-k8s.io/pod-group` label to satisfy `minMember`. Each Pod should have a distinct name; otherwise, the group cannot reach the required number of members and the Pods will remain Pending.
 
 :::warning
 
@@ -199,17 +221,12 @@ current pods number: 3, minMember of group: 5
 
 ## Tune the node lock
 
-Two independent timeouts control node lock behavior.
-
-| Flag | Default | Description |
-| --- | --- | --- |
-| `--node-lock-retry-timeout` | `28s` | How long `Bind` retries the node lock for a Pod labeled with `scheduling.x-k8s.io/pod-group`. `0` disables retry and restores fail-fast behavior. Polling interval is 100 ms. |
-| `--node-lock-timeout` | `5m` | How long a lock stays valid before another Pod may take it over. Applies to every Pod, not only gang members. |
+Two extender flags control node lock behavior: `--node-lock-retry-timeout` bounds how long `Bind` retries a contended lock for a group member, and `--node-lock-timeout` bounds how long a lock stays valid before another Pod may take it over. Both are described in [Global Config](../configure.md#scheduler-configs-extender-arguments).
 
 Set the retry timeout through the chart. `scheduler.extender.extraArgs` replaces the default list, so keep the existing entries:
 
 ```bash
-helm upgrade hami hami-charts/hami -n hami-system --reuse-values \
+helm upgrade hami hami-charts/hami -n kube-system --reuse-values \
   --set-json 'scheduler.extender.extraArgs=["--debug","-v=4","--node-lock-retry-timeout=28s"]'
 ```
 
@@ -225,15 +242,19 @@ The default of `28s` leaves 2 seconds of headroom under that `30s` timeout.
 
 **Pods stay Pending with `BindingFailed: node <name> has been locked within 5m0s`**
 
-The retry is not active for these Pods. Check that the `scheduling.x-k8s.io/pod-group` label is on the Pod (not the PodGroup only, and not in annotations), and that `--node-lock-retry-timeout` is not set to `0`.
+The retry is not active for these Pods. Check that the `scheduling.x-k8s.io/pod-group` label is on the Pod itself (not on the PodGroup only, and not in annotations), and that `--node-lock-retry-timeout` is not set to `0`.
 
 **The scheduler container crash-loops on startup**
 
-Look for `only one queue sort plugin required` in the kube-scheduler logs. `PrioritySort` is still enabled alongside Coscheduling. See [step 3](#3-enable-coscheduling-in-the-scheduler-config).
+Look for `only one queue sort plugin required` in the kube-scheduler logs. `PrioritySort` is still enabled alongside Coscheduling. See [step 4](#4-enable-coscheduling-in-the-scheduler-config).
 
 **All members of a group stay Pending and no node is ever selected**
 
-Either fewer than `minMember` members were created, or the scheduler cannot read `PodGroup` resources. Check the kube-scheduler logs for `PreFilter failed` and confirm the RBAC from [step 4](#4-grant-access-to-podgroups) is applied.
+Either fewer than `minMember` members were created, or the scheduler cannot read `PodGroup` resources. The two cases log differently: a short group is rejected in `PreFilter` with `cannot find enough sibling pods`, while missing RBAC surfaces in `Permit` as `PodGroup not found`. For the latter, confirm the RBAC from [step 5](#5-grant-access-to-podgroups) is applied.
+
+**`kubectl get podgroup` reports no status**
+
+The `scheduler-plugins-controller` is missing or crash-looping. Gang scheduling still works, but the status view does not. Check `kubectl get deploy -n scheduler-plugins` and confirm [step 3](#3-deploy-the-scheduler-plugins-controller) was applied. A `forbidden` error on `podgroups/status` in the controller logs means its own RBAC was not created — re-apply the manifest from that step.
 
 **Containers fail with `libdl.so.2: cannot open shared object file`**
 
@@ -244,5 +265,5 @@ HAMi injects `LD_PRELOAD` pointing at a glibc build of `libvgpu.so`. Images base
 - [Coscheduling plugin](https://github.com/kubernetes-sigs/scheduler-plugins/tree/master/pkg/coscheduling)
 - [scheduler-plugins releases](https://github.com/kubernetes-sigs/scheduler-plugins/releases)
 - [Global Config](../configure.md)
-- [Using HAMi with Kueue](../kueue/how-to-use-kueue.md)
-- [Using HAMi with KAI Scheduler](../kai-scheduler/how-to-use-kai-scheduler.md)
+- [How to use kueue on HAMi](../kueue/how-to-use-kueue.md)
+- [How to use KAI Scheduler with HAMi](../kai-scheduler/how-to-use-kai-scheduler.md)

--- a/docs/userguide/coscheduling/how-to-use-coscheduling.md
+++ b/docs/userguide/coscheduling/how-to-use-coscheduling.md
@@ -1,0 +1,248 @@
+---
+title: How to use Coscheduling with HAMi
+sidebar_label: How to use Coscheduling
+---
+
+[Coscheduling](https://github.com/kubernetes-sigs/scheduler-plugins/tree/master/pkg/coscheduling) is a scheduler plugin from [kubernetes-sigs/scheduler-plugins](https://github.com/kubernetes-sigs/scheduler-plugins) that provides gang scheduling. A group of Pods is admitted only when at least `minMember` of them can be placed at once, which is what distributed training needs: a job either gets all of its GPUs or none of them.
+
+This guide covers running Coscheduling inside the HAMi scheduler and tuning the node lock behavior that gang binding exercises.
+
+## How it works
+
+HAMi and Coscheduling operate at two different points of the scheduling cycle.
+
+Coscheduling works in the **Permit** phase. Each member Pod that passes filtering is parked in a waiting queue. Once `minMember` members are waiting, all of them are released into the bind phase at the same time.
+
+HAMi works in the **Bind** phase, through the extender. Before binding, the extender takes a per-node lock by writing the `hami.io/mutex.lock` annotation onto the Node object:
+
+```text
+hami.io/mutex.lock: 2026-06-14T15:05:03Z,default,gang-pod-1
+```
+
+The lock serializes device allocation on that node. Without it, two Pods bound at the same moment would both read the same device usage snapshot and could be handed overlapping slices of one GPU. The lock is released by the device plugin once `Allocate()` finishes and the Pod annotations are updated, which takes about 20 ms on a real GPU. A lock that is never released expires after the node lock timeout (5 minutes by default).
+
+These two mechanisms meet at gang release. Coscheduling releases every member in the same millisecond, so if several members target the same node, they contend on a lock that is held for only a few tens of milliseconds. The Pod that loses fails its bind, returns to Pending, and comes back through the default kube-scheduler backoff, which is measured in seconds. A five-member gang converges, but it takes several backoff rounds to do it.
+
+To close that gap, the extender retries the node lock for Pods that carry the Coscheduling group label:
+
+- A Pod with a non-empty `scheduling.x-k8s.io/pod-group` label polls the lock every 100 ms until `--node-lock-retry-timeout` expires.
+- Any partially acquired lock is released before each retry, so a Pod requesting devices from more than one vendor cannot leave a stale lock behind.
+- Errors that are not lock contention are returned immediately and are not retried.
+- Pods without the label keep the original fail-fast behavior.
+
+:::note
+
+`--node-lock-retry-timeout` is available in builds newer than v2.9.0.
+
+:::
+
+## Prerequisites
+
+- A Kubernetes cluster with GPU nodes and HAMi installed.
+- A [scheduler-plugins release](https://github.com/kubernetes-sigs/scheduler-plugins/releases) built against your Kubernetes minor version. The examples below use v0.34.7 on Kubernetes v1.35.
+- Helm 3.
+- `kubectl` with cluster-admin rights.
+
+## 1. Install HAMi with the scheduler-plugins kube-scheduler
+
+The HAMi scheduler Pod runs two containers: an upstream `kube-scheduler` and the HAMi `vgpu-scheduler-extender`. Coscheduling is compiled into the scheduler-plugins build of kube-scheduler, so point the chart at that image instead of the stock one:
+
+```bash
+helm repo add hami-charts https://project-hami.github.io/HAMi/
+helm repo update
+
+helm install hami hami-charts/hami \
+  --namespace hami-system --create-namespace \
+  --set scheduler.kubeScheduler.image.registry=registry.k8s.io \
+  --set scheduler.kubeScheduler.image.repository=scheduler-plugins/kube-scheduler \
+  --set scheduler.kubeScheduler.image.tag=v0.34.7 \
+  --wait --timeout 10m
+```
+
+On an existing installation, run the same three `--set` flags through `helm upgrade --reuse-values`.
+
+## 2. Install the PodGroup CRD
+
+Coscheduling reads `PodGroup` resources. Install the CRD from the same scheduler-plugins release:
+
+```bash
+kubectl apply -f https://raw.githubusercontent.com/kubernetes-sigs/scheduler-plugins/v0.34.7/config/crd/bases/scheduling.x-k8s.io_podgroups.yaml
+```
+
+## 3. Enable Coscheduling in the scheduler config
+
+The chart renders the KubeSchedulerConfiguration into the `hami-scheduler` ConfigMap. Add the plugin to the profile:
+
+```bash
+kubectl edit configmap hami-scheduler -n hami-system
+```
+
+The `profiles` entry must look like this:
+
+```yaml
+profiles:
+  - schedulerName: hami-scheduler
+    plugins:
+      multiPoint:
+        enabled:
+          - name: Coscheduling
+      queueSort:
+        disabled:
+          - name: PrioritySort
+    pluginConfig:
+      - name: Coscheduling
+        args:
+          permitWaitingTimeSeconds: 10
+```
+
+:::warning
+
+`PrioritySort` must be disabled. Coscheduling registers its own queue sort plugin, and kube-scheduler refuses to start with two of them:
+
+```text
+only one queue sort plugin required for profile with scheduler name "hami-scheduler", but got 2
+```
+
+:::
+
+The ConfigMap is owned by the chart, so `helm upgrade` overwrites this edit. Re-apply it after every upgrade, or manage the ConfigMap outside the chart.
+
+Restart the scheduler to pick up the change:
+
+```bash
+kubectl rollout restart deploy/hami-scheduler -n hami-system
+kubectl rollout status deploy/hami-scheduler -n hami-system
+```
+
+## 4. Grant access to PodGroups
+
+The scheduler ServiceAccount installed by the chart cannot read `PodGroup` resources. Add the permission:
+
+```yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: hami-podgroup-reader
+rules:
+  - apiGroups: ["scheduling.x-k8s.io"]
+    resources: ["podgroups"]
+    verbs: ["get", "list", "watch", "create", "update", "patch"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: hami-podgroup-reader
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: hami-podgroup-reader
+subjects:
+  - kind: ServiceAccount
+    name: hami-scheduler
+    namespace: hami-system
+```
+
+Without it, `PreFilter` fails for every member and the whole group stays Pending.
+
+## 5. Submit a gang
+
+Create a `PodGroup` and label every member with its name. Each member requests vGPU resources as usual:
+
+```yaml
+apiVersion: scheduling.x-k8s.io/v1alpha1
+kind: PodGroup
+metadata:
+  name: gang-training
+spec:
+  minMember: 4
+  scheduleTimeoutSeconds: 60
+---
+apiVersion: v1
+kind: Pod
+metadata:
+  name: gang-worker-1
+  labels:
+    scheduling.x-k8s.io/pod-group: gang-training
+spec:
+  schedulerName: hami-scheduler
+  containers:
+    - name: worker
+      image: ubuntu:22.04
+      command: ["sleep", "3600"]
+      resources:
+        limits:
+          nvidia.com/gpu: "1"
+          nvidia.com/gpumem: "3000"
+          nvidia.com/gpucores: "30"
+```
+
+The manifest above defines one member. Create `minMember` Pods from the same template with distinct names, otherwise the group never reaches its quorum and every member stays Pending.
+
+:::warning
+
+`scheduling.x-k8s.io/pod-group` must be under `metadata.labels`. Placing it under `metadata.annotations` bypasses gang logic without any error: the Pods schedule one by one regardless of `minMember`.
+
+:::
+
+Verify that the group was admitted together:
+
+```bash
+kubectl get pods -l scheduling.x-k8s.io/pod-group=gang-training -o wide
+```
+
+When fewer than `minMember` members exist, `PreFilter` rejects the group before the HAMi extender is reached:
+
+```text
+pre-filter pod gang-worker-1 cannot find enough sibling pods,
+current pods number: 3, minMember of group: 5
+```
+
+## Tune the node lock
+
+Two independent timeouts control node lock behavior.
+
+| Flag | Default | Description |
+| --- | --- | --- |
+| `--node-lock-retry-timeout` | `28s` | How long `Bind` retries the node lock for a Pod labeled with `scheduling.x-k8s.io/pod-group`. `0` disables retry and restores fail-fast behavior. Polling interval is 100 ms. |
+| `--node-lock-timeout` | `5m` | How long a lock stays valid before another Pod may take it over. Applies to every Pod, not only gang members. |
+
+Set the retry timeout through the chart. `scheduler.extender.extraArgs` replaces the default list, so keep the existing entries:
+
+```bash
+helm upgrade hami hami-charts/hami -n hami-system --reuse-values \
+  --set-json 'scheduler.extender.extraArgs=["--debug","-v=4","--node-lock-retry-timeout=28s"]'
+```
+
+:::warning
+
+Keep `--node-lock-retry-timeout` below the extender `httpTimeout` in the KubeSchedulerConfiguration, which the chart sets to `30s`. If the retry outlives the HTTP call, kube-scheduler abandons the bind request while the extender is still waiting for the lock, and the Pod is retried from the top.
+
+:::
+
+The default of `28s` leaves 2 seconds of headroom under that `30s` timeout.
+
+## Troubleshooting
+
+**Pods stay Pending with `BindingFailed: node <name> has been locked within 5m0s`**
+
+The retry is not active for these Pods. Check that the `scheduling.x-k8s.io/pod-group` label is on the Pod (not the PodGroup only, and not in annotations), and that `--node-lock-retry-timeout` is not set to `0`.
+
+**The scheduler container crash-loops on startup**
+
+Look for `only one queue sort plugin required` in the kube-scheduler logs. `PrioritySort` is still enabled alongside Coscheduling. See [step 3](#3-enable-coscheduling-in-the-scheduler-config).
+
+**All members of a group stay Pending and no node is ever selected**
+
+Either fewer than `minMember` members were created, or the scheduler cannot read `PodGroup` resources. Check the kube-scheduler logs for `PreFilter failed` and confirm the RBAC from [step 4](#4-grant-access-to-podgroups) is applied.
+
+**Containers fail with `libdl.so.2: cannot open shared object file`**
+
+HAMi injects `LD_PRELOAD` pointing at a glibc build of `libvgpu.so`. Images based on musl, such as `busybox` and `alpine`, cannot load it. Use a glibc image for GPU workloads.
+
+## Related links
+
+- [Coscheduling plugin](https://github.com/kubernetes-sigs/scheduler-plugins/tree/master/pkg/coscheduling)
+- [scheduler-plugins releases](https://github.com/kubernetes-sigs/scheduler-plugins/releases)
+- [Global Config](../configure.md)
+- [Using HAMi with Kueue](../kueue/how-to-use-kueue.md)
+- [Using HAMi with KAI Scheduler](../kai-scheduler/how-to-use-kai-scheduler.md)

--- a/i18n/zh/docusaurus-plugin-content-docs/current.json
+++ b/i18n/zh/docusaurus-plugin-content-docs/current.json
@@ -103,6 +103,10 @@
     "message": "在 Kueue 中使用 HAMi",
     "description": "The label for category 'Using HAMi with Kueue' in sidebar 'docs'"
   },
+  "sidebar.docs.category.Using HAMi with Coscheduling": {
+    "message": "在 HAMi 中使用 Coscheduling",
+    "description": "The label for category 'Using HAMi with Coscheduling' in sidebar 'docs'"
+  },
   "sidebar.docs.category.nvidia-examples": {
     "message": "示例",
     "description": "The label for category 'Examples' in sidebar 'docs'"

--- a/i18n/zh/docusaurus-plugin-content-docs/current.json
+++ b/i18n/zh/docusaurus-plugin-content-docs/current.json
@@ -103,9 +103,9 @@
     "message": "在 Kueue 中使用 HAMi",
     "description": "The label for category 'Using HAMi with Kueue' in sidebar 'docs'"
   },
-  "sidebar.docs.category.Using HAMi with Coscheduling": {
+  "sidebar.docs.category.Using Coscheduling with HAMi": {
     "message": "在 HAMi 中使用 Coscheduling",
-    "description": "The label for category 'Using HAMi with Coscheduling' in sidebar 'docs'"
+    "description": "The label for category 'Using Coscheduling with HAMi' in sidebar 'docs'"
   },
   "sidebar.docs.category.nvidia-examples": {
     "message": "示例",

--- a/i18n/zh/docusaurus-plugin-content-docs/current/userguide/configure.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/current/userguide/configure.md
@@ -84,8 +84,8 @@ helm upgrade hami hami-charts/hami -n kube-system --reuse-values \
 
 | 参数 | 类型 | 描述 | 默认值 |
 | --- | --- | --- | --- |
-| `--node-lock-retry-timeout` | 时长 | 当节点锁被同一个 PodGroup 的其他成员持有时，`Bind` 重试该锁的时长。仅对带有 `scheduling.x-k8s.io/pod-group` 标签的 Pod 生效，其他 Pod 保持原有的快速失败行为。设为 `0` 关闭重试。该值需小于 KubeSchedulerConfiguration 中扩展器的 `httpTimeout`（chart 设为 `30s`）。参见[如何在 HAMi 中使用 Coscheduling](coscheduling/how-to-use-coscheduling.md)。 | `28s` |
-| `--node-lock-timeout` | 时长 | 一把节点锁在被其他 Pod 接管前的有效期。对所有 Pod 生效，不限于 PodGroup 成员。 | `5m` |
+| `--node-lock-retry-timeout` | 时长 | 当节点锁被同一个 PodGroup 的其他成员持有时，`Bind` 重试该锁的时长，轮询间隔为 100 毫秒。仅对属于 PodGroup 的 Pod 生效，即带有非空 `scheduling.x-k8s.io/pod-group` 标签或设置了 `spec.schedulingGroup.podGroupName` 的 Pod，其他 Pod 保持原有的快速失败行为。设为 `0` 关闭重试。该值需小于 KubeSchedulerConfiguration 中扩展器的 `httpTimeout`（chart 设为 `30s`）。在高于 v2.9.0 的版本中可用。参见[如何在 HAMi 中使用 Coscheduling](coscheduling/how-to-use-coscheduling.md)。 | `28s` |
+| `--node-lock-timeout` | 时长 | 一把节点锁在被其他 Pod 接管前的有效期。对所有 Pod 生效，不限于 PodGroup 成员。chart 另有 `scheduler.nodeLockExpire`，用于设置 `HAMI_NODELOCK_EXPIRE`，但调度器会在读取该变量之后再应用本参数，因此实际生效的是本参数。 | `5m` |
 
 ## Pod 配置：注解
 

--- a/i18n/zh/docusaurus-plugin-content-docs/current/userguide/configure.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/current/userguide/configure.md
@@ -75,7 +75,7 @@ helm install hami hami-charts/hami --set devicePlugin.deviceMemoryScaling=5 -n k
 
 ## 调度器配置：扩展器参数
 
-调度器扩展器从 `scheduler.extender.extraArgs` 读取命令行参数。chart 默认值为 `["--debug", "-v=4"]`，设置该值会替换整个列表，因此需要保留想要沿用的条目：
+调度器扩展器从 `scheduler.extender.extraArgs` 读取命令行参数。chart 默认值为 `["--debug", "-v=4"]`，设置该值会替换整个列表，因此需要保留想要沿用的条目。下面的命令使用 `--set-json`，需要 Helm 3.10 或更高版本：
 
 ```bash
 helm upgrade hami hami-charts/hami -n kube-system --reuse-values \

--- a/i18n/zh/docusaurus-plugin-content-docs/current/userguide/configure.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/current/userguide/configure.md
@@ -73,6 +73,20 @@ helm install hami hami-charts/hami --set devicePlugin.deviceMemoryScaling=5 -n k
 | `scheduler.defaultSchedulerPolicy.nodeSchedulerPolicy` | 字符串 | GPU 节点调度策略：`"binpack"` 表示尽可能将任务分配到同一个 GPU 节点；`"spread"` 表示尽可能将任务分配到不同的 GPU 节点。 | `"binpack"` |
 | `scheduler.defaultSchedulerPolicy.gpuSchedulerPolicy` | 字符串 | GPU 调度策略：`"binpack"` 表示尽可能将任务分配到同一个 GPU；`"spread"` 表示尽可能将任务分配到不同的 GPU。 | `"spread"` |
 
+## 调度器配置：扩展器参数
+
+调度器扩展器从 `scheduler.extender.extraArgs` 读取命令行参数。chart 默认值为 `["--debug", "-v=4"]`，设置该值会替换整个列表，因此需要保留想要沿用的条目：
+
+```bash
+helm upgrade hami hami-charts/hami -n kube-system --reuse-values \
+  --set-json 'scheduler.extender.extraArgs=["--debug","-v=4","--node-lock-retry-timeout=28s"]'
+```
+
+| 参数 | 类型 | 描述 | 默认值 |
+| --- | --- | --- | --- |
+| `--node-lock-retry-timeout` | 时长 | 当节点锁被同一个 PodGroup 的其他成员持有时，`Bind` 重试该锁的时长。仅对带有 `scheduling.x-k8s.io/pod-group` 标签的 Pod 生效，其他 Pod 保持原有的快速失败行为。设为 `0` 关闭重试。该值需小于 KubeSchedulerConfiguration 中扩展器的 `httpTimeout`（chart 设为 `30s`）。参见[如何在 HAMi 中使用 Coscheduling](coscheduling/how-to-use-coscheduling.md)。 | `28s` |
+| `--node-lock-timeout` | 时长 | 一把节点锁在被其他 Pod 接管前的有效期。对所有 Pod 生效，不限于 PodGroup 成员。 | `5m` |
+
 ## Pod 配置：注解
 
 | 参数 | 类型 | 描述 | 示例 |

--- a/i18n/zh/docusaurus-plugin-content-docs/current/userguide/coscheduling/how-to-use-coscheduling.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/current/userguide/coscheduling/how-to-use-coscheduling.md
@@ -25,7 +25,7 @@ hami.io/mutex.lock: 2026-06-14T15:05:03Z,default,gang-pod-1
 
 为了消除这段空转，扩展器会为属于某个 PodGroup 的 Pod 重试节点锁：
 
-- 带有非空 `scheduling.x-k8s.io/pod-group` 标签，或设置了 `spec.schedulingGroup.podGroupName` 的 Pod，都算作分组成员。这类 Pod 每 100 毫秒轮询一次锁，直到 `--node-lock-retry-timeout` 超时。
+- 带有非空 `scheduling.x-k8s.io/pod-group` 标签的 Pod 算作分组成员。这类 Pod 每 100 毫秒轮询一次锁，直到 `--node-lock-retry-timeout` 超时。
 - 每次重试前会释放已部分获取的锁，因此同时申请多个厂商设备的 Pod 不会残留过期锁。
 - 非锁争抢类错误会立即返回，不做重试。
 - 不属于任何分组的 Pod 保持原有的快速失败行为。
@@ -40,7 +40,7 @@ hami.io/mutex.lock: 2026-06-14T15:05:03Z,default,gang-pod-1
 
 - 一个已安装 HAMi 且具备 GPU 节点的 Kubernetes 集群。
 - 与集群 Kubernetes 次版本匹配的 [scheduler-plugins 版本](https://github.com/kubernetes-sigs/scheduler-plugins/releases)。scheduler-plugins 的次版本与其编译所用的 Kubernetes 客户端库版本一致，请对照[兼容性矩阵](https://github.com/kubernetes-sigs/scheduler-plugins#compatibility-matrix)选择与集群匹配的版本。下文示例使用 v0.34.7，该版本基于 Kubernetes v1.34 构建。
-- Helm 3。
+- Helm 3.10 或更高版本。
 - 具备 cluster-admin 权限的 `kubectl`。
 
 ## 1. 使用 scheduler-plugins 的 kube-scheduler 安装 HAMi
@@ -265,5 +265,4 @@ HAMi 注入的 `LD_PRELOAD` 指向基于 glibc 构建的 `libvgpu.so`。基于 m
 - [Coscheduling 插件](https://github.com/kubernetes-sigs/scheduler-plugins/tree/master/pkg/coscheduling)
 - [scheduler-plugins 版本列表](https://github.com/kubernetes-sigs/scheduler-plugins/releases)
 - [全局配置](../configure.md)
-- [如何在 HAMi 上使用 Kueue](../kueue/how-to-use-kueue.md)
 - [如何在 KAI Scheduler 中使用 HAMi](../kai-scheduler/how-to-use-kai-scheduler.md)

--- a/i18n/zh/docusaurus-plugin-content-docs/current/userguide/coscheduling/how-to-use-coscheduling.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/current/userguide/coscheduling/how-to-use-coscheduling.md
@@ -23,23 +23,23 @@ hami.io/mutex.lock: 2026-06-14T15:05:03Z,default,gang-pod-1
 
 这两个机制在 gang 释放时相遇。Coscheduling 会在同一毫秒内释放全部成员，因此当多个成员落在同一节点时，它们会争抢一把只持有几十毫秒的锁。抢锁失败的 Pod 绑定失败并回到 Pending，随后经由 kube-scheduler 的退避重试回来，而退避是以秒为单位的。5 个成员的 gang 最终会收敛，但需要经过多轮退避。
 
-为了消除这段空转，扩展器会为带有 Coscheduling 分组标签的 Pod 重试节点锁：
+为了消除这段空转，扩展器会为属于某个 PodGroup 的 Pod 重试节点锁：
 
-- 带有非空 `scheduling.x-k8s.io/pod-group` 标签的 Pod 每 100 毫秒轮询一次锁，直到 `--node-lock-retry-timeout` 超时。
+- 带有非空 `scheduling.x-k8s.io/pod-group` 标签，或设置了 `spec.schedulingGroup.podGroupName` 的 Pod，都算作分组成员。这类 Pod 每 100 毫秒轮询一次锁，直到 `--node-lock-retry-timeout` 超时。
 - 每次重试前会释放已部分获取的锁，因此同时申请多个厂商设备的 Pod 不会残留过期锁。
 - 非锁争抢类错误会立即返回，不做重试。
-- 未带该标签的 Pod 保持原有的快速失败行为。
+- 不属于任何分组的 Pod 保持原有的快速失败行为。
 
 :::note
 
-`--node-lock-retry-timeout` 在高于 v2.9.0 的版本中可用。
+`--node-lock-retry-timeout` 在高于 v2.9.0 的版本中可用。把它传给更早版本的扩展器会因无法识别该参数而退出，因此请在确认所用构建包含该参数后再添加。
 
 :::
 
 ## 前置条件
 
 - 一个已安装 HAMi 且具备 GPU 节点的 Kubernetes 集群。
-- 与集群 Kubernetes 次版本匹配的 [scheduler-plugins 版本](https://github.com/kubernetes-sigs/scheduler-plugins/releases)。下文示例使用 Kubernetes v1.35 与 v0.34.7。
+- 与集群 Kubernetes 次版本匹配的 [scheduler-plugins 版本](https://github.com/kubernetes-sigs/scheduler-plugins/releases)。scheduler-plugins 的次版本与其编译所用的 Kubernetes 客户端库版本一致，请对照[兼容性矩阵](https://github.com/kubernetes-sigs/scheduler-plugins#compatibility-matrix)选择与集群匹配的版本。下文示例使用 v0.34.7，该版本基于 Kubernetes v1.34 构建。
 - Helm 3。
 - 具备 cluster-admin 权限的 `kubectl`。
 
@@ -52,7 +52,7 @@ helm repo add hami-charts https://project-hami.github.io/HAMi/
 helm repo update
 
 helm install hami hami-charts/hami \
-  --namespace hami-system --create-namespace \
+  --namespace kube-system \
   --set scheduler.kubeScheduler.image.registry=registry.k8s.io \
   --set scheduler.kubeScheduler.image.repository=scheduler-plugins/kube-scheduler \
   --set scheduler.kubeScheduler.image.tag=v0.34.7 \
@@ -69,12 +69,30 @@ Coscheduling 读取 `PodGroup` 资源。从同一个 scheduler-plugins 版本安
 kubectl apply -f https://raw.githubusercontent.com/kubernetes-sigs/scheduler-plugins/v0.34.7/config/crd/bases/scheduling.x-k8s.io_podgroups.yaml
 ```
 
-## 3. 在调度器配置中启用 Coscheduling
+## 3. 部署 scheduler-plugins 控制器
+
+gang 准入本身并不依赖该控制器：Coscheduling 插件依据 `PodGroup` 的 spec 以及自身的内存记账来判断。控制器提供的是 `PodGroup.status` —— 它负责协调 `phase`、`running`、`succeeded` 与 `failed`，这正是 `kubectl get podgroup` 展示的内容，也是跟踪一组 Pod 进度所需的信息。它以独立镜像随同一版本发布。
+
+从发布清单部署控制器：
+
+```bash
+kubectl apply -f https://raw.githubusercontent.com/kubernetes-sigs/scheduler-plugins/v0.34.7/manifests/install/all-in-one.yaml
+```
+
+该清单会创建 `scheduler-plugins` 命名空间、控制器 Deployment 以及控制器所需的 RBAC，**不会**安装第二个调度器，因此可以与 HAMi 调度器共存。清单中同时创建的 `system:kube-scheduler:plugins` ClusterRole 绑定的是 `system:kube-scheduler` 用户，并不覆盖 HAMi 调度器的 ServiceAccount，这部分由[第 5 步](#5-授予访问-podgroup-的权限)单独处理。
+
+确认控制器已就绪：
+
+```bash
+kubectl rollout status deploy/scheduler-plugins-controller -n scheduler-plugins
+```
+
+## 4. 在调度器配置中启用 Coscheduling
 
 chart 会把 KubeSchedulerConfiguration 渲染到 `hami-scheduler` ConfigMap 中。将插件加入 profile：
 
 ```bash
-kubectl edit configmap hami-scheduler -n hami-system
+kubectl edit configmap hami-scheduler -n kube-system
 ```
 
 `profiles` 条目应如下所示：
@@ -110,13 +128,13 @@ only one queue sort plugin required for profile with scheduler name "hami-schedu
 重启调度器使配置生效：
 
 ```bash
-kubectl rollout restart deploy/hami-scheduler -n hami-system
-kubectl rollout status deploy/hami-scheduler -n hami-system
+kubectl rollout restart deploy/hami-scheduler -n kube-system
+kubectl rollout status deploy/hami-scheduler -n kube-system
 ```
 
-## 4. 授予访问 PodGroup 的权限
+## 5. 授予访问 PodGroup 的权限
 
-chart 安装的调度器 ServiceAccount 无法读取 `PodGroup` 资源。补充权限：
+chart 安装的调度器 ServiceAccount 无法读取 `PodGroup` 资源。Coscheduling 插件只会读取它们——解析 Pod 所属的分组、统计同组成员数量，并与 `minMember` 比较——因此调度器只需要只读权限：
 
 ```yaml
 apiVersion: rbac.authorization.k8s.io/v1
@@ -126,7 +144,7 @@ metadata:
 rules:
   - apiGroups: ["scheduling.x-k8s.io"]
     resources: ["podgroups"]
-    verbs: ["get", "list", "watch", "create", "update", "patch"]
+    verbs: ["get", "list", "watch"]
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
@@ -139,12 +157,16 @@ roleRef:
 subjects:
   - kind: ServiceAccount
     name: hami-scheduler
-    namespace: hami-system
+    namespace: kube-system
 ```
 
-缺少该权限时，每个成员的 `PreFilter` 都会失败，整组 Pod 会一直处于 Pending。
+该 ServiceAccount 以 Helm release 名称命名：release 名为 `hami` 时对应 `hami-scheduler`。若使用了其他 release 名称或命名空间，请相应调整 `name` 与 `namespace`。
 
-## 5. 提交一个 gang
+对 `PodGroup.status` 的写入来自[步骤 3](#3-部署-scheduler-plugins-控制器)部署的控制器，它拥有自己的 ServiceAccount 与 RBAC，因此调度器在这里不需要 `create`、`update` 或 `patch` 权限。
+
+缺少该 ClusterRole 时，调度器的 PodGroup lister 始终为空。`PreFilter` 仍会通过 —— 它把无法解析的分组当作没有分组处理 —— 但随后 `Permit` 会以 `PodGroup not found` 拒绝每个成员，整组 Pod 一直处于 Pending。
+
+## 6. 提交一个 gang
 
 创建 `PodGroup`，并给每个成员打上分组名标签。成员照常申请 vGPU 资源：
 
@@ -176,7 +198,7 @@ spec:
           nvidia.com/gpucores: "30"
 ```
 
-上面的清单只定义了一个成员。请用同一份模板创建 `minMember` 个名称不同的 Pod，否则该组永远达不到法定成员数，所有成员都会停留在 Pending。
+上面的清单定义的是该 gang 中的一个 Pod。请创建更多带有相同 `scheduling.x-k8s.io/pod-group` 标签的 Pod 以满足 `minMember`。每个 Pod 的名称必须不同，否则该组无法达到所需的成员数量，这些 Pod 会一直停留在 Pending。
 
 :::warning
 
@@ -199,17 +221,12 @@ current pods number: 3, minMember of group: 5
 
 ## 调整节点锁
 
-有两个相互独立的超时控制节点锁行为。
-
-| 参数 | 默认值 | 说明 |
-| --- | --- | --- |
-| `--node-lock-retry-timeout` | `28s` | 对带有 `scheduling.x-k8s.io/pod-group` 标签的 Pod，`Bind` 重试节点锁的时长。设为 `0` 关闭重试，恢复快速失败行为。轮询间隔为 100 毫秒。 |
-| `--node-lock-timeout` | `5m` | 一把锁在被其他 Pod 接管前的有效期。对所有 Pod 生效，不限于 gang 成员。 |
+有两个扩展器参数控制节点锁行为：`--node-lock-retry-timeout` 限定 `Bind` 为分组成员重试被占用的锁的时长，`--node-lock-timeout` 限定一把锁在被其他 Pod 接管前的有效期。两者的完整说明见[全局配置](../configure.md#调度器配置扩展器参数)。
 
 通过 chart 设置重试超时。`scheduler.extender.extraArgs` 会替换整个默认列表，因此需要保留已有条目：
 
 ```bash
-helm upgrade hami hami-charts/hami -n hami-system --reuse-values \
+helm upgrade hami hami-charts/hami -n kube-system --reuse-values \
   --set-json 'scheduler.extender.extraArgs=["--debug","-v=4","--node-lock-retry-timeout=28s"]'
 ```
 
@@ -229,11 +246,15 @@ helm upgrade hami hami-charts/hami -n hami-system --reuse-values \
 
 **调度器容器启动后反复崩溃**
 
-在 kube-scheduler 日志中查找 `only one queue sort plugin required`。这表示 `PrioritySort` 仍与 Coscheduling 同时启用，见[步骤 3](#3-在调度器配置中启用-coscheduling)。
+在 kube-scheduler 日志中查找 `only one queue sort plugin required`。这表示 `PrioritySort` 仍与 Coscheduling 同时启用，见[步骤 4](#4-在调度器配置中启用-coscheduling)。
 
 **整组 Pod 一直 Pending 且从未选中节点**
 
-要么创建的成员数少于 `minMember`，要么调度器读不到 `PodGroup` 资源。检查 kube-scheduler 日志中的 `PreFilter failed`，并确认[步骤 4](#4-授予访问-podgroup-的权限)的 RBAC 已应用。
+要么创建的成员数少于 `minMember`，要么调度器读不到 `PodGroup` 资源。两种情况的日志不同：成员不足会在 `PreFilter` 阶段以 `cannot find enough sibling pods` 被拒绝，而 RBAC 缺失则表现为 `Permit` 阶段的 `PodGroup not found`。属于后者时，请确认[步骤 5](#5-授予访问-podgroup-的权限)的 RBAC 已应用。
+
+**`kubectl get podgroup` 看不到 status**
+
+`scheduler-plugins-controller` 缺失或反复崩溃。gang 调度本身仍然可用，只是看不到状态。执行 `kubectl get deploy -n scheduler-plugins` 检查，并确认[步骤 3](#3-部署-scheduler-plugins-控制器)已应用。如果控制器日志中出现 `podgroups/status` 的 `forbidden` 报错，说明其自身的 RBAC 未被创建，请重新应用该步骤中的清单。
 
 **容器报错 `libdl.so.2: cannot open shared object file`**
 
@@ -244,5 +265,5 @@ HAMi 注入的 `LD_PRELOAD` 指向基于 glibc 构建的 `libvgpu.so`。基于 m
 - [Coscheduling 插件](https://github.com/kubernetes-sigs/scheduler-plugins/tree/master/pkg/coscheduling)
 - [scheduler-plugins 版本列表](https://github.com/kubernetes-sigs/scheduler-plugins/releases)
 - [全局配置](../configure.md)
-- [在 Kueue 中使用 HAMi](../kueue/how-to-use-kueue.md)
+- [如何在 HAMi 上使用 Kueue](../kueue/how-to-use-kueue.md)
 - [如何在 KAI Scheduler 中使用 HAMi](../kai-scheduler/how-to-use-kai-scheduler.md)

--- a/i18n/zh/docusaurus-plugin-content-docs/current/userguide/coscheduling/how-to-use-coscheduling.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/current/userguide/coscheduling/how-to-use-coscheduling.md
@@ -1,0 +1,248 @@
+---
+title: 如何在 HAMi 中使用 Coscheduling
+sidebar_label: 如何使用 Coscheduling
+---
+
+[Coscheduling](https://github.com/kubernetes-sigs/scheduler-plugins/tree/master/pkg/coscheduling) 是 [kubernetes-sigs/scheduler-plugins](https://github.com/kubernetes-sigs/scheduler-plugins) 提供的调度插件，用于实现 gang scheduling。只有当一组 Pod 中至少 `minMember` 个可以同时被放置时，这组 Pod 才会被准入。这正是分布式训练所需要的语义：一个作业要么拿到全部 GPU，要么一个都不拿。
+
+本文介绍如何在 HAMi 调度器中运行 Coscheduling，以及如何调整 gang 绑定阶段会触发的节点锁行为。
+
+## 工作原理
+
+HAMi 与 Coscheduling 作用在调度周期的两个不同阶段。
+
+Coscheduling 作用于 **Permit** 阶段。每个通过过滤的成员 Pod 会被放入等待队列，当等待中的成员达到 `minMember` 时，它们会被同时释放进入绑定阶段。
+
+HAMi 通过扩展器作用于 **Bind** 阶段。绑定前，扩展器会在 Node 对象上写入 `hami.io/mutex.lock` 注解，从而获取该节点的锁：
+
+```text
+hami.io/mutex.lock: 2026-06-14T15:05:03Z,default,gang-pod-1
+```
+
+该锁用于串行化节点上的设备分配。如果没有它，同一时刻绑定的两个 Pod 会读到同一份设备使用快照，可能被分配到同一张 GPU 的重叠切片。锁由设备插件在 `Allocate()` 完成并更新 Pod 注解后释放，在真实 GPU 上耗时约 20 毫秒。若锁始终未被释放，则在节点锁超时（默认 5 分钟）后过期。
+
+这两个机制在 gang 释放时相遇。Coscheduling 会在同一毫秒内释放全部成员，因此当多个成员落在同一节点时，它们会争抢一把只持有几十毫秒的锁。抢锁失败的 Pod 绑定失败并回到 Pending，随后经由 kube-scheduler 的退避重试回来，而退避是以秒为单位的。5 个成员的 gang 最终会收敛，但需要经过多轮退避。
+
+为了消除这段空转，扩展器会为带有 Coscheduling 分组标签的 Pod 重试节点锁：
+
+- 带有非空 `scheduling.x-k8s.io/pod-group` 标签的 Pod 每 100 毫秒轮询一次锁，直到 `--node-lock-retry-timeout` 超时。
+- 每次重试前会释放已部分获取的锁，因此同时申请多个厂商设备的 Pod 不会残留过期锁。
+- 非锁争抢类错误会立即返回，不做重试。
+- 未带该标签的 Pod 保持原有的快速失败行为。
+
+:::note
+
+`--node-lock-retry-timeout` 在高于 v2.9.0 的版本中可用。
+
+:::
+
+## 前置条件
+
+- 一个已安装 HAMi 且具备 GPU 节点的 Kubernetes 集群。
+- 与集群 Kubernetes 次版本匹配的 [scheduler-plugins 版本](https://github.com/kubernetes-sigs/scheduler-plugins/releases)。下文示例使用 Kubernetes v1.35 与 v0.34.7。
+- Helm 3。
+- 具备 cluster-admin 权限的 `kubectl`。
+
+## 1. 使用 scheduler-plugins 的 kube-scheduler 安装 HAMi
+
+HAMi 调度器 Pod 中运行两个容器：上游 `kube-scheduler` 和 HAMi `vgpu-scheduler-extender`。Coscheduling 编译在 scheduler-plugins 版本的 kube-scheduler 中，因此需要把 chart 指向该镜像：
+
+```bash
+helm repo add hami-charts https://project-hami.github.io/HAMi/
+helm repo update
+
+helm install hami hami-charts/hami \
+  --namespace hami-system --create-namespace \
+  --set scheduler.kubeScheduler.image.registry=registry.k8s.io \
+  --set scheduler.kubeScheduler.image.repository=scheduler-plugins/kube-scheduler \
+  --set scheduler.kubeScheduler.image.tag=v0.34.7 \
+  --wait --timeout 10m
+```
+
+对已有安装，使用 `helm upgrade --reuse-values` 传入相同的三个 `--set` 参数。
+
+## 2. 安装 PodGroup CRD
+
+Coscheduling 读取 `PodGroup` 资源。从同一个 scheduler-plugins 版本安装 CRD：
+
+```bash
+kubectl apply -f https://raw.githubusercontent.com/kubernetes-sigs/scheduler-plugins/v0.34.7/config/crd/bases/scheduling.x-k8s.io_podgroups.yaml
+```
+
+## 3. 在调度器配置中启用 Coscheduling
+
+chart 会把 KubeSchedulerConfiguration 渲染到 `hami-scheduler` ConfigMap 中。将插件加入 profile：
+
+```bash
+kubectl edit configmap hami-scheduler -n hami-system
+```
+
+`profiles` 条目应如下所示：
+
+```yaml
+profiles:
+  - schedulerName: hami-scheduler
+    plugins:
+      multiPoint:
+        enabled:
+          - name: Coscheduling
+      queueSort:
+        disabled:
+          - name: PrioritySort
+    pluginConfig:
+      - name: Coscheduling
+        args:
+          permitWaitingTimeSeconds: 10
+```
+
+:::warning
+
+必须禁用 `PrioritySort`。Coscheduling 会注册自己的队列排序插件，而 kube-scheduler 在存在两个排序插件时拒绝启动：
+
+```text
+only one queue sort plugin required for profile with scheduler name "hami-scheduler", but got 2
+```
+
+:::
+
+该 ConfigMap 由 chart 管理，`helm upgrade` 会覆盖这次修改。每次升级后需要重新应用，或者把该 ConfigMap 移出 chart 自行管理。
+
+重启调度器使配置生效：
+
+```bash
+kubectl rollout restart deploy/hami-scheduler -n hami-system
+kubectl rollout status deploy/hami-scheduler -n hami-system
+```
+
+## 4. 授予访问 PodGroup 的权限
+
+chart 安装的调度器 ServiceAccount 无法读取 `PodGroup` 资源。补充权限：
+
+```yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: hami-podgroup-reader
+rules:
+  - apiGroups: ["scheduling.x-k8s.io"]
+    resources: ["podgroups"]
+    verbs: ["get", "list", "watch", "create", "update", "patch"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: hami-podgroup-reader
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: hami-podgroup-reader
+subjects:
+  - kind: ServiceAccount
+    name: hami-scheduler
+    namespace: hami-system
+```
+
+缺少该权限时，每个成员的 `PreFilter` 都会失败，整组 Pod 会一直处于 Pending。
+
+## 5. 提交一个 gang
+
+创建 `PodGroup`，并给每个成员打上分组名标签。成员照常申请 vGPU 资源：
+
+```yaml
+apiVersion: scheduling.x-k8s.io/v1alpha1
+kind: PodGroup
+metadata:
+  name: gang-training
+spec:
+  minMember: 4
+  scheduleTimeoutSeconds: 60
+---
+apiVersion: v1
+kind: Pod
+metadata:
+  name: gang-worker-1
+  labels:
+    scheduling.x-k8s.io/pod-group: gang-training
+spec:
+  schedulerName: hami-scheduler
+  containers:
+    - name: worker
+      image: ubuntu:22.04
+      command: ["sleep", "3600"]
+      resources:
+        limits:
+          nvidia.com/gpu: "1"
+          nvidia.com/gpumem: "3000"
+          nvidia.com/gpucores: "30"
+```
+
+上面的清单只定义了一个成员。请用同一份模板创建 `minMember` 个名称不同的 Pod，否则该组永远达不到法定成员数，所有成员都会停留在 Pending。
+
+:::warning
+
+`scheduling.x-k8s.io/pod-group` 必须放在 `metadata.labels` 下。放在 `metadata.annotations` 下会静默绕过全部 gang 逻辑，不产生任何报错：Pod 会无视 `minMember` 逐个被调度。
+
+:::
+
+确认整组被同时准入：
+
+```bash
+kubectl get pods -l scheduling.x-k8s.io/pod-group=gang-training -o wide
+```
+
+当成员数量少于 `minMember` 时，`PreFilter` 会在请求到达 HAMi 扩展器之前拒绝该组：
+
+```text
+pre-filter pod gang-worker-1 cannot find enough sibling pods,
+current pods number: 3, minMember of group: 5
+```
+
+## 调整节点锁
+
+有两个相互独立的超时控制节点锁行为。
+
+| 参数 | 默认值 | 说明 |
+| --- | --- | --- |
+| `--node-lock-retry-timeout` | `28s` | 对带有 `scheduling.x-k8s.io/pod-group` 标签的 Pod，`Bind` 重试节点锁的时长。设为 `0` 关闭重试，恢复快速失败行为。轮询间隔为 100 毫秒。 |
+| `--node-lock-timeout` | `5m` | 一把锁在被其他 Pod 接管前的有效期。对所有 Pod 生效，不限于 gang 成员。 |
+
+通过 chart 设置重试超时。`scheduler.extender.extraArgs` 会替换整个默认列表，因此需要保留已有条目：
+
+```bash
+helm upgrade hami hami-charts/hami -n hami-system --reuse-values \
+  --set-json 'scheduler.extender.extraArgs=["--debug","-v=4","--node-lock-retry-timeout=28s"]'
+```
+
+:::warning
+
+`--node-lock-retry-timeout` 必须小于 KubeSchedulerConfiguration 中扩展器的 `httpTimeout`，chart 将其设为 `30s`。如果重试时间超过该 HTTP 调用时长，kube-scheduler 会在扩展器仍在等锁时放弃这次绑定请求，Pod 将从头重新调度。
+
+:::
+
+默认值 `28s` 在 `30s` 超时之下预留了 2 秒余量。
+
+## 故障排查
+
+**Pod 持续 Pending，事件为 `BindingFailed: node <name> has been locked within 5m0s`**
+
+这些 Pod 上的重试没有生效。确认 `scheduling.x-k8s.io/pod-group` 标签打在 Pod 上（不能只打在 PodGroup 上，也不能放在 annotations 里），并确认 `--node-lock-retry-timeout` 没有被设为 `0`。
+
+**调度器容器启动后反复崩溃**
+
+在 kube-scheduler 日志中查找 `only one queue sort plugin required`。这表示 `PrioritySort` 仍与 Coscheduling 同时启用，见[步骤 3](#3-在调度器配置中启用-coscheduling)。
+
+**整组 Pod 一直 Pending 且从未选中节点**
+
+要么创建的成员数少于 `minMember`，要么调度器读不到 `PodGroup` 资源。检查 kube-scheduler 日志中的 `PreFilter failed`，并确认[步骤 4](#4-授予访问-podgroup-的权限)的 RBAC 已应用。
+
+**容器报错 `libdl.so.2: cannot open shared object file`**
+
+HAMi 注入的 `LD_PRELOAD` 指向基于 glibc 构建的 `libvgpu.so`。基于 musl 的镜像（如 `busybox`、`alpine`）无法加载它。GPU 工作负载请使用 glibc 镜像。
+
+## 相关链接
+
+- [Coscheduling 插件](https://github.com/kubernetes-sigs/scheduler-plugins/tree/master/pkg/coscheduling)
+- [scheduler-plugins 版本列表](https://github.com/kubernetes-sigs/scheduler-plugins/releases)
+- [全局配置](../configure.md)
+- [在 Kueue 中使用 HAMi](../kueue/how-to-use-kueue.md)
+- [如何在 KAI Scheduler 中使用 HAMi](../kai-scheduler/how-to-use-kai-scheduler.md)

--- a/sidebars.js
+++ b/sidebars.js
@@ -373,7 +373,7 @@ module.exports = {
             },
             {
               type: "category",
-              label: "Using HAMi with Coscheduling",
+              label: "Using Coscheduling with HAMi",
               items: ["userguide/coscheduling/how-to-use-coscheduling"],
             },
           ],

--- a/sidebars.js
+++ b/sidebars.js
@@ -371,6 +371,11 @@ module.exports = {
               label: "Using HAMi with KAI Scheduler",
               items: ["userguide/kai-scheduler/how-to-use-kai-scheduler"],
             },
+            {
+              type: "category",
+              label: "Using HAMi with Coscheduling",
+              items: ["userguide/coscheduling/how-to-use-coscheduling"],
+            },
           ],
         },
       ],


### PR DESCRIPTION
**What type of PR is this?**

/kind documentation

**What this PR does / why we need it**:

Project-HAMi/HAMi#2066 added a PodGroup-aware node lock retry in the
scheduler extender, along with the `--node-lock-retry-timeout` flag.
Neither the flag nor the Coscheduling setup it targets is documented
on the site today.

This adds:

- `userguide/coscheduling/how-to-use-coscheduling.md` covering how the
  Coscheduling Permit phase and the HAMi node lock interact, the setup
  steps (scheduler-plugins image, PodGroup CRD, scheduler config, RBAC,
  gang submission), node lock tuning, and troubleshooting.
- A new extender arguments section in `userguide/configure.md` for
  `--node-lock-retry-timeout` and `--node-lock-timeout`.

Setup steps and error messages come from testing on kind and on a k3s
cluster with a real T4, recorded in Project-HAMi/HAMi#1832.

The flag is not in v2.9.0, so both pages target `docs/` only.

**Which issue(s) this PR fixes**:

Fixes #733

**Checklist**:

- [x] `npm run lint` and `npm run format:check` pass
- [x] `npm run build` succeeds for both `en` and `zh`
- [x] Chinese translation updated if English docs changed (or noted why not)
- [x] Commits are signed off (`git commit -s`)

**AI assistance**: I used Claude Code to draft both pages from the merged
implementation and my earlier test notes, then verified every step against
the chart templates and the scheduler-plugins v0.34.7 release myself.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
  - Added English and Chinese guides for using HAMi with Kubernetes Coscheduling.
  - Documented installation, configuration, gang scheduling, PodGroup permissions, timeout tuning, and troubleshooting.
  - Added scheduler extender argument documentation, including node-lock timeout settings and Helm examples.
  - Added the Coscheduling guide to the documentation sidebar with Chinese localization.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->