### PR TITLE
doc: update range grammar description in GPU virtualization

### DIFF
--- a/docs/core-concepts/gpu-virtualization.md
+++ b/docs/core-concepts/gpu-virtualization.md
@@ -5,7 +5,7 @@ sidebar_label: GPU Virtualization
 
 In AI inference scenarios, a common dilemma is that GPUs are expensive, but mostly idle.
 
-A typical inference service often only uses 20%~40% of the GPU's compute and a small amount of VRAM, leaving the rest idle. Kubernetes' default GPU scheduling model is exclusive: `nvidia.com/gpu: 1` means the entire card is yours, and all other Pods must wait. Want to share a single GPU across multiple inference services? The standard Device Plugin cannot do it, because it can only report device counts (integers) to the scheduler - there is no concept of "VRAM quota."
+A typical inference service often only uses between 20% and 40% of the GPU's compute and a small amount of VRAM, leaving the rest idle. Kubernetes' default GPU scheduling model is exclusive: `nvidia.com/gpu: 1` means the entire card is yours, and all other Pods must wait. Want to share a single GPU across multiple inference services? The standard Device Plugin cannot do it, because it can only report device counts (integers) to the scheduler - there is no concept of "VRAM quota."
 
 This led to various GPU sharing solutions. NVIDIA's official Time-Slicing allows multiple Pods to be scheduled concurrently, but provides no VRAM isolation - a Pod OOM can crash all tasks on the card. MIG hardware partitioning offers true isolation, but only datacenter-grade cards like A100 and H100 support it.
 


### PR DESCRIPTION
**What type of PR is this?**

/kind documentation

**What this PR does / why we need it**:
The previous statement misrepresents how range is written in english,
this changes makes it read better and accurate

**Which issue(s) this PR fixes**:
N/A

**Checklist**:

- [X] `npm run lint` and `npm run format:check` pass
- [X] `npm run build` succeeds for both `en` and `zh`
- [ ] Chinese translation not updated, because the tilde sign represents range in chinese
- [X] Commits are signed off (`git commit -s`)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved image, logo, navigation, and footer URL handling for more reliable page rendering across deployment paths.
  * Prevented cover images from being recalculated unnecessarily.

* **Documentation**
  * Clarified the estimated GPU utilization range for inference workloads, indicating values between 20% and 40%.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->