### PR TITLE
docs: add hami_host_gpu_memory_controller_utilization_ratio to host metrics table

### DIFF
--- a/docs/userguide/monitoring/real-time-device-usage.md
+++ b/docs/userguide/monitoring/real-time-device-usage.md
@@ -14,6 +14,7 @@ It contains the following host-level metrics:
 | Metrics | Description | Example |
 | --- | --- | --- |
 | hami_host_gpu_utilization_ratio | GPU core utilization ratio on host (0-100) | `{device_index="0",device_type="NVIDIA-NVIDIA H200",device_uuid="GPU-00552014-5c87-89ac-b1a6-7b53aa24b0ec",zone="vGPU"}` 0 |
+| hami_host_gpu_memory_controller_utilization_ratio | GPU memory controller utilization ratio on host (0-100) | `{device_index="0",device_type="NVIDIA-NVIDIA H200",device_uuid="GPU-00552014-5c87-89ac-b1a6-7b53aa24b0ec",zone="vGPU"}` 0 |
 | hami_host_gpu_memory_used_bytes | GPU real-time device memory usage on host | `{device_index="0",device_type="NVIDIA-NVIDIA H200",device_uuid="GPU-00552014-5c87-89ac-b1a6-7b53aa24b0ec",zone="vGPU"}` 2.87244288e+08 |
 
 It also exposes per-container and per-vGPU metrics for each scheduled task:

--- a/i18n/zh/docusaurus-plugin-content-docs/current/userguide/monitoring/real-time-device-usage.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/current/userguide/monitoring/real-time-device-usage.md
@@ -15,6 +15,7 @@ curl {GPU 节点 IP}:31992/metrics
 | 指标 | 描述 | 示例 |
 | --- | --- | --- |
 | hami_host_gpu_utilization_ratio | 主机上的 GPU 核心利用率（0-100） | `{device_index="0",device_type="NVIDIA-NVIDIA H200",device_uuid="GPU-00552014-5c87-89ac-b1a6-7b53aa24b0ec",zone="vGPU"}` 0 |
+| hami_host_gpu_memory_controller_utilization_ratio | 主机上的 GPU 显存控制器利用率（0-100） | `{device_index="0",device_type="NVIDIA-NVIDIA H200",device_uuid="GPU-00552014-5c87-89ac-b1a6-7b53aa24b0ec",zone="vGPU"}` 0 |
 | hami_host_gpu_memory_used_bytes | 主机上的 GPU 实时设备显存使用情况 | `{device_index="0",device_type="NVIDIA-NVIDIA H200",device_uuid="GPU-00552014-5c87-89ac-b1a6-7b53aa24b0ec",zone="vGPU"}` 2.87244288e+08 |
 
 它还为每个调度的任务暴露每容器和每 vGPU 的指标：

--- a/i18n/zh/docusaurus-plugin-content-docs/version-v2.9.0/userguide/monitoring/real-time-device-usage.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/version-v2.9.0/userguide/monitoring/real-time-device-usage.md
@@ -15,6 +15,7 @@ curl {GPU 节点 IP}:31992/metrics
 | 指标 | 描述 | 示例 |
 | --- | --- | --- |
 | hami_host_gpu_utilization_ratio | 主机上的 GPU 核心利用率（0-100） | `{device_index="0",device_type="NVIDIA-NVIDIA H200",device_uuid="GPU-00552014-5c87-89ac-b1a6-7b53aa24b0ec",zone="vGPU"}` 0 |
+| hami_host_gpu_memory_controller_utilization_ratio | 主机上的 GPU 显存控制器利用率（0-100） | `{device_index="0",device_type="NVIDIA-NVIDIA H200",device_uuid="GPU-00552014-5c87-89ac-b1a6-7b53aa24b0ec",zone="vGPU"}` 0 |
 | hami_host_gpu_memory_used_bytes | 主机上的 GPU 实时设备显存使用情况 | `{device_index="0",device_type="NVIDIA-NVIDIA H200",device_uuid="GPU-00552014-5c87-89ac-b1a6-7b53aa24b0ec",zone="vGPU"}` 2.87244288e+08 |
 
 它还为每个调度的任务暴露每容器和每 vGPU 的指标：

--- a/i18n/zh/docusaurus-plugin-content-docs/version-v2.9.0/userguide/monitoring/real-time-device-usage.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/version-v2.9.0/userguide/monitoring/real-time-device-usage.md
@@ -15,7 +15,6 @@ curl {GPU 节点 IP}:31992/metrics
 | 指标 | 描述 | 示例 |
 | --- | --- | --- |
 | hami_host_gpu_utilization_ratio | 主机上的 GPU 核心利用率（0-100） | `{device_index="0",device_type="NVIDIA-NVIDIA H200",device_uuid="GPU-00552014-5c87-89ac-b1a6-7b53aa24b0ec",zone="vGPU"}` 0 |
-| hami_host_gpu_memory_controller_utilization_ratio | 主机上的 GPU 显存控制器利用率（0-100） | `{device_index="0",device_type="NVIDIA-NVIDIA H200",device_uuid="GPU-00552014-5c87-89ac-b1a6-7b53aa24b0ec",zone="vGPU"}` 0 |
 | hami_host_gpu_memory_used_bytes | 主机上的 GPU 实时设备显存使用情况 | `{device_index="0",device_type="NVIDIA-NVIDIA H200",device_uuid="GPU-00552014-5c87-89ac-b1a6-7b53aa24b0ec",zone="vGPU"}` 2.87244288e+08 |
 
 它还为每个调度的任务暴露每容器和每 vGPU 的指标：


### PR DESCRIPTION
**What type of PR is this?**
/kind documentation

**What this PR does / why we need it:**
`hami_host_gpu_memory_controller_utilization_ratio` was added to vGPUmonitor in Project-HAMi/HAMi#2616 but the real-time-device-usage.md doc only listed `hami_host_gpu_utilization_ratio` and `hami_host_gpu_memory_used_bytes` in the host-level metrics table. added the missing entry so operators know the metric exists and what labels it carries.

**Which issue(s) this PR fixes:**
related to Project-HAMi/HAMi#2616

**Checklist:**
- [ ] `npm run lint` and `npm run format:check` pass
- [ ] `npm run build` succeeds for both `en` and `zh`
- [ ] Chinese translation updated if English docs changed (or noted why not) — no zh equivalent for this page
- [x] Commits are signed off (`git commit -s`)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added the host-level GPU memory controller utilization ratio metric to the real-time device usage monitoring guide.
  * Included a description and Prometheus usage example for the new metric in English and Chinese documentation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->