### PR TITLE
docs(core-concepts): clarify which cu/nvml symbols libvgpu.so intercepts

### DIFF
--- a/docs/core-concepts/gpu-virtualization.md
+++ b/docs/core-concepts/gpu-virtualization.md
@@ -68,7 +68,7 @@ HAMi consists of four core components:
 | `HAMi MutatingWebhook Server` | Deployment (embedded in hami-scheduler Pod) | Admission entry point: scans Pod resource fields, rewrites `schedulerName` to `hami-scheduler` for Pods that need HAMi scheduling (configurable); Pods with explicitly specified schedulerName are skipped |
 | `HAMi Scheduler-Extender` | Deployment (embedded in hami-scheduler Pod) | Scheduling core: maintains a global GPU view, implements fine-grained VRAM/compute-aware scheduling during Filter/Bind phases, supports binpack/spread strategies |
 | `HAMi Device Plugin` | DaemonSet | Node resource layer: registers virtual GPU resources with Kubelet; mounts `libvgpu.so` and `ld.so.preload` into containers via hostPath during `Allocate`, and injects environment variables such as `CUDA_DEVICE_MEMORY_LIMIT_<index>` and `CUDA_DEVICE_SM_LIMIT` |
-| `HAMi-Core` (`libvgpu.so`) | Dynamic library (injected during Device Plugin Allocate) | In-container soft isolation: overrides `dlsym` to hijack NVIDIA library functions starting with `cu`/`nvml`, implementing VRAM limit interception and compute throttling |
+| `HAMi-Core` (`libvgpu.so`) | Dynamic library (injected during Device Plugin Allocate) | In-container soft isolation: overrides `dlsym` to hijack the specific NVIDIA library functions listed in its hook table (not every `cu`/`nvml`-prefixed symbol), implementing VRAM limit interception and compute throttling |
 
 After deployment, the Pod status looks like this:
 
