### PR TITLE
fix: correct CTA spacing on Events page and add missing Event structured-data fields (#725)

### DIFF
--- a/src/components/EventLanding.js
+++ b/src/components/EventLanding.js
@@ -72,6 +72,26 @@ export default function EventLanding({ slug }) {
     description: pick(locale, event.description),
     image: bannerUrl ? `${siteConfig.url}${bannerUrl}` : undefined,
     eventAttendanceMode: "https://schema.org/OfflineEventAttendanceMode",
+    eventStatus: `https://schema.org/${event.eventStatus || "EventScheduled"}`,
+    organizer: {
+      "@type": "Organization",
+      name: "HAMi",
+      url: "https://project-hami.io/",
+    },
+    offers: {
+      "@type": "Offer",
+      url: event.externalUrl || `${siteConfig.url}/events/${event.slug}`,
+      price: event.price ?? "0",
+      priceCurrency: event.priceCurrency || "USD",
+      availability: "https://schema.org/InStock",
+      validFrom: event.offerValidFrom || event.date,
+    },
+    ...(event.speaker && {
+      performer: {
+        "@type": "Person",
+        name: event.speaker,
+      },
+    }),
   };
 
   return (

--- a/src/components/EventLanding.js
+++ b/src/components/EventLanding.js
@@ -56,53 +56,53 @@ export default function EventLanding({ slug }) {
       </Layout>
     );
   }
-const effectiveEventStatus = event.eventStatus || "EventScheduled";
+  const effectiveEventStatus = event.eventStatus || "EventScheduled";
 
-const eventJsonLd = {
-  "@context": "https://schema.org",
-  "@type": "Event",
-  name: pick(locale, event.title),
-  startDate: event.date,
-  endDate: event.endDate || event.date,
-  location: {
-    "@type": "Place",
-    name: pick(locale, event.location),
-    ...(event.address && {
-      address: { "@type": "PostalAddress", ...event.address },
-    }),
-  },
-  description: pick(locale, event.description),
-  image: bannerUrl ? `${siteConfig.url}${bannerUrl}` : undefined,
-  eventAttendanceMode: "https://schema.org/OfflineEventAttendanceMode",
-  eventStatus: `https://schema.org/${effectiveEventStatus}`,
-  organizer: {
-    "@type": "Organization",
-    name: "HAMi",
-    url: "https://project-hami.io/",
-  },
-  ...(event.speaker
-    ? {
-        performer: event.speaker
-          .split(",")
-          .map((name) => ({ "@type": "Person", name: name.trim() })),
-      }
-    : {}),
-  ...(event.price !== undefined || event.externalUrl
-    ? {
-        offers: {
-          "@type": "Offer",
-          url: event.externalUrl || `${siteConfig.url}/events/${event.slug}`,
-          price: event.price ?? "0",
-          priceCurrency: event.priceCurrency || "USD",
-          availability:
-            effectiveEventStatus === "EventScheduled"
-              ? "https://schema.org/InStock"
-              : "https://schema.org/SoldOut",
-          validFrom: event.offerValidFrom || event.date,
-        },
-      }
-    : {}),
-};
+  const eventJsonLd = {
+    "@context": "https://schema.org",
+    "@type": "Event",
+    name: pick(locale, event.title),
+    startDate: event.date,
+    endDate: event.endDate || event.date,
+    location: {
+      "@type": "Place",
+      name: pick(locale, event.location),
+      ...(event.address && {
+        address: { "@type": "PostalAddress", ...event.address },
+      }),
+    },
+    description: pick(locale, event.description),
+    image: bannerUrl ? `${siteConfig.url}${bannerUrl}` : undefined,
+    eventAttendanceMode: "https://schema.org/OfflineEventAttendanceMode",
+    eventStatus: `https://schema.org/${effectiveEventStatus}`,
+    organizer: {
+      "@type": "Organization",
+      name: "HAMi",
+      url: "https://project-hami.io/",
+    },
+    ...(event.speaker
+      ? {
+          performer: event.speaker
+            .split(",")
+            .map((name) => ({ "@type": "Person", name: name.trim() })),
+        }
+      : {}),
+    ...(event.price !== undefined || event.externalUrl
+      ? {
+          offers: {
+            "@type": "Offer",
+            url: event.externalUrl || `${siteConfig.url}/events/${event.slug}`,
+            price: event.price ?? "0",
+            priceCurrency: event.priceCurrency || "USD",
+            availability:
+              effectiveEventStatus === "EventScheduled"
+                ? "https://schema.org/InStock"
+                : "https://schema.org/SoldOut",
+            validFrom: event.offerValidFrom || event.date,
+          },
+        }
+      : {}),
+  };
 
   return (
     <Layout

--- a/src/components/EventLanding.js
+++ b/src/components/EventLanding.js
@@ -69,30 +69,31 @@ export default function EventLanding({ slug }) {
         address: { "@type": "PostalAddress", ...event.address },
       }),
     },
