### PR TITLE
feat(events): add event index page and back navigation

### DIFF
--- a/src/components/EventLanding.js
+++ b/src/components/EventLanding.js
@@ -1,5 +1,6 @@
 import Layout from "@theme/Layout";
 import Head from "@docusaurus/Head";
+import Link from "@docusaurus/Link";
 import useDocusaurusContext from "@docusaurus/useDocusaurusContext";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import { faDiscord, faGithub } from "@fortawesome/free-brands-svg-icons";
@@ -14,15 +15,8 @@ import {
 import useBaseUrl from "@docusaurus/useBaseUrl";
 import events from "@site/src/data/events";
 import { formatDate, formatDateRange } from "@site/src/utils/date";
+import { isChinese, pick } from "@site/src/utils/i18n";
 import styles from "./EventLanding.module.css";
-
-function isChinese(locale) {
-  return locale.startsWith("zh");
-}
-
-function pick(locale, obj) {
-  return isChinese(locale) && obj.zh ? obj.zh : obj.en;
-}
 
 function utm(url, slug) {
   let u;
@@ -94,6 +88,9 @@ export default function EventLanding({ slug }) {
       <main className={styles.page}>
         <section className={styles.hero}>
           <div className="container">
+            <Link to="/landing" className={styles.backLink}>
+              ← {isZh ? "所有活动" : "All Events"}
+            </Link>
             {event.banner && (
               <img src={bannerUrl} alt={pick(locale, event.title)} className={styles.banner} />
             )}
@@ -243,6 +240,13 @@ export default function EventLanding({ slug }) {
                 </a>
               </div>
             </div>
+          </div>
+        </section>
+        <section className={styles.moreEvents}>
+          <div className="container">
+            <Link to="/landing" className={styles.backLink}>
+              ← {isZh ? "所有活动" : "All Events"}
+            </Link>
           </div>
         </section>
       </main>

--- a/src/components/EventLanding.js
+++ b/src/components/EventLanding.js
@@ -89,7 +89,7 @@ export default function EventLanding({ slug }) {
         <section className={styles.hero}>
           <div className="container">
             <Link to="/landing" className={styles.backLink}>
-              ← {isZh ? "所有活动" : "All Events"}
+              ← {isZh ? "落地页" : "Landing Pages"}
             </Link>
             {event.banner && (
               <img src={bannerUrl} alt={pick(locale, event.title)} className={styles.banner} />
@@ -244,8 +244,8 @@ export default function EventLanding({ slug }) {
         </section>
         <section className={styles.moreEvents}>
           <div className="container">
-            <Link to="/landing" className={styles.backLink}>
-              ← {isZh ? "所有活动" : "All Events"}
+            <Link to="/events" className={styles.backLink}>
+              ← {isZh ? "活动日历" : "Events Calendar"}
             </Link>
           </div>
         </section>

--- a/src/components/EventLanding.module.css
+++ b/src/components/EventLanding.module.css
@@ -70,6 +70,59 @@
   text-decoration: none;
 }
 
+/* Backlink */
+.backLink {
+  display: inline-block;
+  margin-bottom: var(--hami-space-16);
+  color: var(--hami-color-muted);
+  font-size: 0.95rem;
+  text-decoration: none;
+}
+
+.backLink:hover {
+  color: var(--hami-color-primary);
+  text-decoration: none;
+}
+
+.moreEvents {
+  padding: var(--hami-space-16) 0 var(--hami-space-48);
+  text-align: center;
+}
+
+/* Event list (landing index) */
+.eventList {
+  display: flex;
+  flex-direction: column;
+  gap: var(--hami-space-16);
+  margin-top: var(--hami-space-32);
+}
+
+.eventCard {
+  display: block;
+  padding: var(--hami-space-24) var(--hami-space-32);
+  text-decoration: none;
+  transition: border-color var(--hami-motion-fast);
+}
+
+.eventCard:hover {
+  border-color: var(--hami-color-primary);
+  text-decoration: none;
+}
+
+.eventTitle {
+  font-family: var(--hami-font-display);
+  font-size: 1.25rem;
+  font-weight: 700;
+  color: var(--hami-color-text);
+  margin-bottom: var(--hami-space-8);
+}
+
+.eventMeta {
+  color: var(--hami-color-muted);
+  font-size: 0.95rem;
+  margin: 0;
+}
+
 /* Case study */
 .caseStudySection {
   padding: var(--hami-space-32) 0;

--- a/src/pages/landing/index.js
+++ b/src/pages/landing/index.js
@@ -13,20 +13,20 @@ export default function EventLandingList() {
 
   return (
     <Layout
-      title={isZh ? "活动" : "Events"}
+      title={isZh ? "落地页 - 列表" : "Landing Pages"}
       description={
         isZh
-          ? "查看 HAMi 团队参与的活动与演讲，获取演讲幻灯片与社区资料。"
+          ? "查看 HAMi 团队的活动落地页，获取演讲详情与社区资料。"
           : "See the events and talks the HAMi team is part of, with slides and community resources."
       }
     >
       <main className={styles.page}>
         <section className={styles.hero}>
           <div className="container">
-            <h1 className={styles.title}>{isZh ? "活动" : "Events"}</h1>
+            <h1 className={styles.title}>{isZh ? "落地页" : "Landing Pages"}</h1>
             <p className={styles.description}>
               {isZh
-                ? "查看 HAMi 团队参与的活动与演讲，获取演讲幻灯片与社区资料。"
+                ? "查看 HAMi 团队的活动落地页，获取演讲详情与社区资料。"
                 : "See the events and talks the HAMi team is part of, with slides and community resources."}
             </p>
             <div className={styles.eventList}>

--- a/src/pages/landing/index.js
+++ b/src/pages/landing/index.js
@@ -1,0 +1,54 @@
+import Layout from "@theme/Layout";
+import Link from "@docusaurus/Link";
+import useDocusaurusContext from "@docusaurus/useDocusaurusContext";
+import events from "@site/src/data/events";
+import { formatDate, formatDateRange } from "@site/src/utils/date";
+import { isChinese, pick } from "@site/src/utils/i18n";
+import styles from "@site/src/components/EventLanding.module.css";
+
+export default function EventLandingList() {
+  const { i18n } = useDocusaurusContext();
+  const isZh = isChinese(i18n.currentLocale);
+  const locale = i18n.currentLocale;
+
+  return (
+    <Layout
+      title={isZh ? "活动" : "Events"}
+      description={
+        isZh
+          ? "查看 HAMi 团队参与的活动与演讲，获取演讲幻灯片与社区资料。"
+          : "See the events and talks the HAMi team is part of, with slides and community resources."
+      }
+    >
+      <main className={styles.page}>
+        <section className={styles.hero}>
+          <div className="container">
+            <h1 className={styles.title}>{isZh ? "活动" : "Events"}</h1>
+            <p className={styles.description}>
+              {isZh
+                ? "查看 HAMi 团队参与的活动与演讲，获取演讲幻灯片与社区资料。"
+                : "See the events and talks the HAMi team is part of, with slides and community resources."}
+            </p>
+            <div className={styles.eventList}>
+              {events.map((e) => (
+                <Link
+                  key={e.slug}
+                  to={`/landing/${e.slug}`}
+                  className={`hami-section-card ${styles.eventCard}`}
+                >
+                  <h3 className={styles.eventTitle}>{pick(locale, e.title)}</h3>
+                  <p className={styles.eventMeta}>
+                    {e.endDate
+                      ? formatDateRange(e.date, e.endDate, locale)
+                      : formatDate(e.date, locale)}
+                    {e.location ? ` - ${pick(locale, e.location)}` : ""}
+                  </p>
+                </Link>
+              ))}
+            </div>
+          </div>
+        </section>
+      </main>
+    </Layout>
+  );
+}

--- a/src/utils/i18n.js
+++ b/src/utils/i18n.js
@@ -1,0 +1,7 @@
+export function isChinese(locale) {
+  return locale.startsWith("zh");
+}
+
+export function pick(locale, obj) {
+  return isChinese(locale) && obj.zh ? obj.zh : obj.en;
+}


### PR DESCRIPTION
**What type of PR is this?**

/kind feature

**What this PR does / why we need it**:

Add /landing index page listing all events, link back to it from
event detail pages, and extract i18n helpers into src/utils/i18n.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a localized events landing page with event titles, dates, locations, and links to event details.
  * Added navigation links to return to the events landing page and browse more events.
  * Added event cards with improved layout, spacing, hover effects, and metadata styling.
  * Added Chinese-language detection and fallback support for event content and page metadata.
  * Added support for displaying both single-event dates and date ranges.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->