@@ -167,7 +167,7 @@ After the Pod is scheduled to the target node, Kubelet calls the Device Plugin's
    - `CUDA_DEVICE_MEMORY_LIMIT_<index>=<number>m`: Per-device VRAM quota, where `index` is the container's device index (0, 1, 2...), with a unit suffix `m` (e.g., `1024m`), derived from the Pod's `nvidia.com/gpumem` request
    - `CUDA_DEVICE_SM_LIMIT=<percentage>`: Compute quota ceiling (from the Pod's `nvidia.com/gpucores` request)
 
-After the container starts, libvgpu.so hijacks NVIDIA dynamic library symbol resolution by **overriding the `dlsym` function**, intercepting all function calls starting with `cu` and `nvml`:
+After the container starts, libvgpu.so hijacks NVIDIA dynamic library symbol resolution by **overriding the `dlsym` function**, intercepting the specific `cu`/`nvml`-prefixed function calls listed in its hook table. Calls to `cu`/`nvml` functions outside that table resolve normally to the real driver:
 
 **VRAM Limit:**
 

--- a/i18n/zh/docusaurus-plugin-content-docs/current/core-concepts/gpu-virtualization.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/current/core-concepts/gpu-virtualization.md
@@ -69,7 +69,7 @@ HAMi 由四个核心组件构成：
 | `HAMi MutatingWebhook Server` | Deployment（内嵌于 hami-scheduler Pod） | 准入入口：扫描 Pod 资源字段，将需要 HAMi 调度的 Pod 的 `schedulerName` 改写为 `hami-scheduler`（可配置）；已显式指定其他 schedulerName 的 Pod 会被跳过 |
 | `HAMi Scheduler-Extender` | Deployment（内嵌于 hami-scheduler Pod） | 调度核心：感知全局 GPU 视图，在 Filter/Bind 阶段实现细粒度显存/算力感知调度，支持 binpack/spread 策略 |
 | `HAMi Device Plugin` | DaemonSet | 节点资源层：向 Kubelet 注册虚拟 GPU 资源；在 `Allocate` 中以 hostPath 方式将 `libvgpu.so` 和 `ld.so.preload` 挂载到容器，并注入 `CUDA_DEVICE_MEMORY_LIMIT_<index>`、`CUDA_DEVICE_SM_LIMIT` 等环境变量 |
-| `HAMi-Core`（`libvgpu.so`） | 动态库（Device Plugin Allocate 时注入） | 容器内软隔离：重写 `dlsym` 劫持以 `cu` / `nvml` 开头的 NVIDIA 库函数，实现显存上限拦截与算力限速 |
+| `HAMi-Core`（`libvgpu.so`） | 动态库（Device Plugin Allocate 时注入） | 容器内软隔离：重写 `dlsym` 劫持其 hook 表中登记的 NVIDIA 库函数（并非所有以 `cu` / `nvml` 开头的符号），实现显存上限拦截与算力限速 |
 
 实际部署后的 Pod 状态如下：
 
@@ -168,7 +168,7 @@ Pod 调度到目标节点后，Kubelet 调用 Device Plugin 的 `Allocate` 接�
    - `CUDA_DEVICE_MEMORY_LIMIT_<index>=<数字>m`：per-device 显存配额，`index` 为容器内设备索引（0、1、2...），值带单位后缀 `m`（如 `1024m`），来自 Pod 申请的 `nvidia.com/gpumem`
    - `CUDA_DEVICE_SM_LIMIT=<百分比>`：算力配额上限（来自 Pod 申请的 `nvidia.com/gpucores`）
 
-容器启动后，libvgpu.so 通过**重写 `dlsym` 函数**劫持 NVIDIA 动态库的符号解析，对所有以 `cu` 和 `nvml` 开头的函数调用进行拦截：
+容器启动后，libvgpu.so 通过**重写 `dlsym` 函数**劫持 NVIDIA 动态库的符号解析，对其 hook 表中登记的 `cu`/`nvml` 前缀函数调用进行拦截；未登记的 `cu`/`nvml` 函数会正常解析到真实驱动：
 
 **显存限制（Memory Limit）：**
 


### PR DESCRIPTION
**What type of PR is this?**

/kind documentation

**What this PR does / why we need it**:

The GPU virtualization page says HAMi-Core hijacks NVIDIA library functions "starting with `cu`/`nvml`", and that it intercepts "all function calls starting with `cu` and `nvml`". That is broader than what `libvgpu.so` does.

`dlsym` is overridden in `src/libvgpu.c`, but what comes back is decided by a lookup, not by the prefix:

- `nvml*` goes to `__dlsym_hook_section_nvml()`, which is an explicit list of `DLSYM_HOOK_FUNC(...)` entries. A symbol that is not in the list returns NULL and falls through to the real `dlsym`.
- `cu*` is resolved against `libvgpu.so` itself first. If HAMi-Core defines no wrapper for it, it falls through the same way. The `cuGetProcAddress` path goes through `__dlsym_hook_section()`, which is the same kind of list.
- One family is skipped outright, in `find_symbols_in_table()` in `src/cuda/hook.c`:

  ```c
  /* Skip CUDA graph functions: let them fall through to real driver */
  if (strncmp(symbol, "cuGraph", 7) == 0) {
      return NULL;
  }
  ```

This matters when the page is used to debug an isolation gap. "Every `cu`/`nvml` call is intercepted" and "the calls in the hook table are intercepted" point at different causes for an allocation that got past the limit.

The change touches the `HAMi-Core` row in the component table and the `dlsym` paragraph in the interception flow section, in English and Chinese. Text only, no links or page structure changed.

AI assistance: I used Claude Code to check the existing wording against the HAMi-core source.

**Which issue(s) this PR fixes**:

None. 4 changed lines, below the 100 line threshold that requires an issue first.

**Checklist**:

- [x] `npm run lint` and `npm run format:check` pass
- [x] `npm run build` succeeds for both `en` and `zh`
- [x] Chinese translation updated if English docs changed (or noted why not)
- [x] Commits are signed off (`git commit -s`)

Note on the first box: markdownlint is clean across the repo and Prettier is clean on both changed files. Running `npm run format:check` on a Windows checkout reports every file in the repo, including untouched ones on master, because `core.autocrlf` gives CRLF line endings locally. That is a local artifact, not something in this diff.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified that only explicitly registered NVIDIA functions are intercepted by the virtualization library.
  * Documented that unregistered functions resolve normally to the underlying driver.
  * Updated both English and Chinese GPU virtualization documentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->