### PR TITLE
fix(tutorials): point local image override at scheduler.extender.image

### DIFF
--- a/i18n/zh/docusaurus-plugin-content-docs-tutorials/current/labs/nvml-mock.md
+++ b/i18n/zh/docusaurus-plugin-content-docs-tutorials/current/labs/nvml-mock.md
@@ -248,8 +248,8 @@ helm install hami ./charts/hami \
   -n kube-system \
   --set devicePlugin.image.repository=hami \
   --set devicePlugin.image.tag=local \
-  --set scheduler.image.repository=hami \
-  --set scheduler.image.tag=local \
+  --set scheduler.extender.image.repository=hami \
+  --set scheduler.extender.image.tag=local \
   --set devicePlugin.nvidiaDriverRoot=/var/lib/nvml-mock/driver \
   --set scheduler.kubeScheduler.imageTag=v1.35.0
 ```

--- a/i18n/zh/docusaurus-plugin-content-docs-tutorials/current/labs/topology-aware-scheduling.md
+++ b/i18n/zh/docusaurus-plugin-content-docs-tutorials/current/labs/topology-aware-scheduling.md
@@ -319,8 +319,8 @@ helm install hami ./charts/hami \
   -n kube-system \
   --set devicePlugin.image.repository=hami \
   --set devicePlugin.image.tag=local \
-  --set scheduler.image.repository=hami \
-  --set scheduler.image.tag=local \
+  --set scheduler.extender.image.repository=hami \
+  --set scheduler.extender.image.tag=local \
   --set devicePlugin.nvidiaDriverRoot=/var/lib/nvml-mock/driver \
   --set scheduler.kubeScheduler.imageTag=${K8S_VERSION} \
   --set scheduler.defaultSchedulerPolicy.gpuSchedulerPolicy=topology-aware

--- a/tutorials/labs/nvml-mock.md
+++ b/tutorials/labs/nvml-mock.md
@@ -248,8 +248,8 @@ helm install hami ./charts/hami \
   -n kube-system \
   --set devicePlugin.image.repository=hami \
   --set devicePlugin.image.tag=local \
-  --set scheduler.image.repository=hami \
-  --set scheduler.image.tag=local \
+  --set scheduler.extender.image.repository=hami \
+  --set scheduler.extender.image.tag=local \
   --set devicePlugin.nvidiaDriverRoot=/var/lib/nvml-mock/driver \
   --set scheduler.kubeScheduler.imageTag=v1.35.0
 ```

--- a/tutorials/labs/topology-aware-scheduling.md
+++ b/tutorials/labs/topology-aware-scheduling.md
@@ -319,8 +319,8 @@ helm install hami ./charts/hami \
   -n kube-system \
   --set devicePlugin.image.repository=hami \
   --set devicePlugin.image.tag=local \
-  --set scheduler.image.repository=hami \
-  --set scheduler.image.tag=local \
+  --set scheduler.extender.image.repository=hami \
+  --set scheduler.extender.image.tag=local \
   --set devicePlugin.nvidiaDriverRoot=/var/lib/nvml-mock/driver \
   --set scheduler.kubeScheduler.imageTag=${K8S_VERSION} \
   --set scheduler.defaultSchedulerPolicy.gpuSchedulerPolicy=topology-aware


### PR DESCRIPTION
**What type of PR is this?**

/kind cleanup

**What this PR does / why we need it**:

Two labs pass `--set scheduler.image.repository/tag`, but the chart has no `scheduler.image` — it's `scheduler.extender.image`.

**Checklist**:

- [X] `npm run lint` and `npm run format:check` pass
- [X] `npm run build` succeeds for both `en` and `zh`
- [X] Chinese translation updated if English docs changed (or noted why not)
- [X] Commits are signed off (`git commit -s`)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Updated HAMi Helm installation tutorials to use the scheduler extender image repository and tag settings.
  - Applied the corrected configuration consistently across English and Chinese guides for NVML mock and topology-aware scheduling labs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->