### PR TITLE
fix(tutorials): correct gpucores unit (30% not 30 cores) and clean up formatting

### DIFF
--- a/i18n/zh/docusaurus-plugin-content-docs-tutorials/current/labs/local-fake-gpu.md
+++ b/i18n/zh/docusaurus-plugin-content-docs-tutorials/current/labs/local-fake-gpu.md
@@ -242,8 +242,6 @@ echo "NODE_NAME=${NODE_NAME}"
 | macOS | `orbstack`               |
 | Linux | `hami-lab-control-plane` |
 
----
-
 :::info[步骤 2–7 在两个平台上完全相同]
 
 从这里开始，所有命令在 macOS 和 Linux 上完全一致。你唯一会注意到的区别是示例输出中的节点名称。

--- a/i18n/zh/docusaurus-plugin-content-docs-tutorials/current/labs/nvml-mock.md
+++ b/i18n/zh/docusaurus-plugin-content-docs-tutorials/current/labs/nvml-mock.md
@@ -485,7 +485,7 @@ EOF
 
 :::info
 
-资源限制格式 `nvidia.com/gpumem` 接受**以 MiB 为单位的绝对值**：`"10"` 表示 10 MiB。`nvidia.com/gpucores: "30"` 表示在所选 GPU 上申请 30 个计算核心。
+资源限制格式 `nvidia.com/gpumem` 接受**以 MiB 为单位的绝对值**：`"10"` 表示 10 MiB。`nvidia.com/gpucores: "30"` 表示在所选 GPU 上申请 30% 的计算算力。
 
 :::
 
@@ -501,7 +501,7 @@ kubectl describe pod gpu-limits | grep vgpu-devices-allocated
 hami.io/vgpu-devices-allocated: GPU-12345678-1234-1234-1234-123456780002,NVIDIA,10,30:;
 ```
 
-注解记录了 `10` MiB 和 `30` 个核心，正是所申请的值。
+注解记录了 `10` MiB 和 `30`（即 30% 的计算算力），正是所申请的值。
 
 ---
 
@@ -646,7 +646,7 @@ kubectl get pod gpu-multi \
 | 基础 GPU 调度 | `gpu-test-1` | 注解显示 1 个 vGPU UUID + 40960 MiB |
 | GPU 共享（时间片） | `gpu-test-1` 到 `gpu-test-4` | 4 个 Pod 并发运行 |
 | 显存限制（`gpumem`） | `gpu-limits` | 注解显示 `10` MiB |
-| 算力限制（`gpucores`） | `gpu-limits` | 注解显示 `30` 个核心 |
+| 算力限制（`gpucores`） | `gpu-limits` | 注解显示 `30`（30% 的计算算力） |
 | 百分比显存（`gpumem-percentage`） | `gpu-mem-30pct` | 注解显示 `12288` MiB（A100 的 30%） |
 | 多 GPU 分配 | `gpu-multi` | hami-scheduler 事件显示 `BindingSucceed` |
 

--- a/i18n/zh/docusaurus-plugin-content-docs-tutorials/current/labs/nvml-mock.md
+++ b/i18n/zh/docusaurus-plugin-content-docs-tutorials/current/labs/nvml-mock.md
@@ -138,8 +138,6 @@ Windows 用户请使用 [WSL2](https://learn.microsoft.com/zh-cn/windows/wsl/ins
 
 :::
 
----
-
 ## 步骤 1：创建 kind 集群
 
 ```bash
@@ -158,8 +156,6 @@ echo "NODE_NAME=${NODE_NAME}"
 ```plaintext
 NODE_NAME=nvml-mock-test-control-plane
 ```
-
----
 
 ## 步骤 2：构建并部署 nvml-mock
 
@@ -210,8 +206,6 @@ NAME                             GPU_PRESENT
 nvml-mock-test-control-plane     true
 ```
 
----
-
 ## 步骤 3：基于 `main` 分支构建 HAMi
 
 `main` 分支包含一个修复：当未启用 MIG 时，阻止调用 `nvidia-mig-parted`。从源码构建可确保该修复已包含在内，无需等待正式发布版本。
@@ -244,8 +238,6 @@ kind load docker-image hami:local --name nvml-mock-test
 ```
 
 调度器和 device-plugin 二进制文件都打包在单个 `hami:local` 镜像中。
