### PR TITLE
fix(docs): update broken architecture image path in contribute-docs

### DIFF
--- a/docs/contributor/contribute-docs.md
+++ b/docs/contributor/contribute-docs.md
@@ -149,7 +149,7 @@ Store images under `/static/img/docs/` using language-aware subdirectories:
 Reference images with absolute paths from the site root:
 
 ```md
-![Architecture diagram](/img/docs/common/architecture/hami-arch.png) ![WebUI Overview](/img/docs/en/userguide/webui-overview.png)
+![Architecture diagram](/img/docs/common/developers/hami-core-design/hami-arch.png) ![WebUI Overview](/img/docs/en/userguide/webui-overview.png)
 ```
 
 Use descriptive alt text. Do not link to external images - host them in the repository.

--- a/i18n/zh/docusaurus-plugin-content-docs/current/contributor/contribute-docs.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/current/contributor/contribute-docs.md
@@ -149,7 +149,7 @@ Docusaurus 会自动把这些解析为正确的 URL，包括版本和语言。
 用相对于站点根目录的绝对路径引用图片：
 
 ```md
-![Architecture diagram](/img/docs/common/architecture/hami-arch.png) ![WebUI Overview](/img/docs/en/userguide/webui-overview.png)
+![Architecture diagram](/img/docs/common/developers/hami-core-design/hami-arch.png) ![WebUI Overview](/img/docs/en/userguide/webui-overview.png)
 ```
 
 使用有意义的 alt 文本，不要链接外部图片，图片要托管在本仓库中。

--- a/i18n/zh/docusaurus-plugin-content-docs/version-v2.9.0/contributor/contribute-docs.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/version-v2.9.0/contributor/contribute-docs.md
@@ -100,7 +100,7 @@ title: 带有标签的文档
   - `/static/img/docs/zh/`：仅中文图片示例：
   - `![WebUI Overview](/img/docs/en/userguide/webui-overview.png)`
   - `![WebUI 集群概览](/img/docs/zh/userguide/webui-overview.png)`
-  - `![Architecture](/img/docs/common/architecture/hami-arch.png)`
+  - `![Architecture](/img/docs/common/developers/hami-core-design/hami-arch.png)`
 
 ### 目录组织
 

--- a/versioned_docs/version-v2.9.0/contributor/contribute-docs.md
+++ b/versioned_docs/version-v2.9.0/contributor/contribute-docs.md
@@ -149,7 +149,7 @@ Store images under `/static/img/docs/` using language-aware subdirectories:
 Reference images with absolute paths from the site root:
 
 ```md
-![Architecture diagram](/img/docs/common/architecture/hami-arch.png) ![WebUI Overview](/img/docs/en/userguide/webui-overview.png)
+![Architecture diagram](/img/docs/common/developers/hami-core-design/hami-arch.png) ![WebUI Overview](/img/docs/en/userguide/webui-overview.png)
 ```
 
 Use descriptive alt text. Do not link to external images - host them in the repository.


### PR DESCRIPTION
**What type of PR is this?**

/kind documentation
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
-->

**What this PR does / why we need it**:

A broken image reference was there in contribute-docs.md where /img/docs/common/architecture/hami-arch.png was used as an example image path in the documentation..The directory /img/docs/common/architecture/ does not exist under static/.

I have updated the example path to the valid image path: /img/docs/common/developers/hami-core-design/hami-arch.png

did changes to
- docs/contributor/contribute-docs.md
- i18n/zh/docusaurus-plugin-content-docs/current/contributor/contribute-docs.md
- versioned_docs/version-v2.9.0/contributor/contribute-docs.md
- i18n/zh/docusaurus-plugin-content-docs/version-v2.9.0/contributor/contribute-docs.md

**Which issue(s) this PR fixes**:

Fixes #762 

**Checklist**:

- [x] `npm run lint` and `npm run format:check` pass
- [x] `npm run build` succeeds for both `en` and `zh`
- [x] Chinese translation updated if English docs changed (or noted why not)
- [x] Commits are signed off (`git commit -s`)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Updated architecture diagram links in current and versioned contributor documentation.
  - Updated both English and Chinese documentation references to the correct image location.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->