### PR TITLE
docs: clarify AWS Marketplace version

### DIFF
--- a/docs/installation/aws-installation.md
+++ b/docs/installation/aws-installation.md
@@ -3,7 +3,7 @@ title: HAMi on AWS
 translated: true
 ---
 
-HAMi is now available on the AWS Marketplace, and you can quickly install it via Helm or AWS add-on.
+HAMi is now available on the AWS Marketplace and can be installed via Helm or the AWS add-on.
 
 ## Prerequisites
 
@@ -13,6 +13,8 @@ Before installation, please ensure you have:
 - Created a Kubernetes cluster
 
 ## Install with Helm
+
+The installation below uses version `2.6.1-community`. To install a newer version, replace `2.6.1-community` in the Helm command with the latest version available on the [AWS Marketplace listing](https://aws.amazon.com/marketplace/pp/prodview-x237accxbpuwa).
 
 You can use the following commands to pull HAMi’s Helm chart and install it:
 


### PR DESCRIPTION
**What type of PR is this?**
/kind documentation

**What this PR does / why we need it**:
Clarifies the AWS Marketplace version used in the installation instructions.

- Specifies that the installation uses version `2.6.1-community`.
- Directs users to check the AWS Marketplace for the latest available version.

**Which issue(s) this PR fixes**:

Fixes #827

**Checklist**:

- [x] `npm run lint` and `npm run format:check` pass
- [x] `npm run build` succeeds for both `en` and `zh`
- [ ] Chinese translation updated if English docs changed (or noted why not)
- [x] Commits are signed off (`git commit -s`)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
  - Updated the AWS installation guide to note availability through the AWS Marketplace.
  - Added installation options using Helm or the AWS add-on.
  - Documented the `2.6.1-community` version and instructed users to check the AWS Marketplace listing for the latest version.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->