-
----
 
 ## 步骤 4：部署 HAMi
 
@@ -332,8 +324,6 @@ hami-scheduler-7858c744cc-7pb79   2/2     Running            0          13m
 
 :::
 
----
-
 ## 步骤 5：验证 GPU 资源
 
 HAMi 将每张物理 GPU 切分成 10 个虚拟槽位。节点有 8 张物理 GPU，因此应该对外提供 **80** 个可分配的虚拟 GPU。
@@ -352,8 +342,6 @@ kubectl describe node ${NODE_NAME} | grep nvidia.com/gpu
 ```
 
 `Capacity` 和 `Allocatable` 都显示 `80`，确认 device-plugin 已注册全部虚拟 GPU 槽位。最后一行是 `Allocated resources` 表，当前为 `0`，因为还没有 Pod 申请 GPU。
-
----
 
 ## 步骤 6：测试基础 GPU 调度
 
@@ -406,8 +394,6 @@ hami.io/vgpu-devices-allocated: GPU-12345678-1234-1234-1234-123456780006,NVIDIA,
 
 > 注解格式为 `<UUID>,<厂商>,<显存MiB>,<算力>`。A100 GPU 有 40960 MiB 显存，看到这个注解即确认调度器分配并记录了一个虚拟 GPU。
 
----
-
 ## 步骤 7：测试 GPU 共享（时间片）
 
 再部署三个 Pod，每个申请 1 张 GPU：
@@ -457,8 +443,6 @@ gpu-test-4   1/1     Running   0          9s
 
 四个 Pod 并发运行在 80 个虚拟 GPU 槽位的资源池上。调度器通过各自独立的 `vgpu-devices-allocated` 注解独立跟踪每次分配。
 
----
-
 ## 步骤 8：测试显存和算力限制
 
 ```bash
@@ -502,8 +486,6 @@ hami.io/vgpu-devices-allocated: GPU-12345678-1234-1234-1234-123456780002,NVIDIA,
 ```
 
 注解记录了 `10` MiB 和 `30`（即 30% 的计算算力），正是所申请的值。
-
----
 
 ## 步骤 9：测试百分比显存申请
 
@@ -565,8 +547,6 @@ GPU-12345678-1234-1234-1234-123456780003,NVIDIA,12288,100:;
 ```
 
 > 第三个字段显示 `12288` MiB（即 40960 MiB 的 30%），确认调度器正确地将百分比转换为本次分配的绝对显存预算。
-
----
 
 ## 步骤 10：测试多 GPU 分配
 
@@ -637,8 +617,6 @@ kubectl get pod gpu-multi \
 
 :::
 
----
-
 ## 已验证功能总结
 
 | 功能 | 测试 Pod | 如何验证 |
@@ -658,8 +636,6 @@ kubectl get pod gpu-multi \
 - 显存超卖和显存覆盖功能
 
 :::
-
----
 
 ## 清理
 
@@ -699,8 +675,6 @@ kind delete cluster --name nvml-mock-test
 如果你想保留环境以便继续实验，可以跳过删除集群这一步。
 
 :::
-
----
 
 ## 下一步
 

--- a/i18n/zh/docusaurus-plugin-content-docs-tutorials/current/labs/online-install.md
+++ b/i18n/zh/docusaurus-plugin-content-docs-tutorials/current/labs/online-install.md
@@ -54,8 +54,6 @@ flowchart LR
 
 > 费用提示：`n1-standard-4` + T4 虚拟机约 $0.55/小时。[实验 3](./gpu-partitioning.md) 和[实验 4](./hami-dra.md) 直接复用这套集群，一次开机即可完成全部三个实验。实验结束后请删除虚拟机。
 
----
-
 ## 步骤 1: 创建 GCP 虚拟机
 
 ### 目的
@@ -324,8 +322,6 @@ prometheus-prometheus-node-exporter-xxxxx              1/1     Running   0      
 
 > 如果安装失败，需要先卸载再重装：`helm uninstall -n monitoring prometheus`
 
