### PR TITLE
feat: add COSCUP 2026 event landing page

### DIFF
--- a/src/components/EventLanding.js
+++ b/src/components/EventLanding.js
@@ -6,6 +6,8 @@ import { faDiscord, faGithub } from "@fortawesome/free-brands-svg-icons";
 import {
   faCalendarDays,
   faLocationDot,
+  faClock,
+  faDoorOpen,
   faFilePdf,
   faVideo,
 } from "@fortawesome/free-solid-svg-icons";
@@ -107,6 +109,19 @@ export default function EventLanding({ slug }) {
                 <FontAwesomeIcon icon={faLocationDot} className={styles.metaIcon} />
                 {pick(locale, event.location)}
               </span>
+              {event.startTime && (
+                <span className={styles.metaItem}>
+                  <FontAwesomeIcon icon={faClock} className={styles.metaIcon} />
+                  {event.startTime}
+                  {event.endTime ? ` - ${event.endTime}` : ""}
+                </span>
+              )}
+              {event.room && (
+                <span className={styles.metaItem}>
+                  <FontAwesomeIcon icon={faDoorOpen} className={styles.metaIcon} />
+                  {event.room}
+                </span>
+              )}
             </div>
             <p className={styles.description}>{pick(locale, event.description)}</p>
             {(event.externalUrl || event.talkUrl) && (

--- a/src/data/events.js
+++ b/src/data/events.js
@@ -115,6 +115,22 @@ const events = [
       en: "Taipei, Taiwan",
       zh: "中国台湾 台北",
     },
+    resources: {
+      communityFlyer: {
+        en: "Community Flyer",
+        zh: "社区宣传册",
+        url: "/resources/flyers/community-flyer.pdf",
+      },
+      talkSlides: {
+        en: "Talk Slides",
+        zh: "演讲幻灯片",
+        url: "/resources/2026-coscup/coscup_2026.pdf",
+      },
+    },
+    cta: {
+      discordUrl: "https://go.dynamia.ai/hami-chat-coscup",
+      githubUrl: "https://go.dynamia.ai/proj-hami-coscup",
+    },
     room: "TR214",
     description: {
       en: "GPUs are expensive. Kubernetes doesn't share them well yet, and DRA is still work in progress. HAMi brings heterogeneous GPU sharing to Kubernetes. This talk covers how HAMi hijacks CUDA calls without touching your application code, why memory isolation matters, and real production use cases where teams cut GPU costs by 40-60%.",

--- a/src/data/events.js
+++ b/src/data/events.js
@@ -102,6 +102,27 @@ const events = [
     talkUrl:
       "https://events.linuxfoundation.org/kubecon-cloudnativecon-japan/program/schedule/?id=1182713",
   },
+  {
+    slug: "coscup-2026",
+    title: {
+      en: "Running Multiple AI Workloads on One GPU with HAMi: Architecture and Gotchas",
+      zh: "用 HAMi 在一块 GPU 上运行多个 AI 工作负载：架构与注意事项",
+    },
+    date: "2026-08-09",
+    startTime: "11:20",
+    endTime: "11:50",
+    location: {
+      en: "Taipei, Taiwan",
+      zh: "中国台湾 台北",
+    },
+    room: "TR214",
+    description: {
+      en: "GPUs are expensive. Kubernetes doesn't share them well yet, and DRA is still work in progress. HAMi brings heterogeneous GPU sharing to Kubernetes. This talk covers how HAMi hijacks CUDA calls without touching your application code, why memory isolation matters, and real production use cases where teams cut GPU costs by 40-60%.",
+      zh: "GPU 很贵。Kubernetes 目前还无法很好地共享它们，DRA 仍在开发中。HAMi 为 Kubernetes 带来异构 GPU 共享。本演讲将介绍 HAMi 如何在不改动应用代码的情况下接管 CUDA 调用、为什么显存隔离至关重要，以及真实的生产用例——团队将 GPU 成本降低了 40-60%。",
+    },
+    externalUrl: "https://coscup.org/2026/en/",
+    talkUrl: "https://coscup.org/2026/en/session/BGYZ3B",
+  },
 ];
 
 export default events;

--- a/src/pages/landing/coscup-2026.js
+++ b/src/pages/landing/coscup-2026.js
@@ -1,0 +1,3 @@
+import EventLanding from "@site/src/components/EventLanding";
+
+export default () => <EventLanding slug="coscup-2026" />;

--- a/static/resources/2026-coscup/coscup_2026.pdf
+++ b/static/resources/2026-coscup/coscup_2026.pdf
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:e3ed0805676c0972f4524a2b6dde6c12d661dbe61f45ef8355ecce30bd59960b
+size 2897467


### PR DESCRIPTION
Add the COSCUP 2026 event with talk details, and extend the
EventLanding component to display start/end time and room.

Signed-off-by: Reza Jelveh <fishmangit@dynamia.ai>

**What type of PR is this?**

/kind documentation

**What this PR does / why we need it**:

CosCup landing


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a COSCUP 2026 event landing page with bilingual event details, schedule, venue, room, and session links.
  * Event metadata now displays start and end times, along with room information when available.
  * Added clock and door icons to improve event detail visibility and make key event information easier to scan.
  * Included links to event resources, calls to action, and individual sessions for convenient access.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->