### PR TITLE
fix(docs): correct volcano-vgpu device plugin manifest URL

### DIFF
--- a/docs/installation/how-to-use-volcano-vgpu.md
+++ b/docs/installation/how-to-use-volcano-vgpu.md
@@ -53,7 +53,7 @@ data:
 Once you have enabled this option on _all_ the GPU nodes you wish to use, you can then enable GPU support in your cluster by deploying the following DaemonSet:
 
 ```shell
-kubectl create -f https://raw.githubusercontent.com/Project-HAMi/volcano-vgpu-device-plugin/main/volcano-vgpu-device-plugin.yml
+kubectl create -f https://raw.githubusercontent.com/Project-HAMi/volcano-vgpu-device-plugin/main/deployments/static/volcano-vgpu-device-plugin.yml
 ```
 
 ### Verify environment is ready

--- a/docs/userguide/volcano-vgpu/nvidia-gpu/how-to-use-volcano-vgpu.md
+++ b/docs/userguide/volcano-vgpu/nvidia-gpu/how-to-use-volcano-vgpu.md
@@ -53,7 +53,7 @@ data:
 Once you have enabled this option on _all_ the GPU nodes you wish to use, you can then enable GPU support in your cluster by deploying the following DaemonSet:
 
 ```shell
-kubectl create -f https://raw.githubusercontent.com/Project-HAMi/volcano-vgpu-device-plugin/main/volcano-vgpu-device-plugin.yml
+kubectl create -f https://raw.githubusercontent.com/Project-HAMi/volcano-vgpu-device-plugin/main/deployments/static/volcano-vgpu-device-plugin.yml
 ```
 
 ### Verify environment is ready

--- a/i18n/zh/docusaurus-plugin-content-docs/current/installation/how-to-use-volcano-vgpu.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/current/installation/how-to-use-volcano-vgpu.md
@@ -54,7 +54,7 @@ data:
 一旦你在*所有*希望使用的 GPU 节点上启用了此选项，你就可以通过部署以下 Daemonset 在集群中启用 GPU 支持：
 
 ```bash
-kubectl create -f https://raw.githubusercontent.com/Project-HAMi/volcano-vgpu-device-plugin/main/volcano-vgpu-device-plugin.yml
+kubectl create -f https://raw.githubusercontent.com/Project-HAMi/volcano-vgpu-device-plugin/main/deployments/static/volcano-vgpu-device-plugin.yml
 ```
 
 ### 验证环境是否准备好

--- a/i18n/zh/docusaurus-plugin-content-docs/current/userguide/volcano-vgpu/nvidia-gpu/how-to-use-volcano-vgpu.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/current/userguide/volcano-vgpu/nvidia-gpu/how-to-use-volcano-vgpu.md
@@ -61,7 +61,7 @@ data:
 在你想要使用的 **所有** GPU 节点上启用此选项后，可以通过部署以下 DaemonSet 来在集群中启用 GPU 支持：
 
 ```bash
-kubectl create -f https://raw.githubusercontent.com/Project-HAMi/volcano-vgpu-device-plugin/main/volcano-vgpu-device-plugin.yml
+kubectl create -f https://raw.githubusercontent.com/Project-HAMi/volcano-vgpu-device-plugin/main/deployments/static/volcano-vgpu-device-plugin.yml
 ```
 
 ### 验证环境是否就绪

--- a/i18n/zh/docusaurus-plugin-content-docs/version-v2.9.0/installation/how-to-use-volcano-vgpu.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/version-v2.9.0/installation/how-to-use-volcano-vgpu.md
@@ -54,7 +54,7 @@ data:
 一旦你在*所有*希望使用的 GPU 节点上启用了此选项，你就可以通过部署以下 Daemonset 在集群中启用 GPU 支持：
 
 ```bash
-kubectl create -f https://raw.githubusercontent.com/Project-HAMi/volcano-vgpu-device-plugin/main/volcano-vgpu-device-plugin.yml
+kubectl create -f https://raw.githubusercontent.com/Project-HAMi/volcano-vgpu-device-plugin/main/deployments/static/volcano-vgpu-device-plugin.yml
 ```
 
 ### 验证环境是否准备好

--- a/i18n/zh/docusaurus-plugin-content-docs/version-v2.9.0/userguide/volcano-vgpu/nvidia-gpu/how-to-use-volcano-vgpu.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/version-v2.9.0/userguide/volcano-vgpu/nvidia-gpu/how-to-use-volcano-vgpu.md
@@ -61,7 +61,7 @@ data:
 在你想要使用的 **所有** GPU 节点上启用此选项后，可以通过部署以下 DaemonSet 来在集群中启用 GPU 支持：
 
 ```bash
-kubectl create -f https://raw.githubusercontent.com/Project-HAMi/volcano-vgpu-device-plugin/main/volcano-vgpu-device-plugin.yml
+kubectl create -f https://raw.githubusercontent.com/Project-HAMi/volcano-vgpu-device-plugin/main/deployments/static/volcano-vgpu-device-plugin.yml
 ```
 
 ### 验证环境是否就绪

--- a/versioned_docs/version-v2.9.0/installation/how-to-use-volcano-vgpu.md
+++ b/versioned_docs/version-v2.9.0/installation/how-to-use-volcano-vgpu.md
@@ -53,7 +53,7 @@ data:
 Once you have enabled this option on _all_ the GPU nodes you wish to use, you can then enable GPU support in your cluster by deploying the following DaemonSet:
 
 ```shell
-kubectl create -f https://raw.githubusercontent.com/Project-HAMi/volcano-vgpu-device-plugin/main/volcano-vgpu-device-plugin.yml
+kubectl create -f https://raw.githubusercontent.com/Project-HAMi/volcano-vgpu-device-plugin/main/deployments/static/volcano-vgpu-device-plugin.yml
 ```
 
 ### Verify environment is ready

--- a/versioned_docs/version-v2.9.0/userguide/volcano-vgpu/nvidia-gpu/how-to-use-volcano-vgpu.md
+++ b/versioned_docs/version-v2.9.0/userguide/volcano-vgpu/nvidia-gpu/how-to-use-volcano-vgpu.md
@@ -53,7 +53,7 @@ data:
 Once you have enabled this option on _all_ the GPU nodes you wish to use, you can then enable GPU support in your cluster by deploying the following DaemonSet:
 
 ```shell
-kubectl create -f https://raw.githubusercontent.com/Project-HAMi/volcano-vgpu-device-plugin/main/volcano-vgpu-device-plugin.yml
+kubectl create -f https://raw.githubusercontent.com/Project-HAMi/volcano-vgpu-device-plugin/main/deployments/static/volcano-vgpu-device-plugin.yml
 ```
 
 ### Verify environment is ready


### PR DESCRIPTION
**What type of PR is this?**

/kind cleanup

**What this PR does / why we need it**:

Upstream PR https://github.com/Project-HAMi/volcano-vgpu-device-plugin/pull/128/ renamed the manifest into `deployments/static/volcano-vgpu-device-plugin.yml`

**Checklist**:

- [X] `npm run lint` and `npm run format:check` pass
- [X] `npm run build` succeeds for both `en` and `zh`
- [X] Chinese translation updated if English docs changed (or noted why not)
- [X] Commits are signed off (`git commit -s`)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Updated Volcano vGPU installation and usage guides to reference the device-plugin manifest at its new `deployments/static/` location.
  - Synchronized the updated deployment command across current, translated, and versioned documentation.
  - Ensures Kubernetes setup instructions use the correct manifest URL.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->