### PR TITLE
refactor: create platforms directory for cloud vendor guides

### DIFF
--- a/docs/installation/platforms/aws.md
+++ b/docs/installation/platforms/aws.md
@@ -26,7 +26,7 @@ tar xf $(pwd)/* && find $(pwd) -maxdepth 1 -type f -delete
 helm install --generate-name --namespace <ENTER_NAMESPACE_HERE> ./*
 ```
 
-You can customize the installation by adjusting the [configuration](../userguide/configure.md).
+You can customize the installation by adjusting the [configuration](../../userguide/configure.md).
 
 ## Install with AWS Add-on
 

--- a/i18n/zh/docusaurus-plugin-content-docs/current/installation/platforms/aws.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/current/installation/platforms/aws.md
@@ -27,7 +27,7 @@ tar xf $(pwd)/* && find $(pwd) -maxdepth 1 -type f -delete
 helm install --generate-name --namespace <ENTER_NAMESPACE_HERE> ./*
 ```
 
-你可以通过调整[配置](../userguide/configure.md)来自定义安装。
+你可以通过调整[配置](../../userguide/configure.md)来自定义安装。
 
 ## 使用 AWS add-on 安装
 

--- a/sidebars.js
+++ b/sidebars.js
@@ -55,10 +55,14 @@ module.exports = {
         "installation/upgrade",
         "installation/uninstall",
         "installation/webui-installation",
-        "installation/aws-installation",
         "installation/how-to-use-hami-dra",
         "installation/how-to-use-volcano-vgpu",
         "installation/how-to-use-volcano-ascend",
+        {
+          type: "category",
+          label: "Cloud Platforms",
+          items: ["installation/platforms/aws"],
+        },
       ],
     },
     {


### PR DESCRIPTION
**What type of PR is this?**

/kind cleanup
/kind documentation

**What this PR does / why we need it**:
Restructures installation documentation by placing cloud vendor/platform guides into a dedicated directory

**Which issue(s) this PR fixes**:
- Created `docs/installation/platforms directory` for vendor guides
- Moved AWS guide from `docs/installation/aws-installation.md‎` to `docs/installation/platforms/aws.md`
- Updated relative link for adjusting configuration in `aws.md` to match new directory depth
- Updated `sidebars.js` to introduce a Cloud Platforms section under Installation
- Updated Chinese translation directory structure to match


Fixes #795 

**Checklist**:

- [X] `npm run lint` and `npm run format:check` pass
- [X] `npm run build` succeeds for both `en` and `zh`
- [X] Chinese translation updated if English docs changed
- [X] Commits are signed off (`git commit -s`)