----
-
 ## 步骤 5: 安装 GPU Operator
 
 ### 目的
@@ -395,8 +391,6 @@ kubectl -n gpu-operator exec -it $(kubectl get pods -n gpu-operator -l app=nvidi
 | N/A   64C    P8             17W /   70W |       1MiB /  15360MiB |      0%      Default |
 +-----------------------------------------------------------------------------------------+
 ```
-
----
 
 ## 步骤 6: 安装 HAMi
 

--- a/i18n/zh/docusaurus-plugin-content-docs-tutorials/current/labs/topology-aware-scheduling.md
+++ b/i18n/zh/docusaurus-plugin-content-docs-tutorials/current/labs/topology-aware-scheduling.md
@@ -203,8 +203,6 @@ NODE_NAME=$(kubectl get nodes -o jsonpath='{.items[0].metadata.name}')
 echo "NODE_NAME=${NODE_NAME}"
 ```
 
----
-
 :::info[后续大部分步骤在两个平台上是一致的]
 
 从这里开始，大多数命令在 macOS 和 Linux 上是一致的。仍有少数步骤存在差异 —— 步骤 2.3 和步骤 3.1 中分别有一条仅 Linux 需要执行的额外 `kind load` 命令 —— 其余部分完全相同，只是示例输出中的节点名不同。

--- a/tutorials/labs/local-fake-gpu.md
+++ b/tutorials/labs/local-fake-gpu.md
@@ -242,8 +242,6 @@ echo "NODE_NAME=${NODE_NAME}"
 | macOS    | `orbstack`               |
 | Linux    | `hami-lab-control-plane` |
 
----
-
 :::info[Steps 2–7 are identical on both platforms]
 
 From here on, all commands work the same on macOS and Linux. The only difference you will notice is your node name in example outputs.

--- a/tutorials/labs/nvml-mock.md
+++ b/tutorials/labs/nvml-mock.md
@@ -138,8 +138,6 @@ Windows users Use [WSL2](https://learn.microsoft.com/en-us/windows/wsl/install) 
 
 :::
 
----
-
 ## Step 1: Create the kind Cluster
 
 ```bash
@@ -158,8 +156,6 @@ Example output:
 ```plaintext
 NODE_NAME=nvml-mock-test-control-plane
 ```
-
----
 
 ## Step 2: Build and Deploy nvml-mock
 
@@ -210,8 +206,6 @@ NAME                             GPU_PRESENT
 nvml-mock-test-control-plane     true
 ```
 
----
-
 ## Step 3: Build HAMi from the `main` Branch
 
 The `main` branch contains a fix preventing `nvidia-mig-parted` from being called when MIG is not enabled. Building from source ensures the fix is present without waiting for a tagged release.
@@ -244,8 +238,6 @@ kind load docker-image hami:local --name nvml-mock-test
 ```
 
 Both the scheduler and device-plugin binaries are packaged into the single `hami:local` image.
-
----
 
 ## Step 4: Deploy HAMi
 
@@ -332,8 +324,6 @@ The `vgpu-monitor` sidecar crashes because it requires real GPU monitoring infra
 
 :::
 
----
-
 ## Step 5: Verify GPU Resources
 
 HAMi partitions each physical GPU into 10 virtual slots. With 8 physical GPUs the node should advertise **80** allocatable virtual GPUs.
@@ -352,8 +342,6 @@ Expected output:
 ```
 
 Both `Capacity` and `Allocatable` showing `80` confirms the device-plugin registered all virtual GPU slots. The final line is the `Allocated resources` table — currently `0` because no Pods have claimed GPUs yet.
-
----
 
 ## Step 6: Test Basic GPU Scheduling
 
@@ -406,8 +394,6 @@ hami.io/vgpu-devices-allocated: GPU-12345678-1234-1234-1234-123456780006,NVIDIA,
 
 > The annotation format is `<UUID>,<vendor>,<memMiB>,<cores>`. A100 GPUs have 40960 MiB of VRAM — seeing this annotation confirms one virtual GPU was allocated and recorded by the scheduler.
 
----
-
 ## Step 7: Test GPU Sharing (Time-slicing)
 
 Deploy three more Pods each requesting 1 GPU:
@@ -457,8 +443,6 @@ gpu-test-4   1/1     Running   0          9s
 
 All four Pods run concurrently against the pool of 80 virtual GPU slots. The scheduler independently tracks each allocation via its own `vgpu-devices-allocated` annotation.
 
----
-
 ## Step 8: Test Memory and Core Limits
 
 ```bash
@@ -502,8 +486,6 @@ hami.io/vgpu-devices-allocated: GPU-12345678-1234-1234-1234-123456780002,NVIDIA,
 ```
 
 The annotation records `10` MiB and `30` (30% of the GPU's compute cores) — exactly the values requested.
-
----
 
 ## Step 9: Test Percentage-Based Memory Request
 
@@ -565,8 +547,6 @@ GPU-12345678-1234-1234-1234-123456780003,NVIDIA,12288,100:;
 ```
 
 > The third field shows `12288` MiB — 30% of 40960 MiB — confirming the scheduler correctly translated the percentage into an absolute memory budget for the allocation.
-
----
 
 ## Step 10: Test Multi-GPU Allocation
 
@@ -637,8 +617,6 @@ You will see two semicolon-separated device entries, one per allocated vGPU slot
 
 :::
 
----
-
 ## Summary of Verified Features
 
 | Feature | Test Pod | How It Is Verified |
@@ -658,8 +636,6 @@ You will see two semicolon-separated device entries, one per allocated vGPU slot
 - Memory overcommit and memory override features
 
 :::
-
----
 
 ## Cleanup
 
@@ -699,8 +675,6 @@ kind delete cluster --name nvml-mock-test
 Skip the cluster deletion step if you want to keep the environment for further experimentation.
 
 :::
-
----
 
 ## Next Steps
 

--- a/tutorials/labs/nvml-mock.md
+++ b/tutorials/labs/nvml-mock.md
@@ -469,7 +469,7 @@ EOF
 
 :::info
 
-Resource Limits Format `nvidia.com/gpumem` takes an **absolute value in MiB** — `"10"` means 10 MiB. `nvidia.com/gpucores: "30"` requests 30% of the compute cores on the selected GPU.
+Resource Limits Format `nvidia.com/gpumem` takes an **absolute value in MiB** — `"10"` means 10 MiB. `nvidia.com/gpucores: "30"` requests 30% of the selected GPU's compute capacity.
 
 :::
 
@@ -485,7 +485,7 @@ Expected output:
 hami.io/vgpu-devices-allocated: GPU-12345678-1234-1234-1234-123456780002,NVIDIA,10,30:;
 ```
 
-The annotation records `10` MiB and `30` (30% of the GPU's compute cores) — exactly the values requested.
+The annotation records `10` MiB and `30` (30% of the GPU's compute capacity) — exactly the values requested.
 
 ## Step 9: Test Percentage-Based Memory Request
 
@@ -624,7 +624,7 @@ You will see two semicolon-separated device entries, one per allocated vGPU slot
 | Basic GPU scheduling | `gpu-test-1` | Annotation shows 1 vGPU UUID + 40960 MiB |
 | GPU sharing (time-slicing) | `gpu-test-1` through `gpu-test-4` | All 4 Pods run concurrently |
 | Memory limit (`gpumem`) | `gpu-limits` | Annotation shows `10` MiB |
-| Core limit (`gpucores`) | `gpu-limits` | Annotation shows `30` (30% of cores) |
+| Compute limit (`gpucores`) | `gpu-limits` | Annotation shows `30` (30% of compute capacity) |
 | Percentage memory (`gpumem-percentage`) | `gpu-mem-30pct` | Annotation shows `12288` MiB (30% of A100) |
 | Multi-GPU allocation | `gpu-multi` | hami-scheduler events show `BindingSucceed` |
 

--- a/tutorials/labs/nvml-mock.md
+++ b/tutorials/labs/nvml-mock.md
@@ -485,7 +485,7 @@ EOF
 
 :::info
 
-Resource Limits Format `nvidia.com/gpumem` takes an **absolute value in MiB** — `"10"` means 10 MiB. `nvidia.com/gpucores: "30"` requests 30 compute cores on the selected GPU.
+Resource Limits Format `nvidia.com/gpumem` takes an **absolute value in MiB** — `"10"` means 10 MiB. `nvidia.com/gpucores: "30"` requests 30% of the compute cores on the selected GPU.
 
 :::
 
@@ -501,7 +501,7 @@ Expected output:
 hami.io/vgpu-devices-allocated: GPU-12345678-1234-1234-1234-123456780002,NVIDIA,10,30:;
 ```
 
-The annotation records `10` MiB and `30` cores — exactly the values requested.
+The annotation records `10` MiB and `30` (30% of the GPU's compute cores) — exactly the values requested.
 
 ---
 
@@ -646,7 +646,7 @@ You will see two semicolon-separated device entries, one per allocated vGPU slot
 | Basic GPU scheduling | `gpu-test-1` | Annotation shows 1 vGPU UUID + 40960 MiB |
 | GPU sharing (time-slicing) | `gpu-test-1` through `gpu-test-4` | All 4 Pods run concurrently |
 | Memory limit (`gpumem`) | `gpu-limits` | Annotation shows `10` MiB |
-| Core limit (`gpucores`) | `gpu-limits` | Annotation shows `30` cores |
+| Core limit (`gpucores`) | `gpu-limits` | Annotation shows `30` (30% of cores) |
 | Percentage memory (`gpumem-percentage`) | `gpu-mem-30pct` | Annotation shows `12288` MiB (30% of A100) |
 | Multi-GPU allocation | `gpu-multi` | hami-scheduler events show `BindingSucceed` |
 

--- a/tutorials/labs/online-install.md
+++ b/tutorials/labs/online-install.md
@@ -54,8 +54,6 @@ flowchart LR
 
 > Cost note: the `n1-standard-4` + T4 VM costs about $0.55 per hour. [Lab 3](./gpu-partitioning.md) and [Lab 4](./hami-dra.md) continue on this same cluster, so one session covers all three labs. Delete the VM when you finish.
 
----
-
 ## Step 1: Create a GCP Virtual Machine
 
 ### Purpose
@@ -324,8 +322,6 @@ prometheus-prometheus-node-exporter-xxxxx              1/1     Running   0      
 
 > If the installation fails, uninstall first before retrying: `helm uninstall -n monitoring prometheus`
 
----
-
 ## Step 5: Install GPU Operator
 
 ### Purpose
@@ -395,8 +391,6 @@ The expected output includes GPU information (driver version, CUDA version, GPU 
 | N/A   64C    P8             17W /   70W |       1MiB /  15360MiB |      0%      Default |
 +-----------------------------------------------------------------------------------------+
 ```
-
----
 
 ## Step 6: Install HAMi
 

--- a/tutorials/labs/topology-aware-scheduling.md
+++ b/tutorials/labs/topology-aware-scheduling.md
@@ -203,8 +203,6 @@ NODE_NAME=$(kubectl get nodes -o jsonpath='{.items[0].metadata.name}')
 echo "NODE_NAME=${NODE_NAME}"
 ```
 
----
-
 :::info[Most remaining steps are the same on both platforms]
 
 From here on, most commands work the same on macOS and Linux. A couple of steps still differ - Step 2.3 and Step 3.1 each call out an extra `kind load` command needed only on Linux. Everything else is identical, aside from the node name you'll see in example outputs.


### PR DESCRIPTION


/kind documentation



**What this PR does / why we need it**:



Clarifies documentation by removing redundant lines and enhancing consistency across tutorials regarding platform differences and GPU scheduling resource limits.



**Which issue(s) this PR fixes**:



Fixes #



**Checklist**:



- [x] `npm run lint` and `npm run format:check` pass

- [x] `npm run build` succeeds for both `en` and `zh`

- [x] Chinese translation updated if English docs changed (or noted why not)

- [x] Commits are signed off (`git commit -s`)



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified that the GPU core allocation value represents a percentage of compute capacity, not an absolute number of cores.
  * Updated the related allocation summary and verified-features information.
  * Improved formatting and spacing across GPU, installation, and topology-aware scheduling tutorials.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->