### PR TITLE
fix(event-landing): enforce 16:9 aspect ratio on banner

### DIFF
--- a/src/components/EventLanding.module.css
+++ b/src/components/EventLanding.module.css
@@ -8,9 +8,11 @@
 }
 
 .banner {
+  display: block;
   width: 100%;
-  max-height: 480px;
+  aspect-ratio: 16 / 9;
   object-fit: cover;
+  object-position: center;
   border-radius: var(--hami-radius-md);
   border: 1px solid var(--hami-color-border);
   margin-bottom: var(--hami-space-32);


### PR DESCRIPTION
Replace the fixed max-height with an aspect-ratio so the banner scales
responsively, and center the image with object-position.

**What type of PR is this?**

/kind cleanup

**What this PR does / why we need it**:

Some banners have an odd aspect-ratio. We should enforce 16:9 as default.

Also requires the same aspect-ratio from the KubeCon China banner. @rootsongjc

**Which issue(s) this PR fixes**:

Fixes #746

Also supercedes #752

**Checklist**:

- [x] `npm run lint` and `npm run format:check` pass
- [x] `npm run build` succeeds for both `en` and `zh`
- [x] Chinese translation updated if English docs changed (or noted why not)
- [x] Commits are signed off (`git commit -s`)
