### PR TITLE
docs(v2.9): correct GPU scoring formulas

### DIFF
--- a/i18n/zh/docusaurus-plugin-content-docs/version-v2.9.0/developers/scheduling.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/version-v2.9.0/developers/scheduling.md
@@ -135,44 +135,48 @@ Node2 score: ((1+2)/4) * 10= 7.5
 
 #### Binpack
 
-Binpack 主要关注每张卡的计算能力和显存使用情况。使用越多，得分越高。
+Binpack 优先选择设备利用率得分较高的卡。以下示例假设每张卡有 10 个虚拟设备槽位，并且当前没有槽位被使用：
 
 ```text
-score: ((request.core + used.core) / allocatable.core + (request.mem + used.mem) / allocatable.mem)) * 10
+score: ((request.slot + used.slot) / allocatable.slot +
+        (request.core + used.core) / allocatable.core +
+        (request.mem + used.mem) / allocatable.mem) * 10
 ```
 
 1. GPU1 的 Binpack 评分信息如下
 
 ```text
-GPU1 Score: ((20+10)/100 + (1000+2000)/8000)) * 10 = 6.75
+GPU1 Score: ((1+0)/10 + (20+10)/100 + (1000+2000)/8000) * 10 = 7.75
 ```
 
 1. GPU2 的 Binpack 评分信息如下
 
 ```text
-GPU2 Score: ((20+70)/100 + (1000+6000)/8000)) * 10 = 17.75
+GPU2 Score: ((1+0)/10 + (20+70)/100 + (1000+6000)/8000) * 10 = 18.75
 ```
 
 因此，在 `Binpack` 策略中我们可以选择 `GPU2`。
 
 #### Spread
 
-Spread 主要关注每张卡的计算能力和显存使用情况。使用越少，得分越高。
+Spread 优先选择设备利用率得分较低的卡。使用相同的示例：
 
 ```text
-score: ((request.core + used.core) / allocatable.core + (request.mem + used.mem) / allocatable.mem)) * 10
+score: ((request.slot + used.slot) / allocatable.slot +
+        (request.core + used.core) / allocatable.core +
+        (request.mem + used.mem) / allocatable.mem) * 10
 ```
 
 1. GPU1 的 Spread 评分信息如下
 
 ```text
-GPU1 Score: ((20+10)/100 + (1000+2000)/8000)) * 10 = 6.75
+GPU1 Score: ((1+0)/10 + (20+10)/100 + (1000+2000)/8000) * 10 = 7.75
 ```
 
 1. GPU2 的 Spread 评分信息如下
 
 ```text
-GPU2 Score: ((20+70)/100 + (1000+6000)/8000)) * 10 = 17.75
+GPU2 Score: ((1+0)/10 + (20+70)/100 + (1000+6000)/8000) * 10 = 18.75
 ```
 
 因此，在 `Spread` 策略中我们可以选择 `GPU1`。

--- a/versioned_docs/version-v2.9.0/developers/scheduling.md
+++ b/versioned_docs/version-v2.9.0/developers/scheduling.md
@@ -134,44 +134,48 @@ In `Spread` policy, `Node2` is selected.
 
 #### Binpack
 
-Binpack mainly focuses on the computing power and video memory usage of each card. The more it is used, the higher the score.
+Binpack prefers the card with the higher device-utilization score. The following example assumes each card has ten virtual-device slots and no slot is currently in use:
 
 ```text
-score: ((request.core + used.core) / allocatable.core + (request.mem + used.mem) / allocatable.mem)) * 10
+score: ((request.slot + used.slot) / allocatable.slot +
+        (request.core + used.core) / allocatable.core +
+        (request.mem + used.mem) / allocatable.mem) * 10
 ```
 
 1. Binpack scoring information for GPU 1 is as follows
 
 ```text
-GPU1 Score: ((20+10)/100 + (1000+2000)/8000)) * 10 = 6.75
+GPU1 Score: ((1+0)/10 + (20+10)/100 + (1000+2000)/8000) * 10 = 7.75
 ```
 
 1. Binpack scoring information for GPU 2 is as follows
 
 ```text
-GPU2 Score: ((20+70)/100 + (1000+6000)/8000)) * 10 = 17.75
+GPU2 Score: ((1+0)/10 + (20+70)/100 + (1000+6000)/8000) * 10 = 18.75
 ```
 
 In `Binpack` policy, `GPU2` is selected.
 
 #### Spread
 
-Spread mainly focuses on the computing power and video memory usage of each card. The less it is used, the higher the score.
+Spread prefers the card with the lower device-utilization score. Using the same example:
 
 ```text
-score: ((request.core + used.core) / allocatable.core + (request.mem + used.mem) / allocatable.mem)) * 10
+score: ((request.slot + used.slot) / allocatable.slot +
+        (request.core + used.core) / allocatable.core +
+        (request.mem + used.mem) / allocatable.mem) * 10
 ```
 
 1. Spread scoring information for GPU 1 is as follows
 
 ```text
-GPU1 Score: ((20+10)/100 + (1000+2000)/8000)) * 10 = 6.75
+GPU1 Score: ((1+0)/10 + (20+10)/100 + (1000+2000)/8000) * 10 = 7.75
 ```
 
 1. Spread scoring information for GPU 2 is as follows
 
 ```text
-GPU2 Score: ((20+70)/100 + (1000+6000)/8000)) * 10 = 17.75
+GPU2 Score: ((1+0)/10 + (20+70)/100 + (1000+6000)/8000) * 10 = 18.75
 ```
 
 In `Spread` policy, `GPU1` is selected.


### PR DESCRIPTION
**What type of PR is this?**
/kind documentation

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
-->

**What this PR does / why we need it**:

Corrects the GPU scoring formulas in the frozen v2.9.0 documentation.

The existing formulas omit the virtual-device slot utilization term, although this term was already part of `ComputeScore` before the configurable scoring weights were introduced.

This update:
- adds the missing slot-utilization term to the GPU Binpack and Spread formulas
- corrects the example scores from `6.75` and `17.75` to `7.75` and `18.75`
- clarifies that Binpack prefers the higher utilization score while Spread prefers the lower score
- updates both the English and Chinese v2.9.0 documentation
- remains scoped only to the released v2.9.0 documentation, as requested during the review of #759

This PR does not backport the new `hami.io/device-scoring-weights` annotation, which belongs to the upcoming release documentation.



**Which issue(s) this PR fixes**:

Follow-up to #759.

**Checklist**:

- [x] `npm run lint` and `npm run format:check` pass
- [x] `npm run build` succeeds for both `en` and `zh`
- [x] Chinese translation updated if English docs changed (or noted why not)
- [x] Commits are signed off (`git commit -s`)

AI Disclosure:
This PR is assisted with AI Assistance for formatting purpose check and am responsible for all the content pushed in this PR.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated GPU scheduling policy documentation to include device-slot utilization in Binpack and Spread scoring formulas.
  * Revised scoring examples and terminology to reflect device-utilization scoring.
  * Clarified that the Spread example uses the same scenario as the Binpack example.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->