-    description: pick(locale, event.description),
-    image: bannerUrl ? `${siteConfig.url}${bannerUrl}` : undefined,
-    eventAttendanceMode: "https://schema.org/OfflineEventAttendanceMode",
-    eventStatus: `https://schema.org/${event.eventStatus || "EventScheduled"}`,
-    organizer: {
-      "@type": "Organization",
-      name: "HAMi",
-      url: "https://project-hami.io/",
-    },
-    offers: {
-      "@type": "Offer",
-      url: event.externalUrl || `${siteConfig.url}/events/${event.slug}`,
-      price: event.price ?? "0",
-      priceCurrency: event.priceCurrency || "USD",
-      availability: "https://schema.org/InStock",
-      validFrom: event.offerValidFrom || event.date,
-    },
-    ...(event.speaker && {
-      performer: event.speaker.split(",").map((name) => ({
-        "@type": "Person",
-        name: name.trim(),
-      })),
-    }),
-  };
+   description: pick(locale, event.description),
+  image: bannerUrl ? `${siteConfig.url}${bannerUrl}` : undefined,
+  eventAttendanceMode: "https://schema.org/OfflineEventAttendanceMode",
+  eventStatus: `https://schema.org/${event.eventStatus || "EventScheduled"}`,
+  organizer: {
+    "@type": "Organization",
+    name: "HAMi",
+    url: "https://project-hami.io/",
+  },
+  ...(event.price !== undefined || event.externalUrl
+    ? {
+        offers: {
+          "@type": "Offer",
+          url: event.externalUrl || `${siteConfig.url}/events/${event.slug}`,
+          price: event.price ?? "0",
+          priceCurrency: event.priceCurrency || "USD",
+          availability:
+            event.eventStatus === "EventScheduled"
+              ? "https://schema.org/InStock"
+              : "https://schema.org/SoldOut",
+          validFrom: event.offerValidFrom || event.date,
+        },
+      }
+    : {}),
+};
 
   return (
     <Layout

--- a/src/components/EventLanding.js
+++ b/src/components/EventLanding.js
@@ -56,28 +56,37 @@ export default function EventLanding({ slug }) {
       </Layout>
     );
   }
