### PR TITLE
docs(get-started): add a page for choosing between HAMi, HAMi-DRA, Volcano vGPU and KAI

### DIFF
--- a/docs/get-started/choose-your-setup.md
+++ b/docs/get-started/choose-your-setup.md
@@ -1,0 +1,62 @@
+---
+title: Choose Your Setup
+sidebar_label: Choose your setup
+---
+
+HAMi ships in more than one shape, and two other projects sit next to it. This page answers the question people ask first: which one do I install?
+
+## HAMi or HAMi-DRA
+
+Both give a container a slice of a GPU. They differ in how Kubernetes hands the device over.
+
+Pick **classic HAMi** unless every line below is true for your cluster:
+
+- Kubernetes v1.34 or later, with the DRA Consumable Capacity [feature gate](https://kubernetes.io/docs/reference/command-line-tools-reference/feature-gates/) enabled
+- [CDI](../installation/configure-cdi.md) enabled in containerd or CRI-O
+- NVIDIA GPU driver 440 or later
+
+If any of them is missing, HAMi-DRA cannot run. See [HAMi DRA for Kubernetes](../installation/how-to-use-hami-dra.md) for the full prerequisites.
+
+|  | Classic HAMi | HAMi-DRA |
+| --- | --- | --- |
+| Kubernetes | v1.23 or later | v1.34 or later, feature gate on |
+| How devices reach the pod | Device Plugin | ResourceClaim, through a mutating webhook |
+| Pod spec | `nvidia.com/gpu`, `nvidia.com/gpumem` and `nvidia.com/gpucores` limits | the same limits, converted to a ResourceClaim for you |
+| CDI | not required | required |
+| Extra components | none | cert-manager |
+
+Both run HAMi-core inside the container, so the memory and core limits behave the same either way. HAMi-DRA changes the allocation path, not the isolation.
+
+Start with [Deploy HAMi using Helm](./deploy-with-helm.md), or with [HAMi DRA for Kubernetes](../installation/how-to-use-hami-dra.md) if the list above is satisfied.
+
+## HAMi, Volcano vGPU or KAI Scheduler
+
+These are not three answers to the same question. Scheduling and isolation are separate jobs:
+
+- **Scheduling** decides which pod lands on which GPU, and how much of it the pod may claim.
+- **Isolation** is what stops a pod from using more than it claimed. In every option below that work is done by the same library, [HAMi-core](https://github.com/Project-HAMi/HAMi-core), injected into the container.
+
+So the real choice is which scheduler you already run.
+
+|  | HAMi | Volcano vGPU | KAI Scheduler |
+| --- | --- | --- | --- |
+| Scheduler | HAMi scheduler | Volcano | KAI |
+| Device plugin | HAMi device plugin | volcano-vgpu-device-plugin | NVIDIA device plugin |
+| Isolation | HAMi-core | HAMi-core | HAMi-core, through kai-resource-isolator |
+| Install HAMi as well | n/a | no | no |
+| Gang scheduling and queues | no | yes | yes |
+| Non-NVIDIA devices | yes, see [Device supported by HAMi](../userguide/device-supported.md) | NVIDIA only, Ascend goes through the separate [Volcano vNPU](../installation/how-to-use-volcano-ascend.md) integration | NVIDIA |
+| Requires | HAMi v2.x | Volcano v1.9 or later | KAI v0.16.4 or later |
+| Guide | [Deploy HAMi using Helm](./deploy-with-helm.md) | [Use Volcano vGPU](../userguide/volcano-vgpu/nvidia-gpu/how-to-use-volcano-vgpu.md) | [Use KAI Scheduler with HAMi](../userguide/kai-scheduler/how-to-use-kai-scheduler.md) |
+
+A short way to decide:
+
+- No scheduler preference, or devices other than NVIDIA: **HAMi**.
+- Already running Volcano for batch jobs: **Volcano vGPU**. You do not need to install HAMi.
+- Already running KAI: **KAI Scheduler** plus kai-resource-isolator. Without the isolator, a pod that asks for a fraction of a GPU can still use all of it.
+
+:::note
+
+Only one device plugin may own `nvidia.com/gpu` on a node. Remove or disable the NVIDIA device plugin before installing the HAMi one. See the [FAQ](../faq/faq.md).
+
+:::

--- a/docs/get-started/choose-your-setup.md
+++ b/docs/get-started/choose-your-setup.md
@@ -46,7 +46,7 @@ So the real choice is which scheduler you already run.
 | Install HAMi as well | n/a | no | no |
 | Gang scheduling and queues | no | yes | yes |
 | Non-NVIDIA devices | yes, see [Device supported by HAMi](../userguide/device-supported.md) | NVIDIA only, Ascend goes through the separate [Volcano vNPU](../installation/how-to-use-volcano-ascend.md) integration | NVIDIA |
-| Requires | HAMi v2.x | Volcano v1.9 or later | KAI v0.16.4 or later |
+| Requires | HAMi v2.x | Volcano later than v1.9 | KAI v0.16.4 or later |
 | Guide | [Deploy HAMi using Helm](./deploy-with-helm.md) | [Use Volcano vGPU](../userguide/volcano-vgpu/nvidia-gpu/how-to-use-volcano-vgpu.md) | [Use KAI Scheduler with HAMi](../userguide/kai-scheduler/how-to-use-kai-scheduler.md) |
 
 A short way to decide:

--- a/docs/get-started/choose-your-setup.md
+++ b/docs/get-started/choose-your-setup.md
@@ -46,7 +46,7 @@ So the real choice is which scheduler you already run.
 | Install HAMi as well | n/a | no | no |
 | Gang scheduling and queues | no | yes | yes |
 | Non-NVIDIA devices | yes, see [Device supported by HAMi](../userguide/device-supported.md) | NVIDIA only, Ascend goes through the separate [Volcano vNPU](../installation/how-to-use-volcano-ascend.md) integration | NVIDIA |
-| Requires | HAMi v2.x | Volcano later than v1.9 | KAI v0.16.4 or later |
+| Requires | HAMi v2.x | Volcano v1.9 or later | KAI v0.16.4 or later |
 | Guide | [Deploy HAMi using Helm](./deploy-with-helm.md) | [Use Volcano vGPU](../userguide/volcano-vgpu/nvidia-gpu/how-to-use-volcano-vgpu.md) | [Use KAI Scheduler with HAMi](../userguide/kai-scheduler/how-to-use-kai-scheduler.md) |
 
 A short way to decide:

--- a/i18n/zh/docusaurus-plugin-content-docs/current/get-started/choose-your-setup.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/current/get-started/choose-your-setup.md
@@ -1,0 +1,63 @@
+---
+title: 选择你的方案
+sidebar_label: 选择你的方案
+translated: true
+---
+
+HAMi 有不止一种形态，旁边还有另外两个项目。本页回答大家最先问的问题：我该装哪一个？
+
+## HAMi 还是 HAMi-DRA
+
+两者都能把一块 GPU 的一部分分给容器，区别在于 Kubernetes 用什么方式把设备交出去。
+
+除非下面每一条都成立，否则请选择**经典 HAMi**：
+
+- Kubernetes v1.34 或更高版本，并启用 DRA Consumable Capacity [特性门控](https://kubernetes.io/docs/reference/command-line-tools-reference/feature-gates/)
+- containerd 或 CRI-O 中已启用 [CDI](../installation/configure-cdi.md)
+- NVIDIA GPU 驱动 440 或更高版本
+
+少任何一条，HAMi-DRA 都无法运行。完整前置条件见 [HAMi DRA for Kubernetes](../installation/how-to-use-hami-dra.md)。
+
+|  | 经典 HAMi | HAMi-DRA |
+| --- | --- | --- |
+| Kubernetes | v1.23 或更高 | v1.34 或更高，需开启特性门控 |
+| 设备如何到达 Pod | Device Plugin | 通过 mutating webhook 生成 ResourceClaim |
+| Pod spec | `nvidia.com/gpu`、`nvidia.com/gpumem` 与 `nvidia.com/gpucores` limits | 写法相同，自动转换为 ResourceClaim |
+| CDI | 不需要 | 需要 |
+| 额外组件 | 无 | cert-manager |
+
+两者都在容器内运行 HAMi-core，因此显存和算力限制的行为完全一致。HAMi-DRA 改变的是分配路径，不是隔离方式。
+
+从 [使用 Helm 部署 HAMi](./deploy-with-helm.md) 开始；若上面的条件都已满足，也可以直接看 [HAMi DRA for Kubernetes](../installation/how-to-use-hami-dra.md)。
+
+## HAMi、Volcano vGPU 还是 KAI Scheduler
+
+这三者并不是同一个问题的三个答案。调度和隔离是两件事：
+
+- **调度**决定 Pod 落在哪块 GPU 上，以及可以申领多少。
+- **隔离**负责让 Pod 无法超出申领量。下面每种方案的这一步都由同一个库完成，也就是注入到容器里的 [HAMi-core](https://github.com/Project-HAMi/HAMi-core)。
+
+所以真正要选的是你已经在用哪个调度器。
+
+|  | HAMi | Volcano vGPU | KAI Scheduler |
+| --- | --- | --- | --- |
+| 调度器 | HAMi scheduler | Volcano | KAI |
+| Device plugin | HAMi device plugin | volcano-vgpu-device-plugin | NVIDIA device plugin |
+| 隔离 | HAMi-core | HAMi-core | HAMi-core，通过 kai-resource-isolator |
+| 是否还要装 HAMi | 不适用 | 否 | 否 |
+| Gang 调度与队列 | 否 | 是 | 是 |
+| 非 NVIDIA 设备 | 支持，见 [HAMi 支持的设备](../userguide/device-supported.md) | 仅 NVIDIA，Ascend 走独立的 [Volcano vNPU](../installation/how-to-use-volcano-ascend.md) 集成 | NVIDIA |
+| 版本要求 | HAMi v2.x | Volcano v1.9 或更高 | KAI v0.16.4 或更高 |
+| 指南 | [使用 Helm 部署 HAMi](./deploy-with-helm.md) | [使用 Volcano vGPU](../userguide/volcano-vgpu/nvidia-gpu/how-to-use-volcano-vgpu.md) | [配合 HAMi 使用 KAI Scheduler](../userguide/kai-scheduler/how-to-use-kai-scheduler.md) |
+
+简单的判断方式：
+
+- 对调度器没有偏好，或者使用 NVIDIA 以外的设备：选 **HAMi**。
+- 已经在用 Volcano 跑批处理任务：选 **Volcano vGPU**，不需要再装 HAMi。
+- 已经在用 KAI：选 **KAI Scheduler** 加 kai-resource-isolator。缺少 isolator 时，申领 GPU 一部分的 Pod 仍然可以用满整卡。
+
+:::note
+
+一个节点上只能有一个 device plugin 拥有 `nvidia.com/gpu`。安装 HAMi 的 device plugin 之前，请先移除或停用 NVIDIA 官方 device plugin。参见 [FAQ](../faq/faq.md)。
+
+:::

--- a/i18n/zh/docusaurus-plugin-content-docs/current/get-started/choose-your-setup.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/current/get-started/choose-your-setup.md
@@ -47,7 +47,7 @@ HAMi 有不止一种形态，旁边还有另外两个项目。本页回答大家
 | 是否还要装 HAMi | 不适用 | 否 | 否 |
 | Gang 调度与队列 | 否 | 是 | 是 |
 | 非 NVIDIA 设备 | 支持，见 [HAMi 支持的设备](../userguide/device-supported.md) | 仅 NVIDIA，Ascend 走独立的 [Volcano vNPU](../installation/how-to-use-volcano-ascend.md) 集成 | NVIDIA |
-| 版本要求 | HAMi v2.x | Volcano v1.9 或更高 | KAI v0.16.4 或更高 |
+| 版本要求 | HAMi v2.x | 高于 Volcano v1.9 | KAI v0.16.4 或更高 |
 | 指南 | [使用 Helm 部署 HAMi](./deploy-with-helm.md) | [使用 Volcano vGPU](../userguide/volcano-vgpu/nvidia-gpu/how-to-use-volcano-vgpu.md) | [配合 HAMi 使用 KAI Scheduler](../userguide/kai-scheduler/how-to-use-kai-scheduler.md) |
 
 简单的判断方式：

--- a/i18n/zh/docusaurus-plugin-content-docs/current/get-started/choose-your-setup.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/current/get-started/choose-your-setup.md
@@ -47,7 +47,7 @@ HAMi 有不止一种形态，旁边还有另外两个项目。本页回答大家
 | 是否还要装 HAMi | 不适用 | 否 | 否 |
 | Gang 调度与队列 | 否 | 是 | 是 |
 | 非 NVIDIA 设备 | 支持，见 [HAMi 支持的设备](../userguide/device-supported.md) | 仅 NVIDIA，Ascend 走独立的 [Volcano vNPU](../installation/how-to-use-volcano-ascend.md) 集成 | NVIDIA |
-| 版本要求 | HAMi v2.x | 高于 Volcano v1.9 | KAI v0.16.4 或更高 |
+| 版本要求 | HAMi v2.x | Volcano v1.9 或更高 | KAI v0.16.4 或更高 |
 | 指南 | [使用 Helm 部署 HAMi](./deploy-with-helm.md) | [使用 Volcano vGPU](../userguide/volcano-vgpu/nvidia-gpu/how-to-use-volcano-vgpu.md) | [配合 HAMi 使用 KAI Scheduler](../userguide/kai-scheduler/how-to-use-kai-scheduler.md) |
 
 简单的判断方式：

--- a/sidebars.js
+++ b/sidebars.js
@@ -37,7 +37,11 @@ module.exports = {
         title: "Get Started",
         description: "Install and run HAMi quickly with a guided first deployment path.",
       },
-      items: ["get-started/deploy-with-helm", "get-started/verify-hami"],
+      items: [
+        "get-started/choose-your-setup",
+        "get-started/deploy-with-helm",
+        "get-started/verify-hami",
+      ],
     },
     {
       type: "category",


### PR DESCRIPTION
/kind documentation
#689 asks for a decision page and a capability matrix. This is both on one page, placed first under Get Started so readers choose before they reach an install guide. It answers HAMi against HAMi-DRA from the three prerequisites, then explains that HAMi, Volcano vGPU and KAI are not three answers to the same question since all three rely on HAMi-core for isolation and only the scheduler differs. Every claim is taken from a page already in this repo and linked from the table.


Part of 689
