### PR TITLE
feat(community): add ambassadors section to community page

### DIFF
--- a/src/data/ambassadors.json
+++ b/src/data/ambassadors.json
@@ -30,8 +30,9 @@
     "name": "Shivam Kumar",
     "github": "https://github.com/maishivamhoo123",
     "avatar": "img/community/ambassadors/shivam-kumar.jpg",
-    "location": "Greater Vijayawada District, India",
-    "locationZh": "印度维杰亚瓦达地区"
+    "location": "Bihar, India",
+    "locationZh": "印度比哈尔邦",
+    "linkedin": "https://www.linkedin.com/in/shivam-kumar-559417290/"
   },
   {
     "name": "Saiyam Pathak",

--- a/src/data/ambassadors.json
+++ b/src/data/ambassadors.json
@@ -1,46 +1,55 @@
-[
-  {
-    "name": "Mesut Oezdil",
-    "github": "https://github.com/mesutoezdil",
-    "avatar": "img/community/ambassadors/mesut-oezdil.jpg",
-    "linkedin": "https://www.linkedin.com/in/mesut-oezdil/",
-    "website": "https://linktr.ee/mesutoezdil",
-    "location": "Stuttgart, Germany",
-    "locationZh": "德国斯图加特"
+{
+  "source": "https://github.com/Project-HAMi/community/blob/main/ambassador-list.md",
+  "lastSyncedAt": "2026-09-03",
+  "term": {
+    "label": "2026–2028",
+    "startsAt": "2026-09-01",
+    "endsAt": "2028-08-31"
   },
-  {
-    "name": "Tianqing Wang",
-    "nameZh": "王天青",
-    "github": "https://github.com/grissomsh",
-    "avatar": "img/community/ambassadors/tianqing-wang.jpg",
-    "linkedin": "https://www.linkedin.com/in/%E5%A4%A9%E9%9D%92-%E7%8E%8B-6104282a/",
-    "location": "Shanghai, China",
-    "locationZh": "中国上海"
-  },
-  {
-    "name": "Xueduan Li",
-    "nameZh": "李学端",
-    "github": "https://github.com/lixd",
-    "avatar": "img/community/ambassadors/xueduan-li.jpg",
-    "website": "https://www.lixueduan.com/",
-    "location": "Chongqing, China",
-    "locationZh": "中国重庆"
-  },
-  {
-    "name": "Shivam Kumar",
-    "github": "https://github.com/maishivamhoo123",
-    "avatar": "img/community/ambassadors/shivam-kumar.jpg",
-    "location": "Bihar, India",
-    "locationZh": "印度比哈尔邦",
-    "linkedin": "https://www.linkedin.com/in/shivam-kumar-559417290/"
-  },
-  {
-    "name": "Saiyam Pathak",
-    "github": "https://github.com/saiyam1814",
-    "avatar": "img/community/ambassadors/saiyam-pathak.jpg",
-    "linkedin": "https://www.linkedin.com/in/saiyampathak/",
-    "website": "https://kubesimplify.com/",
-    "location": "Chandigarh, India",
-    "locationZh": "印度昌迪加尔"
-  }
-]
+  "ambassadors": [
+    {
+      "name": "Mesut Oezdil",
+      "github": "https://github.com/mesutoezdil",
+      "avatar": "img/community/ambassadors/mesut-oezdil.jpg",
+      "linkedin": "https://www.linkedin.com/in/mesut-oezdil/",
+      "website": "https://linktr.ee/mesutoezdil",
+      "location": "Stuttgart, Germany",
+      "locationZh": "德国斯图加特"
+    },
+    {
+      "name": "Tianqing Wang",
+      "nameZh": "王天青",
+      "github": "https://github.com/grissomsh",
+      "avatar": "img/community/ambassadors/tianqing-wang.jpg",
+      "linkedin": "https://www.linkedin.com/in/%E5%A4%A9%E9%9D%92-%E7%8E%8B-6104282a/",
+      "location": "Shanghai, China",
+      "locationZh": "中国上海"
+    },
+    {
+      "name": "Xueduan Li",
+      "nameZh": "李学端",
+      "github": "https://github.com/lixd",
+      "avatar": "img/community/ambassadors/xueduan-li.jpg",
+      "website": "https://www.lixueduan.com/",
+      "location": "Chongqing, China",
+      "locationZh": "中国重庆"
+    },
+    {
+      "name": "Shivam Kumar",
+      "github": "https://github.com/maishivamhoo123",
+      "avatar": "img/community/ambassadors/shivam-kumar.jpg",
+      "location": "Bihar, India",
+      "locationZh": "印度比哈尔邦",
+      "linkedin": "https://www.linkedin.com/in/shivam-kumar-559417290/"
+    },
+    {
+      "name": "Saiyam Pathak",
+      "github": "https://github.com/saiyam1814",
+      "avatar": "img/community/ambassadors/saiyam-pathak.jpg",
+      "linkedin": "https://www.linkedin.com/in/saiyampathak/",
+      "website": "https://kubesimplify.com/",
+      "location": "Chandigarh, India",
+      "locationZh": "印度昌迪加尔"
+    }
+  ]
+}

--- a/src/data/ambassadors.json
+++ b/src/data/ambassadors.json
@@ -1,0 +1,45 @@
+[
+  {
+    "name": "Mesut Oezdil",
+    "github": "https://github.com/mesutoezdil",
+    "avatar": "img/community/ambassadors/mesut-oezdil.jpg",
+    "linkedin": "https://www.linkedin.com/in/mesut-oezdil/",
+    "website": "https://linktr.ee/mesutoezdil",
+    "location": "Stuttgart, Germany",
+    "locationZh": "德国斯图加特"
+  },
+  {
+    "name": "Tianqing Wang",
+    "nameZh": "王天青",
+    "github": "https://github.com/grissomsh",
+    "avatar": "img/community/ambassadors/tianqing-wang.jpg",
+    "linkedin": "https://www.linkedin.com/in/%E5%A4%A9%E9%9D%92-%E7%8E%8B-6104282a/",
+    "location": "Shanghai, China",
+    "locationZh": "中国上海"
+  },
+  {
+    "name": "Xueduan Li",
+    "nameZh": "李学端",
+    "github": "https://github.com/lixd",
+    "avatar": "img/community/ambassadors/xueduan-li.jpg",
+    "website": "https://www.lixueduan.com/",
+    "location": "Chongqing, China",
+    "locationZh": "中国重庆"
+  },
+  {
+    "name": "Shivam Kumar",
+    "github": "https://github.com/maishivamhoo123",
+    "avatar": "img/community/ambassadors/shivam-kumar.jpg",
+    "location": "Greater Vijayawada District, India",
+    "locationZh": "印度维杰亚瓦达地区"
+  },
+  {
+    "name": "Saiyam Pathak",
+    "github": "https://github.com/saiyam1814",
+    "avatar": "img/community/ambassadors/saiyam-pathak.jpg",
+    "linkedin": "https://www.linkedin.com/in/saiyampathak/",
+    "website": "https://kubesimplify.com/",
+    "location": "Chandigarh, India",
+    "locationZh": "印度昌迪加尔"
+  }
+]

--- a/src/pages/community.js
+++ b/src/pages/community.js
@@ -1,12 +1,13 @@
 import React from "react";
 import Layout from "@theme/Layout";
 import useDocusaurusContext from "@docusaurus/useDocusaurusContext";
-import useBaseUrl from "@docusaurus/useBaseUrl";
+import useBaseUrl, { useBaseUrlUtils } from "@docusaurus/useBaseUrl";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import {
   faBilibili,
   faDiscord,
   faGithub,
+  faLinkedin,
   faSlack,
   faYoutube,
 } from "@fortawesome/free-brands-svg-icons";
@@ -15,9 +16,11 @@ import {
   faCalendarDays,
   faCodeBranch,
   faFileLines,
+  faGlobe,
   faUsers,
   faVideo,
 } from "@fortawesome/free-solid-svg-icons";
+import ambassadors from "../data/ambassadors.json";
 import styles from "./community.module.css";
 
 const maintainers = [
@@ -58,40 +61,10 @@ const maintainers = [
   },
 ];
 
+// The ambassador roster lives in ../data/ambassadors.json, ordered as in the
+// canonical list at https://github.com/Project-HAMi/community/blob/main/ambassador-list.md
 const ambassadorProgramUrl =
   "https://github.com/Project-HAMi/community/blob/main/ambassador-program.md";
-
-// Ambassadors currently in term; the canonical roster with terms lives at
-// https://github.com/Project-HAMi/community/blob/main/ambassador-list.md
-const ambassadors = [
-  {
-    name: "Mesut Oezdil",
-    github: "https://github.com/mesutoezdil",
-    avatar: "img/community/ambassadors/mesut-oezdil.jpg",
-  },
-  {
-    name: "Tianqing Wang",
-    nameZh: "王天青",
-    github: "https://github.com/grissomsh",
-    avatar: "img/community/ambassadors/tianqing-wang.jpg",
-  },
-  {
-    name: "Xueduan Li",
-    nameZh: "李学端",
-    github: "https://github.com/lixd",
-    avatar: "img/community/ambassadors/xueduan-li.jpg",
-  },
-  {
-    name: "Shivam Kumar",
-    github: "https://github.com/maishivamhoo123",
-    avatar: "img/community/ambassadors/shivam-kumar.jpg",
-  },
-  {
-    name: "Saiyam Pathak",
-    github: "https://github.com/saiyam1814",
-    avatar: "img/community/ambassadors/saiyam-pathak.jpg",
-  },
-];
 
 function getGitHubUsername(profileUrl) {
   return profileUrl.replace("https://github.com/", "").replace(/\/$/, "");
@@ -107,9 +80,7 @@ export default function CommunityPage() {
   const wechatOfficialQr = useBaseUrl("img/community/wechat-official-account-qr.jpg");
   const wechatVideoQr = useBaseUrl("img/community/wechat-video-channel-qr.jpg");
   const wechatAssistantQr = useBaseUrl("img/community/wechat-assistant-qr.jpg");
-  const imageBaseUrl = useBaseUrl("/");
-  const imagePrefix = imageBaseUrl.endsWith("/") ? imageBaseUrl.slice(0, -1) : imageBaseUrl;
-  const withBaseUrl = (path) => `${imagePrefix}/${path.replace(/^\//, "")}`;
+  const { withBaseUrl } = useBaseUrlUtils();
   const cardConfig = [
     {
       key: "join",
@@ -338,6 +309,8 @@ export default function CommunityPage() {
                   const username = getGitHubUsername(ambassador.github);
                   const displayName =
                     isZh && ambassador.nameZh ? ambassador.nameZh : ambassador.name;
+                  const displayLocation =
+                    isZh && ambassador.locationZh ? ambassador.locationZh : ambassador.location;
                   return (
                     <article key={ambassador.github} className={styles.ambassadorCard}>
                       <div className={styles.ambassadorTop}>
@@ -350,6 +323,14 @@ export default function CommunityPage() {
                         <div className={styles.ambassadorBody}>
                           <h3 className={styles.ambassadorName}>{displayName}</h3>
                           <p className={styles.ambassadorMeta}>
+                            {displayLocation && (
+                              <>
+                                <span>{displayLocation}</span>
+                                <span className={styles.metaSeparator} aria-hidden="true">
+                                  •
+                                </span>
+                              </>
+                            )}
                             <a
                               href={ambassador.github}
                               target="_blank"
@@ -359,6 +340,38 @@ export default function CommunityPage() {
                               <FontAwesomeIcon icon={faGithub} />
                               <span>@{username}</span>
                             </a>
+                            {ambassador.linkedin && (
+                              <>
+                                <span className={styles.metaSeparator} aria-hidden="true">
+                                  •
+                                </span>
+                                <a
+                                  href={ambassador.linkedin}
+                                  target="_blank"
+                                  rel="noreferrer"
+                                  className={styles.githubLink}
+                                >
+                                  <FontAwesomeIcon icon={faLinkedin} />
+                                  <span>LinkedIn</span>
+                                </a>
+                              </>
+                            )}
+                            {ambassador.website && (
+                              <>
+                                <span className={styles.metaSeparator} aria-hidden="true">
+                                  •
+                                </span>
+                                <a
+                                  href={ambassador.website}
+                                  target="_blank"
+                                  rel="noreferrer"
+                                  className={styles.githubLink}
+                                >
+                                  <FontAwesomeIcon icon={faGlobe} />
+                                  <span>{isZh ? "个人主页" : "Website"}</span>
+                                </a>
+                              </>
+                            )}
                           </p>
                         </div>
                       </div>

--- a/src/pages/community.js
+++ b/src/pages/community.js
@@ -17,6 +17,7 @@ import {
   faCodeBranch,
   faFileLines,
   faGlobe,
+  faLocationDot,
   faUsers,
   faVideo,
 } from "@fortawesome/free-solid-svg-icons";
@@ -322,57 +323,64 @@ export default function CommunityPage() {
                         />
                         <div className={styles.ambassadorBody}>
                           <h3 className={styles.ambassadorName}>{displayName}</h3>
-                          <p className={styles.ambassadorMeta}>
+                          <div className={styles.ambassadorMetaRow}>
                             {displayLocation && (
-                              <>
+                              <span className={styles.ambassadorLocation}>
+                                <FontAwesomeIcon icon={faLocationDot} aria-hidden="true" />
                                 <span>{displayLocation}</span>
-                                <span className={styles.metaSeparator} aria-hidden="true">
-                                  •
-                                </span>
-                              </>
+                              </span>
                             )}
-                            <a
-                              href={ambassador.github}
-                              target="_blank"
-                              rel="noreferrer"
-                              className={styles.githubLink}
+                            <nav
+                              className={styles.ambassadorLinks}
+                              aria-label={
+                                isZh
+                                  ? `${displayName} 的个人链接`
+                                  : `${displayName}'s profile links`
+                              }
                             >
-                              <FontAwesomeIcon icon={faGithub} />
-                              <span>@{username}</span>
-                            </a>
-                            {ambassador.linkedin && (
-                              <>
-                                <span className={styles.metaSeparator} aria-hidden="true">
-                                  •
-                                </span>
+                              <a
+                                href={ambassador.github}
+                                target="_blank"
+                                rel="noreferrer"
+                                className={`${styles.ambassadorLink} ${styles.ambassadorGithubLink}`}
+                              >
+                                <FontAwesomeIcon icon={faGithub} aria-hidden="true" />
+                                <span>@{username}</span>
+                              </a>
+                              {ambassador.linkedin && (
                                 <a
                                   href={ambassador.linkedin}
                                   target="_blank"
                                   rel="noreferrer"
-                                  className={styles.githubLink}
+                                  className={`${styles.ambassadorLink} ${styles.ambassadorIconLink}`}
+                                  aria-label={
+                                    isZh
+                                      ? `${displayName} 的 LinkedIn`
+                                      : `${displayName}'s LinkedIn profile`
+                                  }
+                                  title="LinkedIn"
                                 >
-                                  <FontAwesomeIcon icon={faLinkedin} />
-                                  <span>LinkedIn</span>
+                                  <FontAwesomeIcon icon={faLinkedin} aria-hidden="true" />
                                 </a>
-                              </>
-                            )}
-                            {ambassador.website && (
-                              <>
-                                <span className={styles.metaSeparator} aria-hidden="true">
-                                  •
-                                </span>
+                              )}
+                              {ambassador.website && (
                                 <a
                                   href={ambassador.website}
                                   target="_blank"
                                   rel="noreferrer"
-                                  className={styles.githubLink}
+                                  className={`${styles.ambassadorLink} ${styles.ambassadorIconLink}`}
+                                  aria-label={
+                                    isZh
+                                      ? `${displayName} 的个人主页`
+                                      : `${displayName}'s personal website`
+                                  }
+                                  title={isZh ? "个人主页" : "Website"}
                                 >
-                                  <FontAwesomeIcon icon={faGlobe} />
-                                  <span>{isZh ? "个人主页" : "Website"}</span>
+                                  <FontAwesomeIcon icon={faGlobe} aria-hidden="true" />
                                 </a>
-                              </>
-                            )}
-                          </p>
+                              )}
+                            </nav>
+                          </div>
                         </div>
                       </div>
                     </article>

--- a/src/pages/community.js
+++ b/src/pages/community.js
@@ -224,27 +224,27 @@ export default function CommunityPage() {
         <section className={styles.section}>
           <div className="container">
             <div className={styles.governanceSection}>
-              <h2 className={styles.maintainersTitle}>{isZh ? "维护者" : "Maintainers"}</h2>
+              <h2 className={styles.peopleTitle}>{isZh ? "维护者" : "Maintainers"}</h2>
               <p className={styles.governanceIntro}>
                 {isZh
                   ? "HAMi 由以下维护者共同推进，负责项目方向、评审与版本发布。"
                   : "HAMi is maintained by the people below, who help guide project direction, reviews, and releases."}
               </p>
 
-              <div className={styles.maintainersGrid}>
+              <div className={styles.peopleGrid}>
                 {maintainers.map((maintainer) => {
                   const username = getGitHubUsername(maintainer.github);
                   return (
-                    <article key={maintainer.github} className={styles.maintainerCard}>
-                      <div className={styles.maintainerTop}>
+                    <article key={maintainer.github} className={styles.personCard}>
+                      <div className={styles.personTop}>
                         <img
-                          className={styles.maintainerAvatar}
+                          className={styles.personAvatar}
                           src={`${maintainer.github}.png?size=160`}
                           alt=""
                           loading="lazy"
                         />
-                        <div className={styles.maintainerBody}>
-                          <h3 className={styles.maintainerName}>{maintainer.name}</h3>
+                        <div className={styles.personBody}>
+                          <h3 className={styles.personName}>{maintainer.name}</h3>
                           <p className={styles.maintainerMeta}>
                             {maintainer.employerUrl ? (
                               <a
@@ -290,7 +290,7 @@ export default function CommunityPage() {
         <section className={styles.section}>
           <div className="container">
             <div className={styles.governanceSection}>
-              <h2 className={styles.ambassadorsTitle}>{isZh ? "大使" : "Ambassadors"}</h2>
+              <h2 className={styles.peopleTitle}>{isZh ? "大使" : "Ambassadors"}</h2>
               <p className={styles.governanceIntro}>
                 {isZh
                   ? `当前 ${ambassadorRoster.term.label} 任期的 HAMi 大使通过内容创作、活动组织和社区支持推广项目。`
@@ -306,7 +306,7 @@ export default function CommunityPage() {
                   ? "了解大使计划与申请方式 →"
                   : "Learn about the Ambassador Program and how to apply →"}
               </a>
-              <div className={styles.ambassadorsGrid}>
+              <div className={styles.peopleGrid}>
                 {ambassadors.map((ambassador) => {
                   const username = getGitHubUsername(ambassador.github);
                   const displayName =
@@ -314,16 +314,16 @@ export default function CommunityPage() {
                   const displayLocation =
                     isZh && ambassador.locationZh ? ambassador.locationZh : ambassador.location;
                   return (
-                    <article key={ambassador.github} className={styles.ambassadorCard}>
-                      <div className={styles.ambassadorTop}>
+                    <article key={ambassador.github} className={styles.personCard}>
+                      <div className={`${styles.personTop} ${styles.ambassadorTop}`}>
                         <img
-                          className={styles.ambassadorAvatar}
+                          className={`${styles.personAvatar} ${styles.ambassadorAvatar}`}
                           src={withBaseUrl(ambassador.avatar)}
                           alt=""
                           loading="lazy"
                         />
-                        <div className={styles.ambassadorBody}>
-                          <h3 className={styles.ambassadorName}>{displayName}</h3>
+                        <div className={styles.personBody}>
+                          <h3 className={styles.personName}>{displayName}</h3>
                           <div className={styles.ambassadorMetaRow}>
                             {displayLocation && (
                               <span className={styles.ambassadorLocation}>

--- a/src/pages/community.js
+++ b/src/pages/community.js
@@ -21,7 +21,7 @@ import {
   faUsers,
   faVideo,
 } from "@fortawesome/free-solid-svg-icons";
-import ambassadors from "../data/ambassadors.json";
+import ambassadorRoster from "../data/ambassadors.json";
 import styles from "./community.module.css";
 
 const maintainers = [
@@ -62,8 +62,9 @@ const maintainers = [
   },
 ];
 
-// The ambassador roster lives in ../data/ambassadors.json, ordered as in the
-// canonical list at https://github.com/Project-HAMi/community/blob/main/ambassador-list.md
+// This local roster adds presentation fields that are not in the canonical
+// list. Keep its members and term metadata in sync with ambassadorRoster.source.
+const ambassadors = ambassadorRoster.ambassadors;
 const ambassadorProgramUrl =
   "https://github.com/Project-HAMi/community/blob/main/ambassador-program.md";
 
@@ -239,7 +240,7 @@ export default function CommunityPage() {
                         <img
                           className={styles.maintainerAvatar}
                           src={`${maintainer.github}.png?size=160`}
-                          alt={`${maintainer.name} GitHub avatar`}
+                          alt=""
                           loading="lazy"
                         />
                         <div className={styles.maintainerBody}>
@@ -292,8 +293,8 @@ export default function CommunityPage() {
               <h2 className={styles.ambassadorsTitle}>{isZh ? "大使" : "Ambassadors"}</h2>
               <p className={styles.governanceIntro}>
                 {isZh
-                  ? "HAMi 大使通过内容创作、活动组织和社区支持推广项目。"
-                  : "HAMi Ambassadors evangelize the project through content, events, and community support."}
+                  ? `当前 ${ambassadorRoster.term.label} 任期的 HAMi 大使通过内容创作、活动组织和社区支持推广项目。`
+                  : `HAMi Ambassadors in the current ${ambassadorRoster.term.label} term evangelize the project through content, events, and community support.`}
               </p>
               <a
                 href={ambassadorProgramUrl}
@@ -318,7 +319,7 @@ export default function CommunityPage() {
                         <img
                           className={styles.ambassadorAvatar}
                           src={withBaseUrl(ambassador.avatar)}
-                          alt={`${displayName} photo`}
+                          alt=""
                           loading="lazy"
                         />
                         <div className={styles.ambassadorBody}>
@@ -330,14 +331,7 @@ export default function CommunityPage() {
                                 <span>{displayLocation}</span>
                               </span>
                             )}
-                            <nav
-                              className={styles.ambassadorLinks}
-                              aria-label={
-                                isZh
-                                  ? `${displayName} 的个人链接`
-                                  : `${displayName}'s profile links`
-                              }
-                            >
+                            <div className={styles.ambassadorLinks}>
                               <a
                                 href={ambassador.github}
                                 target="_blank"
@@ -379,7 +373,7 @@ export default function CommunityPage() {
                                   <FontAwesomeIcon icon={faGlobe} aria-hidden="true" />
                                 </a>
                               )}
-                            </nav>
+                            </div>
                           </div>
                         </div>
                       </div>

--- a/src/pages/community.js
+++ b/src/pages/community.js
@@ -58,6 +58,41 @@ const maintainers = [
   },
 ];
 
+const ambassadorProgramUrl =
+  "https://github.com/Project-HAMi/community/blob/main/ambassador-program.md";
+
+// Ambassadors currently in term; the canonical roster with terms lives at
+// https://github.com/Project-HAMi/community/blob/main/ambassador-list.md
+const ambassadors = [
+  {
+    name: "Mesut Oezdil",
+    github: "https://github.com/mesutoezdil",
+    avatar: "img/community/ambassadors/mesut-oezdil.jpg",
+  },
+  {
+    name: "Tianqing Wang",
+    nameZh: "王天青",
+    github: "https://github.com/grissomsh",
+    avatar: "img/community/ambassadors/tianqing-wang.jpg",
+  },
+  {
+    name: "Xueduan Li",
+    nameZh: "李学端",
+    github: "https://github.com/lixd",
+    avatar: "img/community/ambassadors/xueduan-li.jpg",
+  },
+  {
+    name: "Shivam Kumar",
+    github: "https://github.com/maishivamhoo123",
+    avatar: "img/community/ambassadors/shivam-kumar.jpg",
+  },
+  {
+    name: "Saiyam Pathak",
+    github: "https://github.com/saiyam1814",
+    avatar: "img/community/ambassadors/saiyam-pathak.jpg",
+  },
+];
+
 function getGitHubUsername(profileUrl) {
   return profileUrl.replace("https://github.com/", "").replace(/\/$/, "");
 }
@@ -72,6 +107,9 @@ export default function CommunityPage() {
   const wechatOfficialQr = useBaseUrl("img/community/wechat-official-account-qr.jpg");
   const wechatVideoQr = useBaseUrl("img/community/wechat-video-channel-qr.jpg");
   const wechatAssistantQr = useBaseUrl("img/community/wechat-assistant-qr.jpg");
+  const imageBaseUrl = useBaseUrl("/");
+  const imagePrefix = imageBaseUrl.endsWith("/") ? imageBaseUrl.slice(0, -1) : imageBaseUrl;
+  const withBaseUrl = (path) => `${imagePrefix}/${path.replace(/^\//, "")}`;
   const cardConfig = [
     {
       key: "join",
@@ -258,6 +296,62 @@ export default function CommunityPage() {
                             </span>
                             <a
                               href={maintainer.github}
+                              target="_blank"
+                              rel="noreferrer"
+                              className={styles.githubLink}
+                            >
+                              <FontAwesomeIcon icon={faGithub} />
+                              <span>@{username}</span>
+                            </a>
+                          </p>
+                        </div>
+                      </div>
+                    </article>
+                  );
+                })}
+              </div>
+            </div>
+          </div>
+        </section>
+
+        <section className={styles.section}>
+          <div className="container">
+            <div className={styles.governanceSection}>
+              <h2 className={styles.ambassadorsTitle}>{isZh ? "大使" : "Ambassadors"}</h2>
+              <p className={styles.governanceIntro}>
+                {isZh
+                  ? "HAMi 大使通过内容创作、活动组织和社区支持推广项目。"
+                  : "HAMi Ambassadors evangelize the project through content, events, and community support."}
+              </p>
+              <a
+                href={ambassadorProgramUrl}
+                target="_blank"
+                rel="noreferrer"
+                className={styles.programLink}
+              >
+                {isZh
+                  ? "了解大使计划与申请方式 →"
+                  : "Learn about the Ambassador Program and how to apply →"}
+              </a>
+              <div className={styles.ambassadorsGrid}>
+                {ambassadors.map((ambassador) => {
+                  const username = getGitHubUsername(ambassador.github);
+                  const displayName =
+                    isZh && ambassador.nameZh ? ambassador.nameZh : ambassador.name;
+                  return (
+                    <article key={ambassador.github} className={styles.ambassadorCard}>
+                      <div className={styles.ambassadorTop}>
+                        <img
+                          className={styles.ambassadorAvatar}
+                          src={withBaseUrl(ambassador.avatar)}
+                          alt={`${displayName} photo`}
+                          loading="lazy"
+                        />
+                        <div className={styles.ambassadorBody}>
+                          <h3 className={styles.ambassadorName}>{displayName}</h3>
+                          <p className={styles.ambassadorMeta}>
+                            <a
+                              href={ambassador.github}
                               target="_blank"
                               rel="noreferrer"
                               className={styles.githubLink}

--- a/src/pages/community.module.css
+++ b/src/pages/community.module.css
@@ -177,17 +177,26 @@
   color: var(--ifm-color-emphasis-700);
 }
 
-.maintainersTitle {
+.programLink {
+  justify-self: start;
+  font-weight: 600;
+  font-size: 0.92rem;
+}
+
+.maintainersTitle,
+.ambassadorsTitle {
   margin: 0;
 }
 
-.maintainersGrid {
+.maintainersGrid,
+.ambassadorsGrid {
   display: grid;
   grid-template-columns: repeat(2, minmax(0, 1fr));
   gap: 0.875rem;
 }
 
-.maintainerCard {
+.maintainerCard,
+.ambassadorCard {
   display: flex;
   flex-direction: column;
   gap: 0.65rem;
@@ -200,22 +209,26 @@
     box-shadow 0.2s ease;
 }
 
-.maintainerCard:hover {
+.maintainerCard:hover,
+.ambassadorCard:hover {
   border-color: color-mix(in srgb, var(--hami-color-primary) 42%, var(--hami-color-border));
   box-shadow: 0 8px 20px rgba(17, 24, 39, 0.06);
 }
 
-[data-theme="dark"] .maintainerCard:hover {
+[data-theme="dark"] .maintainerCard:hover,
+[data-theme="dark"] .ambassadorCard:hover {
   box-shadow: 0 8px 20px rgba(0, 0, 0, 0.22);
 }
 
-.maintainerTop {
+.maintainerTop,
+.ambassadorTop {
   display: flex;
   align-items: center;
   gap: 0.8rem;
 }
 
-.maintainerAvatar {
+.maintainerAvatar,
+.ambassadorAvatar {
   width: 48px;
   height: 48px;
   border-radius: 999px;
@@ -224,20 +237,23 @@
   flex-shrink: 0;
 }
 
-.maintainerBody {
+.maintainerBody,
+.ambassadorBody {
   display: flex;
   flex-direction: column;
   gap: 0.28rem;
   min-width: 0;
 }
 
-.maintainerName {
+.maintainerName,
+.ambassadorName {
   margin: 0;
   font-size: 0.98rem;
   line-height: 1.2;
 }
 
-.maintainerMeta {
+.maintainerMeta,
+.ambassadorMeta {
   margin: 0;
   display: flex;
   flex-wrap: wrap;
@@ -304,7 +320,8 @@
     grid-template-columns: 1fr;
   }
 
-  .maintainersGrid {
+  .maintainersGrid,
+  .ambassadorsGrid {
     grid-template-columns: 1fr;
   }
 }

--- a/src/pages/community.module.css
+++ b/src/pages/community.module.css
@@ -183,20 +183,17 @@
   font-size: 0.92rem;
 }
 
-.maintainersTitle,
-.ambassadorsTitle {
+.peopleTitle {
   margin: 0;
 }
 
-.maintainersGrid,
-.ambassadorsGrid {
+.peopleGrid {
   display: grid;
   grid-template-columns: repeat(2, minmax(0, 1fr));
   gap: 0.875rem;
 }
 
-.maintainerCard,
-.ambassadorCard {
+.personCard {
   display: flex;
   flex-direction: column;
   gap: 0.65rem;
@@ -209,19 +206,16 @@
     box-shadow 0.2s ease;
 }
 
-.maintainerCard:hover,
-.ambassadorCard:hover {
+.personCard:hover {
   border-color: color-mix(in srgb, var(--hami-color-primary) 42%, var(--hami-color-border));
   box-shadow: 0 8px 20px rgba(17, 24, 39, 0.06);
 }
 
-[data-theme="dark"] .maintainerCard:hover,
-[data-theme="dark"] .ambassadorCard:hover {
+[data-theme="dark"] .personCard:hover {
   box-shadow: 0 8px 20px rgba(0, 0, 0, 0.22);
 }
 
-.maintainerTop,
-.ambassadorTop {
+.personTop {
   display: flex;
   align-items: center;
   gap: 0.8rem;
@@ -235,8 +229,7 @@
   margin-top: 0.1rem;
 }
 
-.maintainerAvatar,
-.ambassadorAvatar {
+.personAvatar {
   width: 48px;
   height: 48px;
   border-radius: 999px;
@@ -245,16 +238,14 @@
   flex-shrink: 0;
 }
 
-.maintainerBody,
-.ambassadorBody {
+.personBody {
   display: flex;
   flex-direction: column;
   gap: 0.28rem;
   min-width: 0;
 }
 
-.maintainerName,
-.ambassadorName {
+.personName {
   margin: 0;
   font-size: 0.98rem;
   line-height: 1.2;
@@ -390,8 +381,7 @@
     grid-template-columns: 1fr;
   }
 
-  .maintainersGrid,
-  .ambassadorsGrid {
+  .peopleGrid {
     grid-template-columns: 1fr;
   }
 }

--- a/src/pages/community.module.css
+++ b/src/pages/community.module.css
@@ -227,6 +227,14 @@
   gap: 0.8rem;
 }
 
+.ambassadorTop {
+  align-items: flex-start;
+}
+
+.ambassadorAvatar {
+  margin-top: 0.1rem;
+}
+
 .maintainerAvatar,
 .ambassadorAvatar {
   width: 48px;
@@ -252,8 +260,7 @@
   line-height: 1.2;
 }
 
-.maintainerMeta,
-.ambassadorMeta {
+.maintainerMeta {
   margin: 0;
   display: flex;
   flex-wrap: wrap;
@@ -262,6 +269,69 @@
   color: var(--ifm-color-emphasis-700);
   font-size: 0.9rem;
   line-height: 1.3;
+}
+
+.ambassadorMetaRow,
+.ambassadorLocation {
+  display: flex;
+  align-items: center;
+}
+
+.ambassadorMetaRow {
+  flex-wrap: wrap;
+  gap: 0.15rem 0.75rem;
+}
+
+.ambassadorLocation {
+  gap: 0.4rem;
+  color: var(--ifm-color-emphasis-600);
+  font-size: 0.84rem;
+  line-height: 1.35;
+}
+
+.ambassadorLocation svg {
+  width: 0.72rem;
+  color: var(--ifm-color-emphasis-500);
+}
+
+.ambassadorLinks {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 0.2rem;
+}
+
+.ambassadorLink {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.32rem;
+  color: var(--ifm-color-emphasis-700);
+  font-size: 0.84rem;
+  font-weight: 500;
+  line-height: 1.35;
+  white-space: nowrap;
+}
+
+.ambassadorLink:hover {
+  color: var(--ifm-color-primary);
+  text-decoration: none;
+}
+
+.ambassadorGithubLink {
+  margin-right: 0.25rem;
+}
+
+.ambassadorIconLink {
+  justify-content: center;
+  width: 1.8rem;
+  height: 1.8rem;
+  border-radius: 6px;
+  color: var(--ifm-color-emphasis-600);
+}
+
+.ambassadorIconLink:hover,
+.ambassadorIconLink:focus-visible {
+  background: color-mix(in srgb, var(--ifm-color-primary) 10%, transparent);
 }
 
 .metaSeparator {

--- a/static/img/community/ambassadors/mesut-oezdil.jpg
+++ b/static/img/community/ambassadors/mesut-oezdil.jpg
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:f97f78e4b9772e9c5f9e0d084078ab277a15183790fbe8f67806849ee456c215
-size 9858
+oid sha256:b90cd9bf759072c17798989b0fe56e692c2017a1baa18fcbb2543e0e08fb2b78
+size 6541

--- a/static/img/community/ambassadors/mesut-oezdil.jpg
+++ b/static/img/community/ambassadors/mesut-oezdil.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:f97f78e4b9772e9c5f9e0d084078ab277a15183790fbe8f67806849ee456c215
+size 9858

--- a/static/img/community/ambassadors/saiyam-pathak.jpg
+++ b/static/img/community/ambassadors/saiyam-pathak.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:6463902d9221b44e5aad671c8d8e136df58ca9be6dceb121ecc800e8b2ae656f
+size 47693

--- a/static/img/community/ambassadors/saiyam-pathak.jpg
+++ b/static/img/community/ambassadors/saiyam-pathak.jpg
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:6463902d9221b44e5aad671c8d8e136df58ca9be6dceb121ecc800e8b2ae656f
-size 47693
+oid sha256:edc459c2ac08d9c38cfcf98083ce4ad02c08fc20e1b488b88a811a21f3d5f0e6
+size 7504

--- a/static/img/community/ambassadors/shivam-kumar.jpg
+++ b/static/img/community/ambassadors/shivam-kumar.jpg
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:cec7880c630371262e6f211810637192a9abf41abe1dc989c54c2eceaa7ee002
-size 39932
+oid sha256:6bbc3924b7310cc1bc7e6324c129ecae42491e23af15485d1c3c6109cf32e27e
+size 6939

--- a/static/img/community/ambassadors/shivam-kumar.jpg
+++ b/static/img/community/ambassadors/shivam-kumar.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:cec7880c630371262e6f211810637192a9abf41abe1dc989c54c2eceaa7ee002
+size 39932

--- a/static/img/community/ambassadors/tianqing-wang.jpg
+++ b/static/img/community/ambassadors/tianqing-wang.jpg
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:f2c8e564258848162d6a54812c26f1430da16fb86091ee850aca325c11959c7b
-size 44012
+oid sha256:8df3146104d85bca7d28deec70fa2a6f029d339aaeee7a208da7810899febb96
+size 7382

--- a/static/img/community/ambassadors/tianqing-wang.jpg
+++ b/static/img/community/ambassadors/tianqing-wang.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:f2c8e564258848162d6a54812c26f1430da16fb86091ee850aca325c11959c7b
+size 44012

--- a/static/img/community/ambassadors/xueduan-li.jpg
+++ b/static/img/community/ambassadors/xueduan-li.jpg
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:55023af6d7a360ac57beb7dc9fe90ec4c2059ac29995ba84777f682681f323fe
-size 36973
+oid sha256:f2a06b8a710ccb3bf90b133b1be085479e105699d73ed2876974cde84105e88d
+size 6880

--- a/static/img/community/ambassadors/xueduan-li.jpg
+++ b/static/img/community/ambassadors/xueduan-li.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:55023af6d7a360ac57beb7dc9fe90ec4c2059ac29995ba84777f682681f323fe
+size 36973


### PR DESCRIPTION
**What type of PR is this?**

/kind feature

**What this PR does / why we need it**:

Add the current ambassador roster with GitHub links and avatars, a link to the ambassador program doc, and card/grid styles that reuse the maintainers layout.

**Which issue(s) this PR fixes**:

**Checklist**:

- [x] `npm run lint` and `npm run format:check` pass
- [x] `npm run build` succeeds for both `en` and `zh`
- [x] Chinese translation updated if English docs changed (or noted why not)
- [x] Commits are signed off (`git commit -s`)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an Ambassadors section to the community page featuring five ambassador profiles.
  * Displays ambassador avatars, names, localized locations, GitHub links, and optional LinkedIn and personal website links.
  * Added a link to the ambassador program.
  * Added accessible, icon-based navigation for ambassador profile links.
* **Style**
  * Improved responsive layouts for ambassador and maintainer cards, including single-column mobile views.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->