### PR TITLE
fix: balance EventLanding hero on wide screens

### DIFF
--- a/src/components/EventLanding.js
+++ b/src/components/EventLanding.js
@@ -124,7 +124,7 @@ export default function EventLanding({ slug }) {
                 )}
               </div>
               <aside className={styles.heroAside} aria-label={isZh ? "活动信息" : "Event details"}>
-                <div className={`hami-section-card ${styles.detailsCard}`}>
+                <div className={styles.detailsCard}>
                   <div className={styles.meta}>
                     <span className={styles.metaItem}>
                       <FontAwesomeIcon icon={faCalendarDays} className={styles.metaIcon} />

--- a/src/components/EventLanding.js
+++ b/src/components/EventLanding.js
@@ -95,57 +95,69 @@ export default function EventLanding({ slug }) {
               <img src={bannerUrl} alt={pick(locale, event.title)} className={styles.banner} />
             )}
             <h1 className={styles.title}>{pick(locale, event.title)}</h1>
-            <div className={styles.meta}>
-              <span className={styles.metaItem}>
-                <FontAwesomeIcon icon={faCalendarDays} className={styles.metaIcon} />
-                {event.endDate
-                  ? formatDateRange(event.date, event.endDate, locale)
-                  : formatDate(event.date, locale)}
-              </span>
-              <span className={styles.metaItem}>
-                <FontAwesomeIcon icon={faLocationDot} className={styles.metaIcon} />
-                {pick(locale, event.location)}
-              </span>
-              {event.startTime && (
-                <span className={styles.metaItem}>
-                  <FontAwesomeIcon icon={faClock} className={styles.metaIcon} />
-                  {event.startTime}
-                  {event.endTime ? ` - ${event.endTime}` : ""}
-                  {event.timeZone ? ` ${event.timeZone}` : ""}
-                </span>
-              )}
-              {event.room && (
-                <span className={styles.metaItem}>
-                  <FontAwesomeIcon icon={faDoorOpen} className={styles.metaIcon} />
-                  {event.room}
-                </span>
-              )}
-            </div>
-            <p className={styles.description}>{pick(locale, event.description)}</p>
-            {(event.externalUrl || event.talkUrl) && (
-              <div className={styles.heroLinks}>
-                {event.externalUrl && (
-                  <a
-                    href={event.externalUrl}
-                    className={styles.externalLink}
-                    target="_blank"
-                    rel="noopener noreferrer"
-                  >
-                    {isZh ? "查看活动官网" : "Event Website"} →
-                  </a>
-                )}
-                {event.talkUrl && (
-                  <a
-                    href={event.talkUrl}
-                    className={styles.externalLink}
-                    target="_blank"
-                    rel="noopener noreferrer"
-                  >
-                    {isZh ? "查看演讲详情" : "Talk Details"} →
-                  </a>
+            <div className={styles.heroBody}>
+              <div className={styles.heroMain}>
+                <p className={styles.description}>{pick(locale, event.description)}</p>
+                {(event.externalUrl || event.talkUrl) && (
+                  <div className={styles.heroLinks}>
+                    {event.externalUrl && (
+                      <a
+                        href={event.externalUrl}
+                        className={styles.externalLink}
+                        target="_blank"
+                        rel="noopener noreferrer"
+                      >
+                        {isZh ? "查看活动官网" : "Event Website"} →
+                      </a>
+                    )}
+                    {event.talkUrl && (
+                      <a
+                        href={event.talkUrl}
+                        className={styles.externalLink}
+                        target="_blank"
+                        rel="noopener noreferrer"
+                      >
+                        {isZh ? "查看演讲详情" : "Talk Details"} →
+                      </a>
+                    )}
+                  </div>
                 )}
               </div>
-            )}
+              <aside className={styles.heroAside} aria-label={isZh ? "活动信息" : "Event details"}>
+                <div className={`hami-section-card ${styles.detailsCard}`}>
+                  <div className={styles.meta}>
+                    <span className={styles.metaItem}>
+                      <FontAwesomeIcon icon={faCalendarDays} className={styles.metaIcon} />
+                      <span>
+                        {event.endDate
+                          ? formatDateRange(event.date, event.endDate, locale)
+                          : formatDate(event.date, locale)}
+                      </span>
+                    </span>
+                    <span className={styles.metaItem}>
+                      <FontAwesomeIcon icon={faLocationDot} className={styles.metaIcon} />
+                      <span>{pick(locale, event.location)}</span>
+                    </span>
+                    {event.startTime && (
+                      <span className={styles.metaItem}>
+                        <FontAwesomeIcon icon={faClock} className={styles.metaIcon} />
+                        <span>
+                          {event.startTime}
+                          {event.endTime ? ` - ${event.endTime}` : ""}
+                          {event.timeZone ? ` ${event.timeZone}` : ""}
+                        </span>
+                      </span>
+                    )}
+                    {event.room && (
+                      <span className={styles.metaItem}>
+                        <FontAwesomeIcon icon={faDoorOpen} className={styles.metaIcon} />
+                        <span>{event.room}</span>
+                      </span>
+                    )}
+                  </div>
+                </div>
+              </aside>
+            </div>
           </div>
         </section>
 

--- a/src/components/EventLanding.module.css
+++ b/src/components/EventLanding.module.css
@@ -36,12 +36,16 @@
 
 .heroAside {
   min-width: 0;
+  position: sticky;
+  top: calc(var(--ifm-navbar-height) + var(--hami-space-16));
 }
 
 .detailsCard {
   padding: var(--hami-space-24);
-  position: sticky;
-  top: calc(var(--ifm-navbar-height) + var(--hami-space-16));
+  background: var(--hami-color-surface);
+  border: 1px solid var(--hami-color-border);
+  border-radius: var(--hami-radius-md);
+  box-shadow: var(--hami-shadow-sm);
 }
 
 .meta {
@@ -304,9 +308,6 @@
 
   .heroAside {
     order: -1;
-  }
-
-  .detailsCard {
     position: static;
   }
 }

--- a/src/components/EventLanding.module.css
+++ b/src/components/EventLanding.module.css
@@ -19,23 +19,50 @@
 .title {
   font-family: var(--hami-font-display);
   font-size: var(--hami-text-h1);
-  margin-bottom: var(--hami-space-16);
+  margin-bottom: var(--hami-space-24);
   color: var(--hami-color-text);
+}
+
+.heroBody {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) minmax(240px, 320px);
+  gap: var(--hami-space-32);
+  align-items: start;
+}
+
+.heroMain {
+  min-width: 0;
+}
+
+.heroAside {
+  min-width: 0;
+}
+
+.detailsCard {
+  padding: var(--hami-space-24);
+  position: sticky;
+  top: calc(var(--ifm-navbar-height) + var(--hami-space-16));
 }
 
 .meta {
   display: flex;
-  flex-wrap: wrap;
-  gap: var(--hami-space-24);
-  margin-bottom: var(--hami-space-24);
+  flex-direction: column;
+  gap: var(--hami-space-16);
+  margin: 0;
 }
 
 .metaItem {
-  display: inline-flex;
-  align-items: center;
-  gap: var(--hami-space-8);
+  display: flex;
+  align-items: flex-start;
+  gap: var(--hami-space-12);
   font-size: 1.05rem;
+  line-height: 1.45;
   color: var(--hami-color-muted);
+}
+
+.metaItem > span {
+  min-width: 0;
+  flex: 1;
 }
 
 .metaIcon {
@@ -43,10 +70,12 @@
   font-size: 0.95rem;
   width: 0.95em;
   height: 0.95em;
+  flex-shrink: 0;
+  margin-top: 0.2em;
 }
 
 .description {
-  max-width: 720px;
+  margin: 0;
   font-size: 1.1rem;
   line-height: 1.7;
   color: var(--hami-color-muted);
@@ -56,7 +85,7 @@
   display: flex;
   flex-wrap: wrap;
   gap: var(--hami-space-16);
-  margin-top: var(--hami-space-16);
+  margin-top: var(--hami-space-24);
 }
 
 .externalLink {
@@ -265,4 +294,19 @@
 
 .btnIcon {
   margin-right: var(--hami-space-8);
+}
+
+@media (max-width: 996px) {
+  .heroBody {
+    grid-template-columns: 1fr;
+    gap: var(--hami-space-24);
+  }
+
+  .heroAside {
+    order: -1;
+  }
+
+  .detailsCard {
+    position: static;
+  }
 }


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

**What this PR does / why we need it**:

Event landing pages capped the description at 720px, so wide screens had a big empty gap on the right. Moved date/location/time into a side card next to the description so the layout fills naturally.

**Which issue(s) this PR fixes**:

Fixes #749

**Before:**

Description stuck at 720px max-width, empty space on the right on widescreen.

<img width="4620" height="2136" alt="image" src="https://github.com/user-attachments/assets/141d44cd-2eba-4c00-b5c0-c7347c613cd9" />


**After:**

Description + links on the left, event details card (date / location / time / room) on the right; stacks on smaller screens.

<img width="1836" height="944" alt="image" src="https://github.com/user-attachments/assets/fe8bf230-d7fe-451f-9924-50c9a3f41485" />

**Checklist**:

- [x] `npm run lint` and `npm run format:check` pass
- [x] `npm run build` succeeds for both `en` and `zh`
- [x] Chinese translation updated if English docs changed (or noted why not)
- [x] Commits are signed off (`git commit -s`)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Reorganized event hero content into a clearer two-column layout.
  * Added an accessible details card for event date, location, time, room, and links.
  * Improved spacing, alignment, icon sizing, and metadata presentation.
  * Added responsive behavior for smaller screens, including a single-column layout and reordered content.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->