### PR TITLE
docs: fix global nvidia driver link in helm guide

### DIFF
--- a/docs/get-started/deploy-with-helm.md
+++ b/docs/get-started/deploy-with-helm.md
@@ -14,7 +14,7 @@ This guide covers:
 - [Helm](https://helm.sh/docs/) v3+
 - [kubectl](https://kubernetes.io/docs/tasks/tools/install-kubectl/) v1.23+
 - [CUDA](https://developer.nvidia.com/cuda-toolkit) v10.2+
-- [NVIDIA Driver](https://www.nvidia.cn/drivers/unix/) v440+
+- [NVIDIA Driver](https://www.nvidia.com/drivers/unix/) v440+
 
 ## Installation {#installation}
 


### PR DESCRIPTION
**What type of PR is this?**
/kind documentation

**What this PR does / why we need it**:
Updates the NVIDIA Driver link in `docs/get-started/deploy-with-helm.md` from the `.cn` localized domain to the global `.com` domain for consistency in English documentation.

**Which issue(s) this PR fixes**:
N/A

**Checklist**:
- [x] `npm run lint` and `npm run format:check` pass
- [x] `npm run build` succeeds for both `en` and `zh`
- [N/A] Chinese translation updated if English docs changed (URL fix for English docs link)
- [x] Commits are signed off (`git commit -s`)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the NVIDIA Driver prerequisite link to the global NVIDIA drivers site.
  * The required driver version remains v440 or later.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->