### PR TITLE
docs/update reference file path for lab3 tutorial for EC2

### DIFF
--- a/i18n/zh/docusaurus-plugin-content-docs-tutorials/current/labs/gpu-partitioning.md
+++ b/i18n/zh/docusaurus-plugin-content-docs-tutorials/current/labs/gpu-partitioning.md
@@ -93,7 +93,12 @@ spec:
 `gpumem-pod-b.yaml` 除了名称不同外完全相同。部署两个 Pod：
 
 ```bash
-kubectl apply -f tutorials/labs/examples/03-gpu-partitioning/gpumem-pod-a.yaml -f tutorials/labs/examples/03-gpu-partitioning/gpumem-pod-b.yaml
+# 设置 HAMi 实验室清单的基本存储库 URL
+
+export HAMI_MANIFEST_RAW="https://raw.githubusercontent.com/Project-HAMi/website/refs/heads/master/tutorials/labs/examples/03-gpu-partitioning"
+
+kubectl apply -f $HAMI_MANIFEST_RAW/gpumem-pod-a.yaml -f $HAMI_MANIFEST_RAW/gpumem-pod-b.yaml
+
 kubectl get pods gpumem-pod-a gpumem-pod-b -o wide
 ```
 
@@ -174,7 +179,7 @@ spec:
 ```
 
 ```bash
-kubectl apply -f tutorials/labs/examples/03-gpu-partitioning/oom-test-pod.yaml
+kubectl apply -f $HAMI_MANIFEST_RAW/oom-test-pod.yaml
 ```
 
 在镜像拉取期间，观察 HAMi 调度器的决策：
@@ -240,7 +245,10 @@ resources:
 ```
 
 ```bash
-kubectl apply -f tutorials/labs/examples/03-gpu-partitioning/gpucores-pod.yaml
+# 重新导出 HAMi 实验室清单
+export HAMI_MANIFEST_RAW="https://raw.githubusercontent.com/Project-HAMi/website/refs/heads/master/tutorials/labs/examples/03-gpu-partitioning"
+
+kubectl apply -f $HAMI_MANIFEST_RAW/gpucores-pod.yaml
 ```
 
 检查 HAMi 注入到容器中的环境变量：

--- a/tutorials/labs/gpu-partitioning.md
+++ b/tutorials/labs/gpu-partitioning.md
@@ -94,7 +94,7 @@ spec:
 
 ```bash
 # Set the base repository URL for HAMi lab manifests
-export HAMI_MANIFEST_RAW="https://raw.githubusercontent.com/Project-HAMi/website/refs/heads/master/tutorials/labs/examples/"
+export HAMI_MANIFEST_RAW="https://raw.githubusercontent.com/Project-HAMi/website/refs/heads/master/tutorials/labs/examples/03-gpu-partitioning"
 
 kubectl apply -f $HAMI_MANIFEST_RAW/gpumem-pod-a.yaml -f $HAMI_MANIFEST_RAW/gpumem-pod-b.yaml
 kubectl get pods gpumem-pod-a gpumem-pod-b -o wide
@@ -177,6 +177,9 @@ spec:
 ```
 
 ```bash
+# Re-export the HAMi lab manifests
+export HAMI_MANIFEST_RAW="https://raw.githubusercontent.com/Project-HAMi/website/refs/heads/master/tutorials/labs/examples/03-gpu-partitioning"
+
 kubectl apply -f $HAMI_MANIFEST_RAW/oom-test-pod.yaml
 ```
 

--- a/tutorials/labs/gpu-partitioning.md
+++ b/tutorials/labs/gpu-partitioning.md
@@ -93,7 +93,10 @@ spec:
 `gpumem-pod-b.yaml` is identical except for the name. Apply both:
 
 ```bash
-kubectl apply -f tutorials/labs/examples/03-gpu-partitioning/gpumem-pod-a.yaml -f tutorials/labs/examples/03-gpu-partitioning/gpumem-pod-b.yaml
+# Set the base repository URL for HAMi lab manifests
+export HAMI_MANIFEST_RAW="https://raw.githubusercontent.com/Project-HAMi/website/refs/heads/master/tutorials/labs/examples/"
+
+kubectl apply -f $HAMI_MANIFEST_RAW/gpumem-pod-a.yaml -f $HAMI_MANIFEST_RAW/gpumem-pod-b.yaml
 kubectl get pods gpumem-pod-a gpumem-pod-b -o wide
 ```
 
@@ -174,7 +177,7 @@ spec:
 ```
 
 ```bash
-kubectl apply -f tutorials/labs/examples/03-gpu-partitioning/oom-test-pod.yaml
+kubectl apply -f $HAMI_MANIFEST_RAW/oom-test-pod.yaml
 ```
 
 While the image pulls, watch the HAMi scheduler make its decision:
@@ -240,7 +243,7 @@ resources:
 ```
 
 ```bash
-kubectl apply -f tutorials/labs/examples/03-gpu-partitioning/gpucores-pod.yaml
+kubectl apply -f $HAMI_MANIFEST_RAW/gpucores-pod.yaml
 ```
 
 Check the environment HAMi injected into the container:


### PR DESCRIPTION
**What type of PR is this?**

/kind documentation

**What this PR does / why we need it**:

It updates the manifests deployment commands in the lab 3 tutorial; GPU partitioning tutorial to use an exported raw GitHub base URL (`HAMI_MANIFEST_RAW`) instead of relative local paths. When executing `kubectl` from a local client targeting a remote node (such as an AWS EC2 instance), relative local manifest paths fail because the tutorial files are not present on the remote filesystem.


**Which issue(s) this PR fixes**:

Fixes #756 

**AI assistance disclosure:**

I used AI tools to compare possible solutions to the problem, and referenced the documentation for applying resource files to kubectl. I applied using raw HTTP paths, links were reviewed and tested by me.

**Checklist**:

- [X] `npm run lint` and `npm run format:check` pass
- [X] `npm run build` succeeds for both `en` and `zh`
- [X] Chinese translation updated if English docs changed. There were two short sentences and I used google translate for translation
- [X] Commits are signed off (`git commit -s`)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated GPU partitioning lab instructions to retrieve deployment manifests from the remote repository.
  * Applied the updated commands to memory-sharing, OOM testing, and compute-limiting exercises.
  * Removed local relative-path references to improve consistency and reliability when following the lab.
  * Synchronized the updated instructions in the Chinese documentation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->