### PR TITLE
docs: add HAMi v2.10.0 release notes for English and Chinese versions

### DIFF
--- a/blog/hami-v2-10-0-release/index.md
+++ b/blog/hami-v2-10-0-release/index.md
@@ -1,0 +1,235 @@
+---
+title: "HAMi v2.10.0 Release: Flexible MIG, Composable Scheduling, and an Expanded Accelerator Ecosystem"
+date: "2026-08-21"
+description: "HAMi v2.10.0 is officially released. This release brings dynamic Flexible MIG, a new mutex scheduling policy, a NUMA-aware sort fix with composable scheduler policies, gang-scheduling (PodGroup) support, AMD MI300X and Biren device support, deeper Ascend management with heterogeneous vNPU/HAMi-core mode and monitoring, and a KAI Scheduler + HAMi-core integration."
+tags: ["Release", "GPU", "Kubernetes", "Scheduling"]
+authors: [hami_community]
+---
+
+The HAMi community is proud to announce the official release of **HAMi v2.10.0**. This release advances HAMi on three fronts: **richer scheduling policies, broader heterogeneous accelerator coverage, and a deeper scheduler ecosystem**.
+
+v2.10.0 introduces dynamic **Flexible MIG**, a new **mutex** scheduling policy, a long-requested **NUMA-aware sort fix**, **composable scheduler policies**, **gang-scheduling (PodGroup)** support, and correct **init-container** resource accounting. On the device side it adds **AMD MI300X** and **Biren** support, **heterogeneous Ascend management** that lets template-based vNPU and HAMi-core nodes coexist in one cluster, and **vNPU HAMi-core monitoring**. It also debuts a **KAI Scheduler + HAMi-core** integration through the new KAI Resource Isolator companion project.
+
+This article walks through the major updates in v2.10.0.
+
+<!-- truncate -->
+
+## Scheduling: More Flexible, More Composable
+
+### Flexible MIG: Dynamic MIG Without Draining the Node
+
+Historically, using NVIDIA MIG (Multi-Instance GPU) with HAMi meant leaning on static MIG geometry and tools like `nvidia-mig-parted`, often requiring a node to be drained or cordoned before changing profiles. v2.10.0 replaces that workflow with **Flexible MIG**, which performs dynamic MIG instance allocation and deallocation on demand ([#2378](https://github.com/Project-HAMi/HAMi/pull/2378), [@FouoF](https://github.com/FouoF)).
+
+Highlights:
+
+- **No drain required**: MIG instances are created and torn down as workloads come and go, without cordoning the node.
+- **NVML dynamic discovery**: profiles are discovered dynamically via NVML, with topology-aware reservations and a profile allowlist to constrain what can be carved out.
+- **State preserved across restarts**: MIG reservations and runtime identities (native GI/CI state) survive device-plugin recovery and node restarts, recorded via Pod annotations.
+- **Safer startup**: the device plugin avoids resetting GPUs that already have active workloads.
+- **Modernized MIG metrics**: DCGM-style metrics expose MIG UUIDs, profiles, instance IDs, and placement coordinates.
+
+> **Known limitations**: CDI mode is not yet supported together with MIG, and multi-device MIG cases still need validation. We recommend testing your specific topology before production rollout.
+
+### Mutex Scheduling Policy and the NUMA Sort Fix
+
+v2.10.0 adds a new **`mutex`** GPU scheduling policy ([#2011](https://github.com/Project-HAMi/HAMi/pull/2011), [@mesutoezdil](https://github.com/mesutoezdil)). A Pod annotated with `hami.io/gpu-scheduler-policy: mutex` is placed **only on GPUs that have no existing users**, guaranteeing exclusive device access for that workload. This is useful for latency-sensitive inference or workloads that must not share a die.
+
+The same change also fixes a long-standing sort bug that affected `binpack` and `spread`. Previously the scheduler used **NUMA node as the primary sort key**, which pinned workloads to a fixed NUMA node regardless of actual load ([#1806](https://github.com/Project-HAMi/HAMi/issues/1806)). With this release, **device utilization Score becomes the primary sort key, and NUMA is used only as a tiebreaker**, so `binpack` and `spread` now behave as expected across multi-NUMA topologies ([#2012](https://github.com/Project-HAMi/HAMi/pull/2012)).
+
+```yaml
+# Request an exclusively-allocated GPU
+metadata:
+  annotations:
+    hami.io/gpu-scheduler-policy: "mutex"
+```
+
+### Composable Scheduler Policies
+
+Individual policies are useful on their own, but real clusters usually want several behaviors at once: pack tightly, but keep NUMA locality, and keep a few GPUs exclusive. v2.10.0 lets `hami.io/gpu-scheduler-policy` take an **ordered, comma-separated list** so filter-style and sort-style policies compose ([#2621](https://github.com/Project-HAMi/HAMi/pull/2621), [@mesutoezdil](https://github.com/mesutoezdil), closes [#2010](https://github.com/Project-HAMi/HAMi/issues/2010)):
+
+- `binpack`, `spread`, and `numa` act as **sort keys, applied in the order written**: `binpack,numa` sorts by binpack first and uses NUMA as the tiebreaker.
+- `mutex` (and `topology-aware` on NVIDIA) act as **filters**, pruning candidates before sorting.
+- Candidates that compare equal get deterministic device-index ordering, and filter-only chains fall back to `spread`.
+- Whitespace around commas is trimmed, and **single values keep working exactly as before**.
+
+```yaml
+# Exclusive GPUs only, then pack tightly with NUMA as tiebreaker
+metadata:
+  annotations:
+    hami.io/gpu-scheduler-policy: "mutex,binpack,numa"
+```
+
+With this change, v2.10.0 closes out the scheduler-policy combination work tracked in the v2.10 roadmap: the policies (`mutex`, `numa`, `topology-aware`, `binpack`, `spread`) can now be used individually or chained in any order.
+
+### PodGroup (Gang-Scheduling) Support
+
+For distributed training and other all-or-nothing workloads, v2.10.0 adds **PodGroup support** so that members of a PodGroup bind cleanly without tearing each other down on node-lock contention ([#2066](https://github.com/Project-HAMi/HAMi/pull/2066), [@lin121291](https://github.com/lin121291), issue [#1832](https://github.com/Project-HAMi/HAMi/issues/1832)).
+
+When multiple members of the same PodGroup bind concurrently to one node, they previously contended on the `hami.io/mutex.lock` annotation; the loser failed immediately and fell back to kube-scheduler backoff. v2.10.0 adds a **retry loop in `Bind`** for PodGroup members (detected via the `scheduling.x-k8s.io/pod-group` label), with a new `--node-lock-retry-timeout` flag (default 28s, deliberately below the 30s extender timeout). Non-PodGroup Pod behavior is unchanged.
+
+### Correct Init-Container Resource Accounting
+
+Pods that use init containers to download weights or prepare data were previously over-counted: the scheduler summed _all_ container requests, treating init containers as if they ran in parallel. v2.10.0 aligns HAMi with standard Kubernetes semantics: the effective request is now `max(Σ app containers, max(init container))` ([#1773](https://github.com/Project-HAMi/HAMi/pull/1773), [@maishivamhoo123](https://github.com/maishivamhoo123)). This eliminates false "node full" failures and incorrect quota denials for Pods that rely on init containers.
+
+## Expanded Heterogeneous Accelerator Support
+
+### AMD Instinct MI300X vGPU
+
+v2.10.0 adds **software vGPU support for AMD Instinct accelerators**, validated against the **MI300X** on ROCm 7.0.2 ([#2290](https://github.com/Project-HAMi/HAMi/pull/2290), [@FouoF](https://github.com/FouoF), [@kenji-mido](https://github.com/kenji-mido)).
+
+Rather than relying on hardware SR-IOV, HAMi injects a userspace hook (`libamvgpu.so`) via glibc `LD_AUDIT` and enforces limits through `HIP_DEVICE_MEMORY_LIMIT`. This delivers hard per-GPU isolation for both memory and compute:
+
+| Dimension | How it's requested | Behavior |
+| :-- | :-- | :-- |
+| Memory isolation | `amd.com/gpumem` (MiB) | Hard per-GPU limit; usage cannot exceed allocation |
+| Compute isolation | `amd.com/gpucores` (0-100, CU%) | Limits compute-unit percentage (e.g. `25` ≈ 76 CUs on a 304-CU device) |
+| Device count | `amd.com/gpu` | Number of GPUs |
+
+```yaml
+resources:
+  limits:
+    amd.com/gpu: "1" # 1 GPU
+    amd.com/gpumem: "49152" # 48 GiB memory
+    amd.com/gpucores: "30" # 30% of compute units
+```
+
+AMD support ships as a dedicated [`amd-device-plugin`](https://github.com/Project-HAMi/amd-device-plugin) component (`0.0.1`) that installs `libamvgpu.so` via a `postStart` hook. **Do not use the upstream ROCm `k8s-device-plugin` together with it.**
+
+:::warning[Requirements and limitations]
+
+- Workload images must be **glibc-based with GLIBC 2.34 or newer** (e.g. a recent `rocm/pytorch` tag). **Alpine/musl, Ubuntu 20.04, and RHEL 8 are not supported yet** ([#2265](https://github.com/Project-HAMi/HAMi/issues/2265)).
+- **No RDNA/WGP-based devices** yet.
+- Multi-GPU-per-Pod cases are not yet validated for lack of hardware.
+- If you use the AMD GPU Operator for drivers, disable its built-in device plugin first.
+
+:::
+
+### Biren Device Support
+
+v2.10.0 adds management support for **Biren** accelerators (verified model: `Biren166M`), contributed by [@DSFans2014](https://github.com/DSFans2014) ([#1711](https://github.com/Project-HAMi/HAMi/pull/1711)). It offers two allocation modes:
+
+- **Full-card mode**: each Pod exclusively occupies an entire GPU.
+- **SVI partitioning**: split a card into a fixed **2 or 4 partitions**, with device UUID selection/exclusion via annotations.
+
+```yaml
+# Label the node first: kubectl label node <node-name> biren=on
+resources:
+  limits:
+    birentech.com/gpu: "1"
+```
+
+> **Note**: Unlike NVIDIA/AMD, you do **not** specify a memory or core size per Pod for Biren; you get a full card or an SVI partition (2- or 4-way). The `biren-device-plugin` DaemonSet is deployed into the `biren-gpu` namespace.
+
+With AMD and Biren joining the lineup, HAMi now covers an even broader range of accelerators including NVIDIA, Huawei Ascend, Cambricon, Hygon DCU, Biren, Enflame, MetaX, Kunlunxin, Iluvatar, AWS Neuron, and Vastai Technologies.
+
+## Deeper Ascend Management
+
+### Heterogeneous Ascend Mode: vNPU and HAMi-core in One Cluster
+
+HAMi v2.9.0 introduced HAMi-core mode for Ascend (software-based memory and compute partitioning). A practical limitation remained: a Pod had to explicitly opt into a mode, so cluster operators effectively maintained two sets of workload configurations.
+
+v2.10.0 makes Ascend workloads **mode-agnostic**. A Pod without a `huawei.com/vnpu-mode` annotation now follows whatever the node it lands on supports within the same cluster: **template-based hard partitioning (vNPU)** on template nodes, and **HAMi-core soft partitioning** on HAMi-core nodes ([HAMi #2035](https://github.com/Project-HAMi/HAMi/pull/2035) and [ascend-device-plugin #106](https://github.com/Project-HAMi/ascend-device-plugin/pull/106), [@ouyangluwei163](https://github.com/ouyangluwei163)). Pods that carry an explicit `huawei.com/vnpu-mode: hami-core` annotation stay pinned to that mode. The scheduler only rejects a hami-core request on a node that genuinely lacks hami-core support.
+
+This reduces the complexity of running mixed Ascend fleets: you no longer need to duplicate workload manifests for the two partitioning styles.
+
+### vNPU HAMi-core Monitoring
+
+Soft-partitioned Ascend resources can now be **observed**, not just allocated. v2.10.0 turns on an embedded Prometheus metrics server for vNPU HAMi-core mode, exposing per-container and per-device visibility:
+
+- **A `metrics` server on port 9395**, started only when `hami-vnpu-core` mode is enabled ([ascend-device-plugin #93](https://github.com/Project-HAMi/ascend-device-plugin/pull/93), [@maverick123123](https://github.com/maverick123123)).
+- **Per-container AICore utilization** via `hami_container_device_utilization_ratio` (correctly mapped per device UUID rather than falling back to the first device).
+- **Per-device memory** via `hami_host_gpu_memory_used_bytes`, aggregated from per-container usage for accuracy under sharing.
+- **Process-level HBM tracking** through DCMI, with per-container shared-memory accounting that also supports multi-device (TP>1) inference ([ascend-device-plugin #87](https://github.com/Project-HAMi/ascend-device-plugin/pull/87); [hami-vnpu-core #10](https://github.com/Project-HAMi/hami-vnpu-core/pull/10)).
+- **Helm-deployable** monitoring via the ascend-device-plugin chart ([#108](https://github.com/Project-HAMi/ascend-device-plugin/pull/108), [@DSFans2014](https://github.com/DSFans2014)).
+
+This takes soft-partitioned Ascend from "allocatable" to "observable and operable."
+
+## Scheduler Ecosystem
+
+### KAI Scheduler + HAMi-core via the KAI Resource Isolator
+
+v2.10.0 debuts an integration that lets **KAI Scheduler** handle GPU-sharing scheduling while **HAMi-core** enforces runtime isolation inside the container, connected by a new companion project: the [KAI Resource Isolator](https://github.com/Project-HAMi/KAI-resource-isolator) (v1.1.0, [@archlitchi](https://github.com/archlitchi); monitoring by [@dttung2905](https://github.com/dttung2905)).
+
+The division of responsibility is clean:
+
+- **KAI Scheduler** decides _which_ Pod gets _what fraction_ of a GPU.
+- The **KAI Resource Isolator** makes that decision _stick_: a DaemonSet (`libsync`) ships HAMi-core's `libvgpu.so` to GPU nodes, and a **mutating webhook** injects the library into shared Pods and patches `/etc/ld.so.preload` so that `libvgpu.so` intercepts CUDA memory-allocation calls and enforces the hard VRAM limit KAI Scheduler established via `CUDA_DEVICE_MEMORY_LIMIT`.
+- The integration **reuses HAMi's monitoring metrics** and stays compatible with the existing HAMi Grafana dashboard.
+
+KAI Scheduler **≥ 0.17.0** is required, with `global.gpuSharing=true` and `binder.plugins.hamicore.enabled=true`.
+
+:::note[Actively maturing]
+
+The KAI + HAMi-core architecture is in place and the isolator is released, but two hardening PRs are still in flight and worth tracking before production hard-isolation use: fraction-based VRAM enforcement ([#6](https://github.com/Project-HAMi/KAI-resource-isolator/pull/6)) and non-root-container directory permissions ([#22](https://github.com/Project-HAMi/KAI-resource-isolator/pull/22)). We recommend validating that memory limits actually take effect in your KAI GPU-sharing Pods. Related HAMi-side CRD work ([#2014](https://github.com/Project-HAMi/HAMi/pull/2014)) is also still in draft. See our earlier deep-dive on [GPU memory hard isolation with KAI Scheduler](/blog/kai-scheduler-hami-gpu-memory-hard-isolation).
+
+:::
+
+### Volcano vNPU Support for Ascend Soft Partitioning
+
+Volcano can now combine with the Ascend device plugin and `hami-vnpu-core` to schedule and run Ascend soft-partitioning workloads, bringing Volcano's batch-scheduling strength together with HAMi's runtime isolation. Volcano exposes Ascend vNPU through its `deviceshare` plugin (`AscendHAMiVNPUEnable: true`), supporting heterogeneous Ascend clusters including 910A, 910B2, 910B3, and 310P.
+
+Requirements worth noting: **Volcano ≥ 1.14** is needed, with **≥ 1.16 required for `hami-core` soft slicing**, and soft slicing is **ARM-only**. See the [ascend-device-plugin Volcano guide](https://github.com/Project-HAMi/ascend-device-plugin/blob/main/docs/volcano.md) for details.
+
+## Chart, Build, and Operational Improvements
+
+- **DRA moved to its own chart** ([#2038](https://github.com/Project-HAMi/HAMi/pull/2038), [@archlitchi](https://github.com/archlitchi)): DRA components are removed from the main HAMi Helm chart. DRA now lives in its [own dedicated chart/repo](https://github.com/Project-HAMi/HAMi-dra), so clusters not using DRA no longer pull those components.
+- **Handshake annotation optimization** ([#2052](https://github.com/Project-HAMi/HAMi/pull/2052), [@archlitchi](https://github.com/archlitchi)): node cleanup now fully removes handshake annotation keys instead of writing timestamped `Deleted_*` markers, keeping health/reset reporting consistent.
+- **ubi8 compile image** ([#1958](https://github.com/Project-HAMi/HAMi/pull/1958), [@spencercjh](https://github.com/spencercjh)): the HAMi and HAMi-core build stages moved to `nvidia/cuda:13.3.0-cudnn-devel-ubi8`, broadening GLIBC compatibility so built artifacts run across a wider range of target distributions.
+- **mock-device-plugin NPU templates** ([mock-device-plugin #18](https://github.com/Project-HAMi/mock-device-plugin/pull/18), [@Wangmin362](https://github.com/Wangmin362)): the mock plugin now supports both new nested and legacy flat `vnpus` config formats and registers Ascend AI-core and Hygon DCU cores resources, enabling hardware-less testing of NPU vNPU scheduling.
+
+## Contributors
+
+v2.10.0 is the result of contributions across the HAMi main repo and the broader Project-HAMi org (ascend-device-plugin, KAI-resource-isolator, mock-device-plugin, hami-vnpu-core, amd-device-plugin). Representative feature owners this cycle:
+
+- [@archlitchi](https://github.com/archlitchi): release coordination, KAI Resource Isolator, DRA chart separation, handshake optimization
+- [@mesutoezdil](https://github.com/mesutoezdil): mutex scheduling policy, NUMA sort fix, composable policy chains
+- [@maverick123123](https://github.com/maverick123123): Ascend vNPU HAMi-core monitoring
+- [@ouyangluwei163](https://github.com/ouyangluwei163): heterogeneous Ascend mode (vNPU + HAMi-core)
+- [@FouoF](https://github.com/FouoF), [@kenji-mido](https://github.com/kenji-mido): AMD MI300X vGPU, Flexible MIG
+- [@DSFans2014](https://github.com/DSFans2014): Biren device support, vNPU monitor Helm chart
+- [@lin121291](https://github.com/lin121291): PodGroup gang-scheduling support
+- [@maishivamhoo123](https://github.com/maishivamhoo123): init-container resource accounting
+- [@Wangmin362](https://github.com/Wangmin362): mock-device-plugin NPU templates
+- [@spencercjh](https://github.com/spencercjh): ubi8 compile image
+- [@dttung2905](https://github.com/dttung2905): KAI vGPU monitor and non-root workload fixes
+
+Thank you to every contributor, and to every user who reported issues, tested release candidates, and shared production feedback. The full contributor list is reflected in the [v2.10.0 release notes](https://github.com/Project-HAMi/HAMi/releases/tag/v2.10.0).
+
+## Upgrade Guide
+
+Upgrade to v2.10.0 via Helm:
+
+```bash
+helm repo add hami-charts https://project-hami.github.io/HAMi/
+helm repo update
+helm upgrade hami hami-charts/hami -n kube-system
+```
+
+For complete installation documentation, refer to: [/docs/installation/online-installation](/docs/installation/online-installation)
+
+:::warning[Upgrade notes]
+
+- **DRA users**: DRA is no longer installed from the main chart. If you rely on HAMi-DRA, follow the [HAMi-dra](https://github.com/Project-HAMi/HAMi-dra) chart installation.
+- **AMD users**: deploy the dedicated [`amd-device-plugin`](https://github.com/Project-HAMi/amd-device-plugin) and ensure workload images meet the GLIBC 2.34 requirement.
+- **Ascend users**: vNPU HAMi-core monitoring requires enabling `hami-core` mode; verify your Volcano version (≥ 1.16 for soft slicing, ARM-only).
+- We recommend verifying compatibility in a test environment before upgrading.
+
+:::
+
+## Summary
+
+HAMi v2.10.0 is a release focused on **scheduling flexibility, accelerator breadth, and ecosystem depth**. With Flexible MIG, composable scheduling policies (mutex, the NUMA sort fix, and comma-separated policy chains), gang-scheduling support, AMD and Biren devices, deeper Ascend management and observability, and a KAI Scheduler + HAMi-core integration, HAMi keeps expanding what a unified heterogeneous-compute scheduling platform can do.
+
+We sincerely welcome more developers, users, and ecosystem partners to join the HAMi community and help advance GPU virtualization and heterogeneous-compute scheduling.
+
+---
+
+**Related links:**
+
+- GitHub Release: [https://github.com/Project-HAMi/HAMi/releases/tag/v2.10.0](https://github.com/Project-HAMi/HAMi/releases/tag/v2.10.0)
+- KAI Resource Isolator: [https://github.com/Project-HAMi/KAI-resource-isolator](https://github.com/Project-HAMi/KAI-resource-isolator)
+- Ascend Device Plugin: [https://github.com/Project-HAMi/ascend-device-plugin](https://github.com/Project-HAMi/ascend-device-plugin)
+- AMD Device Plugin: [https://github.com/Project-HAMi/amd-device-plugin](https://github.com/Project-HAMi/amd-device-plugin)
+- Documentation: [/docs/](/docs/)
+- Community Discord (recommended): [https://discord.gg/Amhy7XmbNq](https://discord.gg/Amhy7XmbNq)
+- Community CNCF Slack: [https://cloud-native.slack.com/archives/C07T10BU4R2](https://cloud-native.slack.com/archives/C07T10BU4R2)

--- a/blog/hami-v2-10-0-release/index.md
+++ b/blog/hami-v2-10-0-release/index.md
@@ -34,7 +34,7 @@ Highlights:
 
 v2.10.0 adds a new **`mutex`** GPU scheduling policy ([#2011](https://github.com/Project-HAMi/HAMi/pull/2011), [@mesutoezdil](https://github.com/mesutoezdil)). A Pod annotated with `hami.io/gpu-scheduler-policy: mutex` is placed **only on GPUs that have no existing users**, guaranteeing exclusive device access for that workload. This is useful for latency-sensitive inference or workloads that must not share a die.
 
-The same change also fixes a long-standing sort bug that affected `binpack` and `spread`. Previously the scheduler used **NUMA node as the primary sort key**, which pinned workloads to a fixed NUMA node regardless of actual load ([#1806](https://github.com/Project-HAMi/HAMi/issues/1806)). With this release, **device utilization Score becomes the primary sort key, and NUMA is used only as a tiebreaker**, so `binpack` and `spread` now behave as expected across multi-NUMA topologies ([#2012](https://github.com/Project-HAMi/HAMi/pull/2012)).
+The same change also fixes a long-standing sort bug that affected `binpack` and `spread`. Previously the scheduler used **NUMA node as the primary sort key**, which pinned workloads to a fixed NUMA node regardless of actual load ([#1806](https://github.com/Project-HAMi/HAMi/issues/1806)). With this release, **device utilization Score becomes the primary sort key, and NUMA is used only as a tiebreaker**, so `binpack` and `spread` now behave as expected across multi-NUMA topologies ([#2011](https://github.com/Project-HAMi/HAMi/pull/2011)).
 
 ```yaml
 # Request an exclusively-allocated GPU

--- a/blog/hami-v2-10-0-release/index.md
+++ b/blog/hami-v2-10-0-release/index.md
@@ -6,7 +6,7 @@ tags: ["Release", "GPU", "Kubernetes", "Scheduling"]
 authors: [hami_community]
 ---
 
-The HAMi community is proud to announce the official release of **HAMi v2.10.0**. This release advances HAMi on three fronts: **richer scheduling policies, broader heterogeneous accelerator coverage, and a deeper scheduler ecosystem**.
+The HAMi community is proud to announce the official release of **HAMi v2.10.0**. This release advances HAMi on three fronts: **more flexible scheduling policies, broader heterogeneous accelerator coverage, and a richer scheduler ecosystem**.
 
 v2.10.0 introduces dynamic **Flexible MIG**, a new **mutex** scheduling policy, a long-requested **NUMA-aware sort fix**, **composable scheduler policies**, **gang-scheduling (PodGroup)** support, and correct **init-container** resource accounting. On the device side it adds **AMD MI300X** and **Biren** support, **heterogeneous Ascend management** that lets template-based vNPU and HAMi-core nodes coexist in one cluster, and **vNPU HAMi-core monitoring**. It also debuts a **KAI Scheduler + HAMi-core** integration through the new KAI Resource Isolator companion project.
 
@@ -122,7 +122,7 @@ resources:
 
 With AMD and Biren joining the lineup, HAMi now covers an even broader range of accelerators including NVIDIA, Huawei Ascend, Cambricon, Hygon DCU, Biren, Enflame, MetaX, Kunlunxin, Iluvatar, AWS Neuron, and Vastai Technologies.
 
-## Deeper Ascend Management
+## More Flexible Ascend Management
 
 ### Heterogeneous Ascend Mode: vNPU and HAMi-core in One Cluster
 

--- a/i18n/zh/docusaurus-plugin-content-blog/hami-meetup-beijing-2025/index.md
+++ b/i18n/zh/docusaurus-plugin-content-blog/hami-meetup-beijing-2025/index.md
@@ -5,6 +5,7 @@ description: "12 月 27 日，HAMi Meetup 北京站近百位技术伙伴齐聚�
 authors: [hami_community]
 tags: ["HAMi", "Meetup", "异构算力", "GPU 虚拟化", "云原生"]
 image: "./hami-meetup-beijing-banner.webp"
+unlisted: true
 ---
 
 ![HAMi Meetup 北京站](hami-meetup-beijing-banner.webp)

--- a/i18n/zh/docusaurus-plugin-content-blog/hami-meetup-shanghai-2025/index.md
+++ b/i18n/zh/docusaurus-plugin-content-blog/hami-meetup-shanghai-2025/index.md
@@ -6,6 +6,7 @@ image: ./meetup-banner.png
 tags:
   ["Meetup", "上海", "异构算力调度", "GPU 虚拟化", "Kubernetes", "国产算力", "AI 训练与推理优化"]
 authors: [hami_community]
+unlisted: true
 ---
 
 11 月 30 日，首场 HAMi Meetup 在上海圆满结束。本次活动以"不卷算力卷效率"为主题，近百位 AI 开发者、运维工程师、企业 IT 架构师齐聚现场，聚焦异构算力调度的核心命题。

--- a/i18n/zh/docusaurus-plugin-content-blog/hami-meetup-shenzhen-2026/index.md
+++ b/i18n/zh/docusaurus-plugin-content-blog/hami-meetup-shenzhen-2026/index.md
@@ -5,6 +5,7 @@ description: "4 月 25 日，HAMi Meetup 深圳站成功举办。来自 CNCF、�
 image: ./meetup-shenzhen-group-photo.webp
 tags: ["HAMi", "Meetup", "深圳", "GPU 虚拟化", "异构算力调度", "DRA", "云原生", "AI 基础设施"]
 authors: [hami_community]
+unlisted: true
 ---
 
 ![HAMi Meetup 深圳站](meetup-shenzhen-group-photo.webp)

--- a/i18n/zh/docusaurus-plugin-content-blog/hami-v2-10-0-release/index.md
+++ b/i18n/zh/docusaurus-plugin-content-blog/hami-v2-10-0-release/index.md
@@ -2,7 +2,7 @@
 title: "HAMi v2.10.0 发布：Flexible MIG、可组合调度策略与更广阔的加速器生态"
 date: "2026-08-21"
 description: "HAMi v2.10.0 正式发布。本次发布带来了动态 Flexible MIG、全新的 mutex 调度策略、NUMA 排序修复与可组合调度策略、PodGroup（gang-scheduling）支持、AMD MI300X 与壁仞设备支持、更深入的昇腾管理（vNPU 与 HAMi-core 异构模式及监控），以及 KAI Scheduler + HAMi-core 集成。"
-tags: ["Release", "GPU", "Kubernetes", "Scheduling"]
+tags: ["Release", "GPU", "Kubernetes", "调度"]
 authors: [hami_community]
 ---
 
@@ -118,7 +118,7 @@ resources:
     birentech.com/gpu: "1"
 ```
 
-> **注意**：与 NVIDIA/AMD 不同，壁仞**不能**按 Pod 指定显存或算力大小，你得到的是整卡或一个 SVI 分区（2 切或 4 切）。`biren-device-plugin` DaemonSet 部署在 `biren-gpu` 命名空间。
+> **注意**：与 NVIDIA/AMD 不同，壁仞**不能**按 Pod 指定显存或算力大小，你得到的是整卡或一个 SVI 分区（2 个分区或 4 个分区）。`biren-device-plugin` DaemonSet 部署在 `biren-gpu` 命名空间。
 
 AMD 与壁仞的加入，使 HAMi 已覆盖更广泛的加速器，包括 NVIDIA、华为昇腾、寒武纪、海光 DCU、壁仞、燧原、沐曦、昆仑芯、Iluvatar、AWS Neuron 与瀚博半导体。
 

--- a/i18n/zh/docusaurus-plugin-content-blog/hami-v2-10-0-release/index.md
+++ b/i18n/zh/docusaurus-plugin-content-blog/hami-v2-10-0-release/index.md
@@ -1,0 +1,235 @@
+---
+title: "HAMi v2.10.0 发布：Flexible MIG、可组合调度策略与更广阔的加速器生态"
+date: "2026-08-21"
+description: "HAMi v2.10.0 正式发布。本次发布带来了动态 Flexible MIG、全新的 mutex 调度策略、NUMA 排序修复与可组合调度策略、PodGroup（gang-scheduling）支持、AMD MI300X 与壁仞设备支持、更深入的昇腾管理（vNPU 与 HAMi-core 异构模式及监控），以及 KAI Scheduler + HAMi-core 集成。"
+tags: ["Release", "GPU", "Kubernetes", "Scheduling"]
+authors: [hami_community]
+---
+
+HAMi 社区正式发布 **HAMi v2.10.0**。本次发布在三个方向上取得进展：**更灵活的调度策略、更广泛的异构加速器覆盖，以及更深入的调度器生态**。
+
+v2.10.0 引入了动态 **Flexible MIG**、全新的 **mutex** 调度策略、社区期待已久的 **NUMA 排序修复**、**可组合调度策略**、**PodGroup（gang-scheduling）** 支持，以及更准确的 **init 容器** 资源计量。在设备侧，新增了 **AMD MI300X** 与**壁仞**支持、让基于模板的 vNPU 与 HAMi-core 节点在同一集群共存的**昇腾异构管理**能力，以及 **vNPU HAMi-core 监控**。同时通过全新的 KAI Resource Isolator 伴随项目，首次实现了 **KAI Scheduler + HAMi-core** 集成。
+
+本文将对 v2.10.0 的主要更新进行详细说明。
+
+<!-- truncate -->
+
+## 调度：更灵活、更可组合
+
+### Flexible MIG：无需驱逐节点的动态 MIG
+
+过去在 HAMi 中使用 NVIDIA MIG（Multi-Instance GPU），往往依赖静态 MIG 几何与 `nvidia-mig-parted` 等工具，在变更 profile 前通常需要先 drain 或 cordon 节点。v2.10.0 用 **Flexible MIG** 取代了这一流程，实现按需动态创建与销毁 MIG 实例（[#2378](https://github.com/Project-HAMi/HAMi/pull/2378)，[@FouoF](https://github.com/FouoF)）。
+
+主要亮点：
+
+- **无需驱逐**：MIG 实例随工作负载的进出动态创建与销毁，无需 cordon 节点。
+- **NVML 动态发现**：通过 NVML 动态发现 profile，结合拓扑感知的资源预留与 profile 白名单来约束可切分的范围。
+- **重启后状态保留**：MIG 预留与运行时身份（原生 GI/CI 状态）可在 device-plugin 恢复与节点重启后保留，并通过 Pod 注解记录。
+- **更安全的启动**：device plugin 会避免重置已有活跃工作负载的 GPU。
+- **MIG 指标现代化**：DCGM 风格的指标暴露 MIG UUID、profile、实例 ID 与位置坐标。
+
+> **已知限制**：CDI 模式暂不支持与 MIG 同时使用，多设备 MIG 场景仍需进一步验证。建议在生产环境部署前，针对你的实际拓扑进行测试。
+
+### Mutex 调度策略与 NUMA 排序修复
+
+v2.10.0 新增了 **`mutex`** GPU 调度策略（[#2011](https://github.com/Project-HAMi/HAMi/pull/2011)，[@mesutoezdil](https://github.com/mesutoezdil)）。带有 `hami.io/gpu-scheduler-policy: mutex` 注解的 Pod 会被调度到**当前没有任何用户使用的 GPU** 上，从而为该工作负载保证独占的设备访问，非常适合对延迟敏感的推理，或不能共享同一颗 die 的工作负载。
+
+同一改动还修复了一个长期存在、影响 `binpack` 与 `spread` 的排序 bug。此前调度器以 **NUMA 节点作为主排序键**，导致无论实际负载如何，工作负载都被固定到某个 NUMA 节点（[#1806](https://github.com/Project-HAMi/HAMi/issues/1806)）。本次发布后，**设备利用率 Score 成为主排序键，NUMA 仅作为 tiebreaker**，因此 `binpack` 与 `spread` 在多 NUMA 拓扑下的行为恢复正常（[#2012](https://github.com/Project-HAMi/HAMi/pull/2012)）。
+
+```yaml
+# 请求独占分配的 GPU
+metadata:
+  annotations:
+    hami.io/gpu-scheduler-policy: "mutex"
+```
+
+### 可组合调度策略
+
+单个策略各有用处，但真实集群往往需要多种行为叠加：既要紧凑装箱，又要保持 NUMA 亲和，还要留几张卡独占。v2.10.0 让 `hami.io/gpu-scheduler-policy` 接受**有序的、逗号分隔的列表**，使过滤型与排序型策略可以组合（[#2621](https://github.com/Project-HAMi/HAMi/pull/2621)，[@mesutoezdil](https://github.com/mesutoezdil)，关闭 [#2010](https://github.com/Project-HAMi/HAMi/issues/2010)）：
+
+- `binpack`、`spread`、`numa` 作为**排序键，按书写顺序生效**：`binpack,numa` 先按 binpack 排序，再以 NUMA 作为 tiebreaker。
+- `mutex`（以及 NVIDIA 上的 `topology-aware`）作为**过滤器**，在排序前先筛掉不合格的候选设备。
+- 比较结果相同的候选按设备索引确定性地排序；仅含过滤器的组合回退为 `spread`。
+- 逗号两侧的空白会被忽略，**单个策略值的行为与之前完全一致**。
+
+```yaml
+# 仅独占 GPU，再紧凑装箱，NUMA 作为 tiebreaker
+metadata:
+  annotations:
+    hami.io/gpu-scheduler-policy: "mutex,binpack,numa"
+```
+
+至此，v2.10 roadmap 中跟踪的调度策略组合工作宣告完成：各策略（`mutex`、`numa`、`topology-aware`、`binpack`、`spread`）既可以单独使用，也可以按任意顺序组合成链。
+
+### PodGroup（gang-scheduling）支持
+
+针对分布式训练等"要么全调度、要么不调度"的工作负载，v2.10.0 新增了 **PodGroup 支持**，使同一 PodGroup 的成员在节点锁竞争时能干净地完成 bind，而不会互相挤掉（[#2066](https://github.com/Project-HAMi/HAMi/pull/2066)，[@lin121291](https://github.com/lin121291)，issue [#1832](https://github.com/Project-HAMi/HAMi/issues/1832)）。
+
+此前，当同一 PodGroup 的多个成员并发 bind 到同一节点时，它们会争抢 `hami.io/mutex.lock` 注解；失败者会立即失败并退回到 kube-scheduler 的退避逻辑。v2.10.0 为 PodGroup 成员（通过 `scheduling.x-k8s.io/pod-group` 标签识别）在 `Bind` 中新增了**重试循环**，并引入新的 `--node-lock-retry-timeout` 参数（默认 28 秒，刻意低于 extender 30 秒的超时）。非 PodGroup 的 Pod 行为保持不变。
+
+### 更准确的 init 容器资源计量
+
+使用 init 容器下载权重或准备数据的 Pod 此前会被多算：调度器将*所有*容器请求相加，把 init 容器当作并行运行来处理。v2.10.0 让 HAMi 对齐了标准 Kubernetes 语义：有效请求变为 `max(Σ 应用容器, max(init 容器))`（[#1773](https://github.com/Project-HAMi/HAMi/pull/1773)，[@maishivamhoo123](https://github.com/maishivamhoo123)）。这消除了依赖 init 容器的 Pod 出现的误报"节点已满"失败与错误的配额拒绝。
+
+## 更广泛的异构加速器支持
+
+### AMD Instinct MI300X vGPU
+
+v2.10.0 新增了对 **AMD Instinct 加速器的软件 vGPU 支持**，已在 **MI300X** 上基于 ROCm 7.0.2 验证（[#2290](https://github.com/Project-HAMi/HAMi/pull/2290)，[@FouoF](https://github.com/FouoF)、[@kenji-mido](https://github.com/kenji-mido)）。
+
+该方案不依赖硬件 SR-IOV，而是通过 glibc `LD_AUDIT` 注入用户态 hook（`libamvgpu.so`），并借助 `HIP_DEVICE_MEMORY_LIMIT` 实施限制。这为显存与算力都提供了硬隔离：
+
+| 维度 | 请求方式 | 行为 |
+| :-- | :-- | :-- |
+| 显存隔离 | `amd.com/gpumem`（MiB） | 单 GPU 硬限制；使用量不会超过分配值 |
+| 算力隔离 | `amd.com/gpucores`（0-100，CU%） | 限制计算单元百分比（如 `25` ≈ 304 CU 设备上的 76 个 CU） |
+| 设备数量 | `amd.com/gpu` | GPU 数量 |
+
+```yaml
+resources:
+  limits:
+    amd.com/gpu: "1" # 1 张 GPU
+    amd.com/gpumem: "49152" # 48 GiB 显存
+    amd.com/gpucores: "30" # 30% 计算单元
+```
+
+AMD 支持以独立的 [`amd-device-plugin`](https://github.com/Project-Hami/amd-device-plugin) 组件（`0.0.1`）提供，通过 `postStart` hook 安装 `libamvgpu.so`。**请勿将其与上游 ROCm `k8s-device-plugin` 混用。**
+
+:::warning[要求与限制]
+
+- 工作负载镜像必须基于 **glibc 且 GLIBC ≥ 2.34**（如较新的 `rocm/pytorch` 标签）。**暂不支持 Alpine/musl、Ubuntu 20.04 与 RHEL 8**（[#2265](https://github.com/Project-HAMi/HAMi/issues/2265)）。
+- 暂不支持基于 **RDNA/WGP** 的设备。
+- 受限于硬件，单 Pod 多 GPU 场景尚未验证。
+- 若使用 AMD GPU Operator 安装驱动，请先关闭其内置的 device plugin。
+
+:::
+
+### 壁仞（Biren）设备支持
+
+v2.10.0 新增了对**壁仞**加速器的管理支持（已验证型号：`Biren166M`），由 [@DSFans2014](https://github.com/DSFans2014) 贡献（[#1711](https://github.com/Project-HAMi/HAMi/pull/1711)）。提供两种分配模式：
+
+- **整卡模式（Full-card）**：每个 Pod 独占一整张 GPU。
+- **SVI 切分**：将一张卡固定切分为 **2 或 4 个分区**，支持通过注解选择/排除设备 UUID。
+
+```yaml
+# 节点需要先打标签：kubectl label node <node-name> biren=on
+resources:
+  limits:
+    birentech.com/gpu: "1"
+```
+
+> **注意**：与 NVIDIA/AMD 不同，壁仞**不能**按 Pod 指定显存或算力大小，你得到的是整卡或一个 SVI 分区（2 切或 4 切）。`biren-device-plugin` DaemonSet 部署在 `biren-gpu` 命名空间。
+
+AMD 与壁仞的加入，使 HAMi 已覆盖更广泛的加速器，包括 NVIDIA、华为昇腾、寒武纪、海光 DCU、壁仞、燧原、沐曦、昆仑芯、Iluvatar、AWS Neuron 与瀚博半导体。
+
+## 更深入的昇腾管理
+
+### 昇腾异构模式：vNPU 与 HAMi-core 同集群共存
+
+HAMi v2.9.0 为昇腾引入了 HAMi-core 模式（基于软件的显存与算力切分）。但此前仍有一个实际限制：Pod 必须显式选择某种模式，集群运维人员实际上要维护两套工作负载配置。
+
+v2.10.0 让昇腾工作负载变为**模式无关（mode-agnostic）**。不带 `huawei.com/vnpu-mode` 注解的 Pod 会跟随其落地节点所支持的模式在同一集群内自动适配：在模板节点上使用**基于模板的硬切分（vNPU）**，在 HAMi-core 节点上使用 **HAMi-core 软切分**（[HAMi #2035](https://github.com/Project-HAMi/HAMi/pull/2035) 与 [ascend-device-plugin #106](https://github.com/Project-HAMi/ascend-device-plugin/pull/106)，[@ouyangluwei163](https://github.com/ouyangluwei163)）。带有显式 `huawei.com/vnpu-mode: hami-core` 注解的 Pod 仍严格绑定到该模式。调度器仅在节点确实不支持 hami-core 时，才会拒绝 hami-core 请求。
+
+这降低了运行混合昇腾机群的复杂度：不再需要为两种切分方式维护两份工作负载清单。
+
+### vNPU HAMi-core 监控
+
+软切分的昇腾资源现在不仅"可分配"，更**可观测**。v2.10.0 为 vNPU HAMi-core 模式开启了内嵌的 Prometheus 指标服务，提供容器级与设备级的可见性：
+
+- **9395 端口的 metrics 服务**，仅在启用 `hami-vnpu-core` 模式时启动（[ascend-device-plugin #93](https://github.com/Project-HAMi/ascend-device-plugin/pull/93)，[@maverick123123](https://github.com/maverick123123)）。
+- **容器级 AICore 利用率**：`hami_container_device_utilization_ratio`（按设备 UUID 正确映射，而非回退到第一个设备）。
+- **设备级显存**：`hami_host_gpu_memory_used_bytes`（按容器用量聚合，确保共享场景下的准确性）。
+- 基于 DCMI 的**进程级 HBM 追踪**，并提供容器级共享内存计量，同时支持多设备（TP>1）推理（[ascend-device-plugin #87](https://github.com/Project-HAMi/ascend-device-plugin/pull/87)；[hami-vnpu-core #10](https://github.com/Project-HAMi/hami-vnpu-core/pull/10)）。
+- 通过 ascend-device-plugin chart **支持 Helm 部署**的监控（[#108](https://github.com/Project-HAMi/ascend-device-plugin/pull/108)，[@DSFans2014](https://github.com/DSFans2014)）。
+
+这让软切分昇腾资源从"可分配"迈向"可观测、可运营"。
+
+## 调度器生态
+
+### 通过 KAI Resource Isolator 实现 KAI Scheduler + HAMi-core
+
+v2.10.0 首次推出了一个集成方案：让 **KAI Scheduler** 负责 GPU 共享的调度决策，而 **HAMi-core** 负责容器内的运行时隔离，两者由全新的伴随项目 [KAI Resource Isolator](https://github.com/Project-HAMi/KAI-resource-isolator)（v1.1.0，[@archlitchi](https://github.com/archlitchi)；监控由 [@dttung2905](https://github.com/dttung2905) 贡献）连接。
+
+职责划分非常清晰：
+
+- **KAI Scheduler** 决定*哪个* Pod 获得*多少* GPU 份额。
+- **KAI Resource Isolator** 让该决策*真正生效*：DaemonSet（`libsync`）将 HAMi-core 的 `libvgpu.so` 下发到 GPU 节点，**mutating webhook** 把该库注入到共享 Pod 中并修改 `/etc/ld.so.preload`，使 `libvgpu.so` 拦截 CUDA 内存分配调用，强制执行 KAI Scheduler 通过 `CUDA_DEVICE_MEMORY_LIMIT` 设定的显存硬限制。
+- 该集成**复用 HAMi 的监控指标**，并与现有的 HAMi Grafana 仪表盘兼容。
+
+需要 KAI Scheduler **≥ 0.17.0**，并设置 `global.gpuSharing=true` 与 `binder.plugins.hamicore.enabled=true`。
+
+:::note[持续完善中]
+
+KAI + HAMi-core 的架构已经就位，isolator 也已发布，但有两个加固 PR 仍在进行中，在生产级硬隔离场景使用前值得跟踪：基于 fraction 的显存强制执行（[#6](https://github.com/Project-HAMi/KAI-resource-isolator/pull/6)）与非 root 容器目录权限（[#22](https://github.com/Project-HAMi/KAI-resource-isolator/pull/22)）。建议在你的 KAI GPU 共享 Pod 中验证显存限制确实生效。HAMi 侧相关的 CRD 工作（[#2014](https://github.com/Project-HAMi/HAMi/pull/2014)）也仍处于 draft 状态。可参阅我们此前的深度文章[《KAI Scheduler + HAMi：GPU 显存硬隔离》](/zh/blog/kai-scheduler-hami-gpu-memory-hard-isolation)。
+
+:::
+
+### Volcano 支持昇腾软切分 vNPU
+
+Volcano 现在可以结合 Ascend device plugin 与 `hami-vnpu-core`，调度并运行昇腾软切分工作负载，把 Volcano 的批量调度能力与 HAMi 的运行时隔离能力结合起来。Volcano 通过其 `deviceshare` 插件（`AscendHAMiVNPUEnable: true`）暴露昇腾 vNPU，支持包括 910A、910B2、910B3、310P 在内的异构昇腾集群。
+
+需要留意的前提条件：需要 **Volcano ≥ 1.14**，**`hami-core` 软切分需要 ≥ 1.16**，且软切分**仅支持 ARM 平台**。详见 [ascend-device-plugin Volcano 指南](https://github.com/Project-HAMi/ascend-device-plugin/blob/main/docs/volcano.md)。
+
+## Chart、构建与运维改进
+
+- **DRA 迁移到独立 chart**（[#2038](https://github.com/Project-HAMi/HAMi/pull/2038)，[@archlitchi](https://github.com/archlitchi)）：DRA 组件从主 HAMi Helm chart 中移除。DRA 现在拥有[独立的 chart/仓库](https://github.com/Project-HAMi/HAMi-dra)，不使用 DRA 的集群不再需要拉取这些组件。
+- **握手注解优化**（[#2052](https://github.com/Project-HAMi/HAMi/pull/2052)，[@archlitchi](https://github.com/archlitchi)）：节点清理时现在会完整移除握手注解键，而不是写入带时间戳的 `Deleted_*` 标记，使健康/重置上报保持一致。
+- **ubi8 编译镜像**（[#1958](https://github.com/Project-HAMi/HAMi/pull/1958)，[@spencercjh](https://github.com/spencercjh)）：HAMi 与 HAMi-core 的构建阶段迁移到 `nvidia/cuda:13.3.0-cudnn-devel-ubi8`，扩大了 GLIBC 兼容范围，使构建产物能在更广泛的目标发行版上运行。
+- **mock-device-plugin NPU 模板**（[mock-device-plugin #18](https://github.com/Project-HAMi/mock-device-plugin/pull/18)，[@Wangmin362](https://github.com/Wangmin362)）：mock 插件现在同时支持新版嵌套格式与旧版扁平 `vnpus` 配置，并注册了昇腾 AI-core 与海光 DCU cores 资源，支持在无硬件环境下测试 NPU vNPU 调度。
+
+## 贡献者
+
+v2.10.0 是 HAMi 主仓库与更广泛的 Project-HAMi 组织（ascend-device-plugin、KAI-resource-isolator、mock-device-plugin、hami-vnpu-core、amd-device-plugin）共同贡献的成果。本周期代表性功能负责人包括：
+
+- [@archlitchi](https://github.com/archlitchi)：发布协调、KAI Resource Isolator、DRA chart 拆分、握手优化
+- [@mesutoezdil](https://github.com/mesutoezdil)：mutex 调度策略、NUMA 排序修复、可组合策略链
+- [@maverick123123](https://github.com/maverick123123)：昇腾 vNPU HAMi-core 监控
+- [@ouyangluwei163](https://github.com/ouyangluwei163)：昇腾异构模式（vNPU + HAMi-core）
+- [@FouoF](https://github.com/FouoF)、[@kenji-mido](https://github.com/kenji-mido)：AMD MI300X vGPU、Flexible MIG
+- [@DSFans2014](https://github.com/DSFans2014)：壁仞设备支持、vNPU 监控 Helm chart
+- [@lin121291](https://github.com/lin121291)：PodGroup gang-scheduling 支持
+- [@maishivamhoo123](https://github.com/maishivamhoo123)：init 容器资源计量
+- [@Wangmin362](https://github.com/Wangmin362)：mock-device-plugin NPU 模板
+- [@spencercjh](https://github.com/spencercjh)：ubi8 编译镜像
+- [@dttung2905](https://github.com/dttung2905)：KAI vGPU 监控与非 root 工作负载修复
+
+感谢每一位贡献者的付出，也感谢每一位报告问题、测试候选版本、分享生产反馈的用户。完整贡献者名单可见 [v2.10.0 Release Notes](https://github.com/Project-HAMi/HAMi/releases/tag/v2.10.0)。
+
+## 升级指南
+
+通过 Helm 升级至 v2.10.0：
+
+```bash
+helm repo add hami-charts https://project-hami.github.io/HAMi/
+helm repo update
+helm upgrade hami hami-charts/hami -n kube-system
+```
+
+完整安装文档请参考：[https://project-hami.io/zh/docs/installation/online-installation](/zh/docs/installation/online-installation)
+
+:::warning[升级注意事项]
+
+- **DRA 用户**：DRA 不再随主 chart 安装。若依赖 HAMi-DRA，请按 [HAMi-dra](https://github.com/Project-HAMi/HAMi-dra) chart 进行安装。
+- **AMD 用户**：请部署独立的 [`amd-device-plugin`](https://github.com/Project-Hami/amd-device-plugin)，并确保工作负载镜像满足 GLIBC 2.34 要求。
+- **昇腾用户**：vNPU HAMi-core 监控需启用 `hami-core` 模式；请核实 Volcano 版本（软切分需 ≥ 1.16，仅支持 ARM）。
+- 建议在升级前于测试环境验证兼容性。
+
+:::
+
+## 总结
+
+HAMi v2.10.0 是一次面向**调度灵活性、加速器广度与生态深度**的版本更新。借助 Flexible MIG、可组合调度策略（mutex、NUMA 排序修复与逗号分隔的策略链）、gang-scheduling 支持、AMD 与壁仞设备、更深入的昇腾管理与可观测性，以及 KAI Scheduler + HAMi-core 集成，HAMi 持续拓展统一异构算力调度平台的能力边界。
+
+我们诚挚欢迎更多开发者、用户和生态伙伴参与 HAMi 社区，共同推动 GPU 虚拟化与异构算力调度能力的演进。
+
+---
+
+**相关链接：**
+
+- GitHub Release：[https://github.com/Project-HAMi/HAMi/releases/tag/v2.10.0](https://github.com/Project-HAMi/HAMi/releases/tag/v2.10.0)
+- KAI Resource Isolator：[https://github.com/Project-HAMi/KAI-resource-isolator](https://github.com/Project-HAMi/KAI-resource-isolator)
+- Ascend Device Plugin：[https://github.com/Project-HAMi/ascend-device-plugin](https://github.com/Project-HAMi/ascend-device-plugin)
+- AMD Device Plugin：[https://github.com/Project-Hami/amd-device-plugin](https://github.com/Project-Hami/amd-device-plugin)
+- 项目文档：[https://project-hami.io/zh/docs/](/zh/docs/)
+- 社区 Discord（推荐）：[https://discord.gg/Amhy7XmbNq](https://discord.gg/Amhy7XmbNq)
+- 社区 CNCF Slack：[https://cloud-native.slack.com/archives/C07T10BU4R2](https://cloud-native.slack.com/archives/C07T10BU4R2)

--- a/i18n/zh/docusaurus-plugin-content-blog/hami-v2-10-0-release/index.md
+++ b/i18n/zh/docusaurus-plugin-content-blog/hami-v2-10-0-release/index.md
@@ -34,7 +34,7 @@ v2.10.0 引入了动态 **Flexible MIG**、全新的 **mutex** 调度策略、�
 
 v2.10.0 新增了 **`mutex`** GPU 调度策略（[#2011](https://github.com/Project-HAMi/HAMi/pull/2011)，[@mesutoezdil](https://github.com/mesutoezdil)）。带有 `hami.io/gpu-scheduler-policy: mutex` 注解的 Pod 会被调度到**当前没有任何用户使用的 GPU** 上，从而为该工作负载保证独占的设备访问，非常适合对延迟敏感的推理，或不能共享同一颗 die 的工作负载。
 
-同一改动还修复了一个长期存在、影响 `binpack` 与 `spread` 的排序 bug。此前调度器以 **NUMA 节点作为主排序键**，导致无论实际负载如何，工作负载都被固定到某个 NUMA 节点（[#1806](https://github.com/Project-HAMi/HAMi/issues/1806)）。本次发布后，**设备利用率 Score 成为主排序键，NUMA 仅作为 tiebreaker**，因此 `binpack` 与 `spread` 在多 NUMA 拓扑下的行为恢复正常（[#2012](https://github.com/Project-HAMi/HAMi/pull/2012)）。
+同一改动还修复了一个长期存在、影响 `binpack` 与 `spread` 的排序 bug。此前调度器以 **NUMA 节点作为主排序键**，导致无论实际负载如何，工作负载都被固定到某个 NUMA 节点（[#1806](https://github.com/Project-HAMi/HAMi/issues/1806)）。本次发布后，**设备利用率 Score 成为主排序键，NUMA 仅作为 tiebreaker**，因此 `binpack` 与 `spread` 在多 NUMA 拓扑下的行为恢复正常（[#2011](https://github.com/Project-HAMi/HAMi/pull/2011)）。
 
 ```yaml
 # 请求独占分配的 GPU

--- a/i18n/zh/docusaurus-plugin-content-blog/hami-v2-10-0-release/index.md
+++ b/i18n/zh/docusaurus-plugin-content-blog/hami-v2-10-0-release/index.md
@@ -6,7 +6,7 @@ tags: ["Release", "GPU", "Kubernetes", "调度"]
 authors: [hami_community]
 ---
 
-HAMi 社区正式发布 **HAMi v2.10.0**。本次发布在三个方向上取得进展：**更灵活的调度策略、更广泛的异构加速器覆盖，以及更深入的调度器生态**。
+HAMi 社区正式发布 **HAMi v2.10.0**。本次发布在三个方向上取得进展：**更灵活的调度策略、更广泛的异构加速器覆盖，以及更加丰富的调度器生态**。
 
 v2.10.0 引入了动态 **Flexible MIG**、全新的 **mutex** 调度策略、社区期待已久的 **NUMA 排序修复**、**可组合调度策略**、**PodGroup（gang-scheduling）** 支持，以及更准确的 **init 容器** 资源计量。在设备侧，新增了 **AMD MI300X** 与**壁仞**支持、让基于模板的 vNPU 与 HAMi-core 节点在同一集群共存的**昇腾异构管理**能力，以及 **vNPU HAMi-core 监控**。同时通过全新的 KAI Resource Isolator 伴随项目，首次实现了 **KAI Scheduler + HAMi-core** 集成。
 
@@ -120,9 +120,9 @@ resources:
 
 > **注意**：与 NVIDIA/AMD 不同，壁仞**不能**按 Pod 指定显存或算力大小，你得到的是整卡或一个 SVI 分区（2 个分区或 4 个分区）。`biren-device-plugin` DaemonSet 部署在 `biren-gpu` 命名空间。
 
-AMD 与壁仞的加入，使 HAMi 已覆盖更广泛的加速器，包括 NVIDIA、华为昇腾、寒武纪、海光 DCU、壁仞、燧原、沐曦、昆仑芯、Iluvatar、AWS Neuron 与瀚博半导体。
+AMD 与壁仞的加入，使 HAMi 已覆盖更广泛的加速器，包括 NVIDIA、华为昇腾、寒武纪、海光 DCU、壁仞、燧原、沐曦、昆仑芯、天数智芯、AWS Neuron 与瀚博半导体。
 
-## 更深入的昇腾管理
+## 更灵活的昇腾管理
 
 ### 昇腾异构模式：vNPU 与 HAMi-core 同集群共存
 


### PR DESCRIPTION

/kind documentation


**What this PR does / why we need it**:

HAMi v2.10.0 introduces significant enhancements including dynamic Flexible MIG, a new mutex scheduling policy, support for AMD MI300X and Biren devices, and improved Ascend management with vNPU and HAMi-core integration. It also implements PodGroup support for gang-scheduling and enhances init-container resource accounting.

PTAL @archlitchi @Shouren @mesutoezdil 


**Which issue(s) this PR fixes**:


**Checklist**:

- [x] `npm run lint` and `npm run format:check` pass
- [x] `npm run build` succeeds for both `en` and `zh`
- [x] Chinese translation updated if English docs changed (or noted why not)
- [x] Commits are signed off (`git commit -s`)



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Documentation

* Added English and Chinese release notes for HAMi v2.10.0.
* Documented Flexible MIG, scheduling policies, NUMA improvements, PodGroup retries, and init-container accounting.
* Highlighted AMD MI300X, Biren, heterogeneous Ascend, KAI Scheduler, Volcano, and monitoring support.
* Added upgrade guidance, compatibility notes, contributor information, and related links.
* Marked selected 2025–2026 meetup articles as unlisted in the Chinese documentation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->