### PR TITLE
fix(blog): pass absolute URLs to X and LinkedIn share buttons

### DIFF
--- a/src/theme/BlogPostItem/Footer/index.js
+++ b/src/theme/BlogPostItem/Footer/index.js
@@ -4,12 +4,16 @@ import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import { faPenToSquare } from "@fortawesome/free-solid-svg-icons";
 import { faLinkedinIn, faXTwitter } from "@fortawesome/free-brands-svg-icons";
 import { useBlogPost } from "@docusaurus/plugin-content-blog/client";
+import useDocusaurusContext from "@docusaurus/useDocusaurusContext";
 import TagsListInline from "@theme/TagsListInline";
 import ReadMoreLink from "@theme/BlogPostItem/Footer/ReadMoreLink";
+import { toAbsoluteSiteUrl } from "@site/src/utils/url";
 import styles from "./styles.module.css";
 
 function ShareButtons({ permalink, title }) {
-  const url = encodeURIComponent(permalink);
+  const { siteConfig } = useDocusaurusContext();
+  const shareUrl = toAbsoluteSiteUrl(siteConfig.url, permalink);
+  const url = encodeURIComponent(shareUrl);
   const text = encodeURIComponent(title || "");
 
   return (

--- a/src/utils/url.js
+++ b/src/utils/url.js
@@ -1,0 +1,9 @@
+export function toAbsoluteSiteUrl(siteUrl, permalink) {
+  if (typeof permalink === "string" && /^[a-z][a-z0-9+.-]*:/i.test(permalink)) {
+    return permalink;
+  }
+
+  const base = String(siteUrl || "").replace(/\/+$/, "") + "/";
+  const path = permalink ? String(permalink) : "";
+  return new URL(path || ".", base).href;
+}

--- a/src/utils/url.test.js
+++ b/src/utils/url.test.js
@@ -1,0 +1,34 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { toAbsoluteSiteUrl } from "./url.js";
+
+const SITE = "https://project-hami.io";
+
+test("toAbsoluteSiteUrl joins a site-relative permalink to the site origin", () => {
+  assert.equal(
+    toAbsoluteSiteUrl(SITE, "/blog/hami-at-kubecon-china-2026"),
+    "https://project-hami.io/blog/hami-at-kubecon-china-2026",
+  );
+});
+
+test("toAbsoluteSiteUrl keeps an already-localized permalink", () => {
+  assert.equal(
+    toAbsoluteSiteUrl(SITE, "/zh/blog/hami-at-kubecon-china-2026"),
+    "https://project-hami.io/zh/blog/hami-at-kubecon-china-2026",
+  );
+});
+
+test("toAbsoluteSiteUrl ignores a trailing slash on the site origin", () => {
+  assert.equal(toAbsoluteSiteUrl(`${SITE}/`, "/blog/foo"), "https://project-hami.io/blog/foo");
+});
+
+test("toAbsoluteSiteUrl leaves an already-absolute URL unchanged", () => {
+  assert.equal(
+    toAbsoluteSiteUrl(SITE, "https://example.com/already-absolute"),
+    "https://example.com/already-absolute",
+  );
+});
+
+test("toAbsoluteSiteUrl prefixes a path that is missing a leading slash", () => {
+  assert.equal(toAbsoluteSiteUrl(SITE, "blog/foo"), "https://project-hami.io/blog/foo");
+});


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

**What this PR does / why we need it**:

Share on X and LinkedIn was encoding `metadata.permalink` (`/blog/...`). The composer opened, but the posted URL was not clickable and no preview card showed.

i made to Join the permalink to `siteConfig.url` so share links are `https://project-hami.io/blog/...` (and `/zh/blog/...` for Chinese). Origin comes from site config, not `window.location`, so a local preview still shares the canonical host.

**Which issue(s) this PR fixes**:

Fixes #830

**Before :**
<img width="682" height="328" alt="image" src="https://github.com/user-attachments/assets/bd375dd6-55f9-485d-886e-141ace63d98d" />

**After :**
<img width="686" height="655" alt="image" src="https://github.com/user-attachments/assets/2a0038e6-9bf9-466a-9907-d45aed9f1681" />


**Checklist**:

- [x] `npm run lint` and `npm run format:check` pass
- [x] `npm run build` succeeds for both `en` and `zh`
- [ ] Chinese translation updated if English docs changed (or noted why not)  Na
- [x] Commits are signed off (`git commit -s`)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Social sharing links now use the site’s complete URL, ensuring shared blog post links work correctly from any page path.
  * Existing absolute URLs remain unchanged, while relative paths are handled consistently.

* **Tests**
  * Added coverage for URL construction, trailing slashes, root paths, localized paths, and absolute URLs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->