### PR TITLE
Update CenCloud website URL in adopters.json

### DIFF
--- a/src/data/adopters.json
+++ b/src/data/adopters.json
@@ -22,7 +22,7 @@
     "name": "CenCloud",
     "nameZh": "琛云科技",
     "logo": "/img/adopters/cencloud.svg",
-    "website": ""
+    "website": "https://www.chenyuncloud.cn/"
   },
   {
     "name": "RiseUnion",


### PR DESCRIPTION
Update the website URL for CenCloud in the adopters.json file to reflect the correct link. This change ensures accurate information for users.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Updates**
  * Added CenCloud’s adopter website: https://www.chenyuncloud.cn/

<!-- end of auto-generated comment: release notes by coderabbit.ai -->