-  const eventJsonLd = {
-    "@context": "https://schema.org",
-    "@type": "Event",
-    name: pick(locale, event.title),
-    startDate: event.date,
-    endDate: event.endDate || event.date,
-    location: {
-      "@type": "Place",
-      name: pick(locale, event.location),
-      ...(event.address && {
-        address: { "@type": "PostalAddress", ...event.address },
-      }),
-    },
-   description: pick(locale, event.description),
+const effectiveEventStatus = event.eventStatus || "EventScheduled";
+
+const eventJsonLd = {
+  "@context": "https://schema.org",
+  "@type": "Event",
+  name: pick(locale, event.title),
+  startDate: event.date,
+  endDate: event.endDate || event.date,
+  location: {
+    "@type": "Place",
+    name: pick(locale, event.location),
+    ...(event.address && {
+      address: { "@type": "PostalAddress", ...event.address },
+    }),
+  },
+  description: pick(locale, event.description),
   image: bannerUrl ? `${siteConfig.url}${bannerUrl}` : undefined,
   eventAttendanceMode: "https://schema.org/OfflineEventAttendanceMode",
-  eventStatus: `https://schema.org/${event.eventStatus || "EventScheduled"}`,
+  eventStatus: `https://schema.org/${effectiveEventStatus}`,
   organizer: {
     "@type": "Organization",
     name: "HAMi",
     url: "https://project-hami.io/",
   },
+  ...(event.speaker
+    ? {
+        performer: event.speaker
+          .split(",")
+          .map((name) => ({ "@type": "Person", name: name.trim() })),
+      }
+    : {}),
   ...(event.price !== undefined || event.externalUrl
     ? {
         offers: {
@@ -86,7 +95,7 @@ export default function EventLanding({ slug }) {
           price: event.price ?? "0",
           priceCurrency: event.priceCurrency || "USD",
           availability:
-            event.eventStatus === "EventScheduled"
+            effectiveEventStatus === "EventScheduled"
               ? "https://schema.org/InStock"
               : "https://schema.org/SoldOut",
           validFrom: event.offerValidFrom || event.date,

--- a/src/components/EventLanding.js
+++ b/src/components/EventLanding.js
@@ -87,10 +87,10 @@ export default function EventLanding({ slug }) {
       validFrom: event.offerValidFrom || event.date,
     },
     ...(event.speaker && {
-      performer: {
+      performer: event.speaker.split(",").map((name) => ({
         "@type": "Person",
-        name: event.speaker,
-      },
+        name: name.trim(),
+      })),
     }),
   };
 

--- a/src/data/events.js
+++ b/src/data/events.js
@@ -6,7 +6,7 @@ const events = [
       zh: "从项目到生产：HAMi 与 Viettel Cloud 亮相 KCD 越南",
     },
     date: "2026-07-25",
-    speaker: "fishman, The Anh Nguyen",
+    speaker: "Reza Jelveh, The Anh Nguyen",
     location: {
       en: "Hanoi, Vietnam",
       zh: "越南 河内",

--- a/src/data/events.js
+++ b/src/data/events.js
@@ -6,6 +6,7 @@ const events = [
       zh: "从项目到生产：HAMi 与 Viettel Cloud 亮相 KCD 越南",
     },
     date: "2026-07-25",
+    speaker: "fishman, The Anh Nguyen",
     location: {
       en: "Hanoi, Vietnam",
       zh: "越南 河内",
@@ -47,6 +48,7 @@ const events = [
       zh: "HAMi 亮相 KubeCon 日本 2026",
     },
     date: "2026-07-28",
+    speaker: "Jeonghyun Kim, Reza Jelveh",
     endDate: "2026-07-30",
     location: {
       en: "Yokohama, Japan",

--- a/src/pages/events.module.css
+++ b/src/pages/events.module.css
@@ -295,17 +295,17 @@
 }
 
 .ctaList {
-  margin: 0 0 var(--hami-space-32);
+  margin: 0 auto var(--hami-space-32);
   padding: 0 0 0 2rem;
-  display: inline-flex;
+  display: flex;
   flex-direction: column;
   gap: var(--hami-space-8);
   color: var(--hami-color-muted);
   font-size: 0.96rem;
   line-height: 1.6;
   text-align: left;
+  max-width: fit-content;
 }
-
 /* ── dark mode ── */
 
 [data-theme="dark"] .dayCard {


### PR DESCRIPTION

<img width="1919" height="1032" alt="Screenshot 2026-08-10 115706" src="https://github.com/user-attachments/assets/88d02d3a-6d5d-4087-a264-8f67c6265ca1" />
Related to #725

## Changes

### UI fix — CTA spacing
The "Want to host or speak at a HAMi event?" section's `.ctaList` used
`display: inline-flex`, which caused the list to shrink-wrap to its content
width instead of behaving as a full block. At certain viewport widths and
zoom levels, this let the "Join the events channel on Discord" button crowd
directly into the list text instead of stacking cleanly below it.

Changed `.ctaList` to `display: flex` with `max-width: fit-content`, which
keeps the same centered, left-aligned visual layout but removes the inline
shrink-wrap behavior that caused the crowding.

### SEO fix — missing Event structured data
Per the Google Search Console warnings referenced in this issue, added the
following fields to the JSON-LD emitted by `EventLanding.js`:

- `organizer` — set to HAMi / project-hami.io for all events
- `eventStatus` — defaults to `EventScheduled`, overridable per event via
  an optional `eventStatus` field on the event object
- `offers` — defaults to a free offer (`price: "0"`), overridable per event
  via optional `price`/`priceCurrency` fields
- `performer` — renders only when an event defines a `speaker` field, so no
  event emits inaccurate performer data. Added `speaker` values for the two
  existing events (kcd-vietnam, kubecon-japan) based on the speakers named
  on their event banners.

## Testing
- Verified the CTA section stacks correctly (no crowding) across multiple
  zoom levels (90%–125%) and window widths.
- Verified the JSON-LD output locally on `/landing/kcd-vietnam` and
  `/landing/kubecon-japan` by inspecting the rendered
  `application/ld+json` script tag — confirmed `organizer`, `eventStatus`,
  `offers`, and `performer` are all present with correct structure
  (`performer` correctly emits as an array of separate `Person` objects
  for multi-speaker events).

## Out of scope
While testing the event landing pages, I noticed the banner image on
`/landing/kcd-vietnam` gets cropped due to `object-fit: cover` not suiting
its square aspect ratio. That's a separate visual issue unrelated to this
fix, so I'll track it as a follow-up PR.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **New Features**
  * Enhanced event metadata with status, organizer, speaker, and ticket information.
  * Added speaker names to selected event listings, including KCD Vietnam and KubeCon Japan.
  * Ticket details now include pricing, currency, availability, links, and validity dates when applicable.

* **Style**
  * Improved event call-to-action layout with better spacing, alignment, and sizing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->


Fixes #725