### PR TITLE
docs: update vGPU memory metric documentation

### DIFF
--- a/docs/userguide/monitoring/real-time-device-usage.md
+++ b/docs/userguide/monitoring/real-time-device-usage.md
@@ -21,7 +21,7 @@ It also exposes per-container and per-vGPU metrics for each scheduled task:
 | Metrics | Description | Example |
 | --- | --- | --- |
 | hami_container_device_utilization_ratio | Container device SM utilization ratio | `{container="cuda",device_uuid="GPU-00552014-5c87-89ac-b1a6-7b53aa24b0ec",namespace="default",pod="vgpu-share",vdevice_index="0",zone="vGPU"}` 0 |
-| hami_container_device_memory_bytes | Container device memory usage breakdown in bytes | `{buffer_size="0",container="cuda",context_size="0",device_uuid="GPU-00552014-5c87-89ac-b1a6-7b53aa24b0ec",module_size="0",namespace="default",offset="0",pod="vgpu-share",vdevice_index="0",zone="vGPU"}` 0 |
+| hami_container_device_memory_bytes | Container device memory usage in bytes | `{container="cuda",device_uuid="GPU-00552014-5c87-89ac-b1a6-7b53aa24b0ec",namespace="default",pod="vgpu-share",vdevice_index="0",zone="vGPU"}` 0 |
 | hami_container_last_kernel_elapsed_seconds | Seconds since last kernel execution in container | `{container="cuda",device_uuid="GPU-00552014-5c87-89ac-b1a6-7b53aa24b0ec",namespace="default",pod="vgpu-share",vdevice_index="0",zone="vGPU"}` 3664 |
 | hami_vgpu_memory_used_bytes | vGPU device memory usage in bytes | `{container="cuda",device_uuid="GPU-00552014-5c87-89ac-b1a6-7b53aa24b0ec",namespace="default",pod="vgpu-share",vdevice_index="0",zone="vGPU"}` 0 |
 | hami_vgpu_memory_limit_bytes | vGPU device memory limit in bytes | `{container="cuda",device_uuid="GPU-00552014-5c87-89ac-b1a6-7b53aa24b0ec",namespace="default",pod="vgpu-share",vdevice_index="0",zone="vGPU"}` 2.097152e+10 |
@@ -31,6 +31,6 @@ It also exposes per-container and per-vGPU metrics for each scheduled task:
 
 :::note
 
-The `context_size`, `module_size`, `buffer_size` and `offset` labels on `hami_container_device_memory_bytes` will be deprecated in v2.10.0. Use `hami_vgpu_memory_context_bytes`, `hami_vgpu_memory_module_bytes` and `hami_vgpu_memory_buffer_bytes` instead.
+In v2.10.0, `hami_container_device_memory_bytes` no longer includes the `context_size`, `module_size`, `buffer_size`, and `offset` labels. Context, module, and buffer memory are exposed through `hami_vgpu_memory_context_bytes`, `hami_vgpu_memory_module_bytes`, and `hami_vgpu_memory_buffer_bytes`.
 
 :::

--- a/i18n/zh/docusaurus-plugin-content-docs/current/userguide/monitoring/real-time-device-usage.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/current/userguide/monitoring/real-time-device-usage.md
@@ -22,7 +22,7 @@ curl {GPU 节点 IP}:31992/metrics
 | 指标 | 描述 | 示例 |
 | --- | --- | --- |
 | hami_container_device_utilization_ratio | 容器设备 SM 利用率 | `{container="cuda",device_uuid="GPU-00552014-5c87-89ac-b1a6-7b53aa24b0ec",namespace="default",pod="vgpu-share",vdevice_index="0",zone="vGPU"}` 0 |
-| hami_container_device_memory_bytes | 容器设备显存使用明细（字节） | `{buffer_size="0",container="cuda",context_size="0",device_uuid="GPU-00552014-5c87-89ac-b1a6-7b53aa24b0ec",module_size="0",namespace="default",offset="0",pod="vgpu-share",vdevice_index="0",zone="vGPU"}` 0 |
+| hami_container_device_memory_bytes | 容器设备显存使用量（字节） | `{container="cuda",device_uuid="GPU-00552014-5c87-89ac-b1a6-7b53aa24b0ec",namespace="default",pod="vgpu-share",vdevice_index="0",zone="vGPU"}` 0 |
 | hami_container_last_kernel_elapsed_seconds | 容器中自上次 kernel 执行以来经过的秒数 | `{container="cuda",device_uuid="GPU-00552014-5c87-89ac-b1a6-7b53aa24b0ec",namespace="default",pod="vgpu-share",vdevice_index="0",zone="vGPU"}` 3664 |
 | hami_vgpu_memory_used_bytes | vGPU 设备显存使用量（字节） | `{container="cuda",device_uuid="GPU-00552014-5c87-89ac-b1a6-7b53aa24b0ec",namespace="default",pod="vgpu-share",vdevice_index="0",zone="vGPU"}` 0 |
 | hami_vgpu_memory_limit_bytes | vGPU 设备显存上限（字节） | `{container="cuda",device_uuid="GPU-00552014-5c87-89ac-b1a6-7b53aa24b0ec",namespace="default",pod="vgpu-share",vdevice_index="0",zone="vGPU"}` 2.097152e+10 |
@@ -32,6 +32,6 @@ curl {GPU 节点 IP}:31992/metrics
 
 :::note
 
-`hami_container_device_memory_bytes` 上的 `context_size`、`module_size`、`buffer_size` 和 `offset` 标签将在 v2.10.0 中弃用，请改用 `hami_vgpu_memory_context_bytes`、`hami_vgpu_memory_module_bytes` 和 `hami_vgpu_memory_buffer_bytes`。
+在 v2.10.0 中，`hami_container_device_memory_bytes` 不再包含 `context_size`、`module_size`、`buffer_size` 和 `offset` 标签。context、module 和 buffer 显存分别通过 `hami_vgpu_memory_context_bytes`、`hami_vgpu_memory_module_bytes` 和 `hami_vgpu_memory_buffer_bytes` 指标提供。
 
 :::


### PR DESCRIPTION
**What type of PR is this?**

/kind documentation

**What this PR does / why we need it**:

The current vGPU monitoring docs still show labels that have been removed from `hami_container_device_memory_bytes`.

This PR:
- updates the metric description and example to match the current schema
- removes `context_size`, `module_size`, `buffer_size`, and `offset` from the example
- updates the v2.10.0 note to reference the separate context, module, and buffer memory metrics
- updates both English and Chinese current docs

The versioned v2.9.0 docs are unchanged.

**Which issue(s) this PR fixes**:

Related to Project-HAMi/HAMi#2356

Related to Project-HAMi/HAMi#2126 (vGPU observability documentation)

**Checklist**:

- [x] `npm run lint` and `npm run format:check` pass
- [x] `npm run build` succeeds
- [x] Chinese translation updated
- [x] Commits are signed off (`git commit -s`)

**AI assistance disclosure**:

AI assistance was used only for wording suggestions and verification guidance. I made the final decisions, reviewed the changes, and ran the checks myself.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated real-time device usage documentation to clarify that the container device memory metric reports total memory usage without memory-breakdown labels.
  * Noted that, since v2.10.0, context, module, and buffer memory are reported through separate vGPU metrics.
  * Updated both English and Chinese documentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->