### PR TITLE
fix(events): remove stale manual landing pages superseded by #701

### DIFF
--- a/src/pages/landing/coscup-2026.js
+++ b/src/pages/landing/coscup-2026.js
@@ -1,3 +1,0 @@
-import EventLanding from "@site/src/components/EventLanding";
-
-export default () => <EventLanding slug="coscup-2026" />;

--- a/src/pages/landing/opensource-summit-korea.js
+++ b/src/pages/landing/opensource-summit-korea.js
@@ -1,3 +1,0 @@
-import EventLanding from "@site/src/components/EventLanding";
-
-export default () => <EventLanding slug="opensource-summit-korea" />;


### PR DESCRIPTION
# PR: Remove stale manual landing pages superseded by #701

## Title
fix(events): remove stale manual landing pages causing duplicate route warnings

## Description

### Problem
Running `npm run build` emits duplicate route warnings for two event landing pages, in both `en` and `zh` locales:

```
[WARNING] Duplicate routes found!
- Attempting to create page at /landing/coscup-2026, but a page already exists at this route.
- Attempting to create page at /landing/opensource-summit-korea, but a page already exists at this route.
This could lead to non-deterministic routing behavior.
```

### Root cause
`src/plugins/events/index.js` iterates over `landingEvents` and programmatically registers a route for each event at `/landing/${event.slug}`, rendering `EventLanding.js` with the event's `slug` prop.

However, `src/pages/landing/coscup-2026.js` and `src/pages/landing/opensource-summit-korea.js` are manual page files that render the exact same component with the exact same prop:

```jsx
import EventLanding from "@site/src/components/EventLanding";
export default () => <EventLanding slug="coscup-2026" />;
```

Since Docusaurus auto-generates routes for any file under `src/pages/`, this creates a route twice — once from the filesystem router, once from the plugin.

This is the same class of issue fixed in #701 ("generalize event landing page routes from data"), which removed two other stale manual pages (`kcd-vietnam.js`, `kubecon-japan.js`) for the identical reason but missed these two.

### Fix
Removed the two redundant manual page files:
- `src/pages/landing/coscup-2026.js`
- `src/pages/landing/opensource-summit-korea.js`

The plugin already handles routing/rendering for these events via `src/data/events.js`.

### Verification
- `npm run build` — duplicate route warnings no longer appear for either `en` or `zh` locale; both builds compile and generate successfully.
- `npm run serve` — manually visited `/landing/coscup-2026`, `/landing/opensource-summit-korea`, and their `/zh/` equivalents; all four render correctly via the plugin-generated route.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Removed Pages**
  * Removed the COSCUP 2026 landing page.
  * Removed the Open Source Summit Korea landing page.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->