### PR TITLE
Enhance troubleshooting guide for HAMi installation

### DIFF
--- a/docs/troubleshooting/troubleshooting.md
+++ b/docs/troubleshooting/troubleshooting.md
@@ -160,3 +160,222 @@ devicePlugin:
 ```
 
 :::
+
+## HAMi device plugin fails on a GPU-less node
+
+HAMi's standard installation expects supported accelerator hardware and the corresponding vendor runtime to be available on nodes where the real device plugin is scheduled.
+Use `mock-device-plugin` when the goal is to test HAMi scheduling behavior without executing workloads on a physical accelerator.The mock plugin is intended for development/testing and does not provide actual GPU execution or GPU performance validation.
+
+When testing HAMi on a machine without a supported NVIDIA GPU, the real NVIDIA device plugin cannot initialize successfully. For scheduler development and testing without physical accelerator hardware, use the HAMi `mock-device-plugin`.
+
+### Error seen
+
+After installing HAMi, check the pods:
+
+```bash
+kubectl get pods -n kube-system
+```
+
+The HAMi device plugin may enter `CrashLoopBackOff`.
+
+Check its logs:
+
+```bash
+kubectl logs -n kube-system <hami-device-plugin-pod> \
+  -c device-plugin --previous
+```
+
+The logs may contain:
+
+```text
+Incompatible strategy detected auto
+If this is a GPU node, did you configure the NVIDIA Container Toolkit?
+If this is not a GPU node, you should set up a toleration or nodeSelector
+to only deploy this plugin on GPU nodes
+error starting plugins: ... invalid device discovery strategy
+```
+
+### Why it happens
+
+The real NVIDIA device plugin uses the NVIDIA discovery strategy and requires the NVIDIA driver/container runtime stack on the host.A GPU-less development machine does not provide that stack. If the node is labelled so that the real device plugin is scheduled there, the plugin attempts to initialize and fails.
+The standard HAMi Quick Start is intended for an environment with the required accelerator prerequisites.
+
+---
+
+## Problem 1: Mock device plugin reports devices as unhealthy
+
+Use this section when the HAMi `mock-device-plugin` is running but repeatedly reports configured devices as unhealthy and the corresponding vendor resources do not appear in the node's `Allocatable` resources.
+
+Check the mock plugin pod:
+
+```bash
+kubectl get pods -n kube-system | grep mock-device-plugin
+```
+
+Then inspect its logs:
+
+```bash
+kubectl logs -n kube-system <mock-device-plugin-pod> --tail=100
+```
+
+You may see repeated messages such as:
+
+```text
+device NVIDIA is unhealthy on this node
+device Ascend910A is unhealthy on this node
+device Ascend910B2 is unhealthy on this node
+```
+
+The messages may repeat on every reconciliation cycle and waiting for the plugin to retry does not provide the missing resource.
+
+Check the node's resources:
+
+```bash
+kubectl get node <node-name> \
+  -o json | jq '.status.capacity'
+```
+
+and:
+
+```bash
+kubectl get node <node-name> \
+  -o json | jq '.status.allocatable'
+```
+
+### Why this happens
+
+The mock device plugin uses node metadata when constructing its virtual device resources. For a mock-only environment, two pieces of node state are important:
+
+1. A vendor registration annotation describing the mock device.
+2. A non-zero vendor count resource in the node's `status.capacity`.
+
+The count resource is used by the plugin's health check. The relevant logic checks whether the node already has a non-zero value for the configured count resource and if the resource is absent, the device is considered unhealthy and resource construction returns without advertising the mock device resources.
+For NVIDIA, the count resource is:
+
+```text
+nvidia.com/gpu
+```
+
+On a fresh mock-only node, this resource may not exist yet which can create a bootstrap dependency:
+
+```text
+CheckHealthy() -> count resource absent from node.Status.Capacity -> device considered unhealthy ->resource registration does not proceed ->count resource is still absent ->CheckHealthy()
+```
+### Diagnose the health gate
+
+Check whether the count resource exists:
+[code block 1 and 2]
+```bash
+kubectl get node <node-name> \
+  -o json | jq '.status.capacity["nvidia.com/gpu"]'
+```
+
+A missing value or a zero value indicates that the NVIDIA count resource has not satisfied the health check. 
+Also check the vendor registration annotation:
+
+```bash
+kubectl get node <node-name> \
+  -o json | jq -r '.metadata.annotations["hami.io/node-nvidia-register"]'
+```
+
+The annotation should contain the mock device configuration being used for the test.
+
+### Bootstrap a mock-only NVIDIA test node
+
+For local testing, seed a non-zero NVIDIA count resource:
+
+```bash
+kubectl patch node <node-name> \
+  --subresource=status \
+  --type=json \
+  -p '[{"op":"add","path":"/status/capacity/nvidia.com~1gpu","value":"1"}]'
+```
+
+Then provide the corresponding mock-device registration annotation.
+
+For example:
+
+```bash
+kubectl annotate node <node-name> \
+  'hami.io/node-nvidia-register=[{"id":"GPU-MOCK-0","count":1,"devmem":81920,"devcore":100,"type":"NVIDIA-A100-SXM4-80GB","health":true,"numa":0,"mode":"hami-core"}]'
+```
+
+Use values appropriate to the mock device you intend to simulate. The status patch is a local testing/bootstrap workaround and not a replacement for a normal device-plugin registration flow and should not be applied to production nodes as a way of claiming that hardware exists. After the mock plugin reconciles the node, verify the node's allocatable resources:
+
+```bash
+kubectl get node <node-name> \
+  -o json | jq '.status.allocatable
+    | with_entries(select(.key | test("nvidia.com")))'
+```
+For an NVIDIA mock device, resources such as the following may appear:
+
+```text
+nvidia.com/gpu
+nvidia.com/gpumem
+nvidia.com/gpucores
+nvidia.com/gpumem-percentage
+```
+
+The exact set depends on the mock device configuration. You can verify the count resource and registration annotation by doing codeblock 1 and 2.
+
+The vendor count resource is used as a health gate and doesnt describe the complete properties of the mock device. The mock device configuration, including the simulated device properties, is provided through the vendor registration configuration.This is suitable for testing HAMi's scheduler and resource-placement behavior without physical accelerator hardware and does not provide realtime GPU execution; NVIDIA driver/runtime validation; accelerator performance measurements; validation of hardware-specific runtime behavior.Use a real supported accelerator environment when testing functionality that depends on physical hardware or vendor runtime components.
+
+---
+
+## Problem 2: Scheduler pod enters `ImagePullBackOff` while pulling `kube-scheduler`
+
+During validation of HAMi on a Fedora/`kind` environment, the scheduler pod also encountered an image-pull failure for the configured `kube-scheduler` image.
+
+The observed error was:
+
+```text
+failed to resolve reference ...:
+tls: failed to verify certificate:
+x509: certificate signed by unknown authority
+```
+
+The HAMi scheduler extender image from Docker Hub pulled successfully in the same environment.This behavior was reproduced in the validation environment, but the investigation did not establish whether the TLS failure is:
+
+* specific to that environment's certificate trust configuration; or
+* a broader issue affecting other networks using the configured registry mirror.
+
+For that reason, this observation is recorded here for visibility rather than presented as a general HAMi failure with a universal workaround.
+
+### Solution: 
+When this occurs, inspect the scheduler pod events:
+
+```bash
+kubectl describe pod -n kube-system <hami-scheduler-pod>
+```
+
+and verify which image and registry failed:
+
+```bash
+kubectl get pod -n kube-system <hami-scheduler-pod> \
+  -o json | jq '.spec.containers[].image'
+```
+
+If the failure is caused by TLS certificate verification, investigate the container runtime's trust configuration and the accessibility of the configured registry from the affected node.
+
+---
+GPU-less kind validation environment
+
+The troubleshooting above was validated using:
+
+OS: Fedora Linux
+CPU: Intel Core i3-5005U, 2 cores / 4 threads
+GPU: Intel HD Graphics 5500 integrated graphics; no CUDA-capable discrete GPU
+RAM: 16 GB
+Cluster	kind, single control-plane node
+Kubernetes	v1.36.1
+HAMi chart	hami-charts/hami
+HAMi image	docker.io/projecthami/hami:v2.9.0
+mock-device-plugin	main at time of testing
+
+This environment was intentionally selected to represent a contributor attempting to evaluate HAMi without access to a discrete accelerator.
+
+For a disposable kind cluster, clean up with:
+
+`kind delete cluster --name <cluster-name>`
+
+--


### PR DESCRIPTION
Added troubleshooting documentation for HAMi installation and scheduler testing on GPU-less nodes, including the real NVIDIA device-plugin failure, the `mock-device-plugin` health-check bootstrap issue, and an observed scheduler image-pull/TLS failure.

**What type of PR is this?**

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
--> /kind documentation

--

**What this PR does / why we need it**:

This PR updates documentation to enable HAMi development on GPU-less nodes by addressing mock device plugin health checks and providing troubleshooting for the real device plugin. Key findings include fixing mock-device-plugin bootstrap failures by seeding non-zero vendor count resources and documenting prerequisites for the real NVIDIA plugin.
Troubleshooting and the Workarounds around it:
 
- GPU-less Testing: Use mock-device-plugin for scheduler testing on nodes without physical GPUs.
- Fix Unhealthy Mock Devices: If CheckHealthy() fails due to missing node.Status.Capacity, manually patch the node to add a non-zero vendor count and apply the mock-device-plugin annotation.
- Real Plugin Failure: If the real plugin enters CrashLoopBackOff on GPU-less nodes, verify the host-side NVIDIA driver stack or use the mock plugin.
- Diagnostic Commands: Review node capacity (kubectl get node -o yaml) and mock-device registration annotations.

 The investigation was performed on a Fedora Linux machine with an Intel Core i3-5005U, Intel HD Graphics 5500 integrated graphics, 16 GB RAM, and a single-node `kind` cluster running Kubernetes v1.36.1. HAMi chart `hami-charts/hami` with image `docker.io/projecthami/hami:v2.9.0` was used, with `mock-device-plugin` cloned from `main` at the time of testing.

The standard HAMi Quick Start exposed the following findings in detail:

### 1. Real HAMi device plugin fails on GPU-less nodes

On a node without a supported NVIDIA GPU and NVIDIA container runtime, the real device plugin entered `CrashLoopBackOff` with errors including:

```text
Incompatible strategy detected auto
If this is a GPU node, did you configure the NVIDIA Container Toolkit?
If this is not a GPU node, you should set up a toleration or nodeSelector
to only deploy this plugin on GPU nodes
error starting plugins: ... invalid device discovery strategy
```

The troubleshooting documentation now explains that the real NVIDIA device plugin requires the corresponding host-side NVIDIA driver/runtime stack and that GPU-less contributors should use the mock device plugin for scheduler testing instead.

### 2. `mock-device-plugin` can repeatedly report devices as unhealthy

After deploying the official `mock-device-plugin`, the DaemonSet ran but repeatedly logged:

```text
device NVIDIA is unhealthy on this node
device Ascend910A is unhealthy on this node
device Ascend910B2 is unhealthy on this node
```

No corresponding GPU-related resources appeared in the node's `Allocatable` resources. Source inspection traced this behavior to `CheckHealthy()` in:

```text
internal/pkg/api/device/device.go
```
which checks whether the node already has a non-zero count resource in `node.Status.Capacity`:

```go
func CheckHealthy(n *corev1.Node, cardResourceName string) bool {
    capacity, exists := n.Status.Capacity[corev1.ResourceName(cardResourceName)]
    if !exists {
        return false
    }
    return !capacity.IsZero()
}
```

The device implementation returns before registering resources when this check fails.This creates a bootstrap dependency on a fresh mock-only node:

```text
CheckHealthy() -> count resource absent from node.Status.Capacity -> device considered unhealthy -> resource registration does not proceed -> count resource remains absent-> CheckHealthy() fails again
```

This is documented as a testing workaround, not a production configuration or a code-level fix [it worked for me but must be tested with different hardware]

### 3. Scheduler pod image-pull/TLS failure observed during validation

During the same installation, the scheduler pod also entered `ImagePullBackOff` while pulling:

```text
registry.cn-hangzhou.aliyuncs.com/google_containers/kube-scheduler:v1.36.1
```

with:

```text
tls: failed to verify certificate:
x509: certificate signed by unknown authority
```

The HAMi scheduler extender image from Docker Hub pulled successfully in the same environment. This failure was reproduced in the validation environment, but its broader scope is not established since it may be environment-specific, so the documentation records the observation and diagnostic commands without presenting it as a confirmed HAMi-wide issue or providing an unverified universal workaround. A separate investigation in `ipsitapp8/hami-placement-lab` identified a different mock-device-plugin issue involving the scheduler node lock during `Allocate()`. That issue occurs at a later stage, after device registration, and is separate from the registration/bootstrap problem documented here. This investigation independently reproduced the behavior on Fedora + `kind` and traced the bootstrap condition to the `CheckHealthy()` logic that occurs before it.

`docs/troubleshooting/troubleshooting.md` now includes:

* GPU-less HAMi device-plugin troubleshooting & explanation of the NVIDIA device-plugin failure and prerequisites;
* mock-device-plugin unhealthy-device symptoms;
* diagnostic commands for node `Capacity`, `Allocatable`, and registration annotations;
* explanation of the count-resource health gate;
* the GPU-less mock-device bootstrap workaround;
* verification commands and expected resources;
* limitations of mock-based scheduler testing;
* the observed scheduler image-pull/TLS failure and its current environment-specific status;

Another thing observed: device health could be tracked independently of pre-existing node capacity rather than using `node.Status.Capacity` as the bootstrap health gate. This was not implemented or tested in this documentation PR and is included only as a maintainer-facing observation for future code-level work.

**Which issue(s) this PR fixes**:

Is a part of #656

Related:

* Project-HAMi/mock-device-plugin#21
* Project-HAMi/mock-device-plugin#16
* Project-HAMi/mock-device-plugin#14

**Checklist**:

* [x] `npm run lint` and `npm run format:check` pass
* [x] `npm run build` succeeds for both `en` and `zh` - Build currently fails on `master` (pre-existing, unrelated broken image assets in static), confirmed via `git stash` test against clean master. Not caused by this PR's changes.
* [x] Chinese translation updated if English docs changed (or noted why not)- no zh translation added; this is English-only troubleshooting content, flagging for maintainer guidance on whether zh parity is expected here.
* [x] Commits are signed off (`git commit -s`)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added troubleshooting guidance for running the GPU device plugin on nodes without GPUs.
  * Documented how to resolve unhealthy mock devices, including required node configuration steps.
  * Added diagnostic steps for scheduler pods experiencing `ImagePullBackOff`.
  * Documented a Fedora/kind GPU-less validation environment.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->